### PR TITLE
fix: make `aula contacts` work, and show contacts as a child-guardian table

### DIFF
--- a/src/aula/api_client.py
+++ b/src/aula/api_client.py
@@ -1050,29 +1050,55 @@ class AulaApiClient:
 
     async def get_groups(
         self,
-        institution_codes: list[str],
-        child_institution_profile_ids: list[int],
+        institution_codes: list[str] | None = None,
+        child_institution_profile_ids: list[int] | None = None,
     ) -> list[Group]:
-        """Fetch groups for the given institution codes and child profile IDs."""
-        params: dict[str, Any] = {
-            "method": "groups.getGroupsByContext",
-            "InstitutionCodes[]": institution_codes,
-            "ChildInstitutionProfileIds[]": child_institution_profile_ids,
-        }
+        """Fetch the groups available in the logged-in user's context.
+
+        The API accepts exactly one of the two filters and answers HTTP 400 if
+        both are sent together. Mirroring the Aula web client: guardians filter
+        by ``child_institution_profile_ids`` (which yields the children's own
+        class and SFO groups), employees by ``institution_codes``. When both are
+        given, the child filter wins.
+
+        ``data`` comes back as a list of profile contexts, each carrying its own
+        ``groups`` list; those are flattened and de-duplicated by group ID.
+
+        Raises:
+            ValueError: If neither filter is supplied.
+        """
+        params: dict[str, Any] = {"method": "groups.getGroupsByContext"}
+        if child_institution_profile_ids:
+            params["childInstitutionProfileIds[]"] = child_institution_profile_ids
+        elif institution_codes:
+            params["institutionCodes[]"] = institution_codes
+        else:
+            raise ValueError(
+                "get_groups requires either institution_codes or child_institution_profile_ids"
+            )
 
         resp = await self._request_with_version_retry("get", self.api_url, params=params)
         resp.raise_for_status()
 
-        raw_groups = resp.json().get("data", {}).get("groups", [])
-        if not isinstance(raw_groups, list):
-            return []
+        data = resp.json().get("data")
+        raw_groups: list[Any] = []
+        if isinstance(data, list):
+            for context in data:
+                if isinstance(context, dict) and isinstance(context.get("groups"), list):
+                    raw_groups.extend(context["groups"])
+        elif isinstance(data, dict) and isinstance(data.get("groups"), list):
+            raw_groups = data["groups"]
 
         groups: list[Group] = []
+        seen_ids: set[Any] = set()
         for item in raw_groups:
             try:
                 if not isinstance(item, dict) or "id" not in item:
                     _LOGGER.warning("Skipping invalid group data: %s", item)
                     continue
+                if item["id"] in seen_ids:
+                    continue
+                seen_ids.add(item["id"])
                 groups.append(Group.from_dict(item))
             except (TypeError, ValueError, KeyError) as e:
                 _LOGGER.warning("Skipping group due to parsing error: %s - Data: %s", e, item)
@@ -1705,17 +1731,38 @@ class AulaApiClient:
         return resp.json().get("data", {})
 
     async def get_contact_list(
-        self, group_id: int, page: int | None = None, order: str | None = None
+        self,
+        group_id: int,
+        page: int = 1,
+        order: str = "asc",
+        profile_type: str = "guardian",
+        field: str = "name",
     ) -> list[dict]:
-        """Fetch contact list for a group."""
+        """Fetch the contact list for a group.
+
+        The API method name is ``profiles.getContactlist`` (lowercase ``l``) and
+        every parameter here is required: omitting ``filter``, ``field``,
+        ``page`` or ``order`` answers HTTP 400, as does ``page=0`` (pages are
+        1-based).
+
+        Args:
+            group_id: Group to list contacts for.
+            page: 1-based page number; each page holds up to 20 contacts.
+            order: ``asc`` or ``desc``.
+            profile_type: Which profiles to return - ``child``, ``boy``,
+                ``girl``, ``guardian`` or ``employee``. Note that a group only
+                returns contacts for the types it actually contains, so a
+                parents-only group yields nothing for ``child``.
+            field: Field to sort by (``name``).
+        """
         params: dict[str, Any] = {
-            "method": "profiles.getContactList",
-            "GroupId": group_id,
+            "method": "profiles.getContactlist",
+            "groupId": group_id,
+            "filter": profile_type,
+            "field": field,
+            "page": page,
+            "order": order,
         }
-        if page is not None:
-            params["Page"] = page
-        if order:
-            params["Order"] = order
         resp = await self._request_with_version_retry("get", self.api_url, params=params)
         resp.raise_for_status()
         data = resp.json().get("data", [])
@@ -1723,17 +1770,21 @@ class AulaApiClient:
             return []
         return data
 
-    async def get_contact_parents(
-        self, page: int | None = None, order: str | None = None
-    ) -> list[dict]:
-        """Fetch other parents."""
+    async def get_contact_parents(self, page: int = 1, order: str = "asc") -> list[dict]:
+        """Fetch other parents.
+
+        Both parameters are required by the API; omitting them answers HTTP 400.
+        Accounts without access to the "other parents" list get HTTP 403.
+
+        Args:
+            page: 1-based page number.
+            order: ``asc`` or ``desc``.
+        """
         params: dict[str, Any] = {
             "method": "profiles.getContactParents",
+            "page": page,
+            "order": order,
         }
-        if page is not None:
-            params["Page"] = page
-        if order:
-            params["Order"] = order
         resp = await self._request_with_version_retry("get", self.api_url, params=params)
         resp.raise_for_status()
         data = resp.json().get("data", [])

--- a/src/aula/cli.py
+++ b/src/aula/cli.py
@@ -6,6 +6,7 @@ import functools
 import logging
 import os
 import sys
+from collections.abc import Awaitable, Callable
 from zoneinfo import ZoneInfo
 
 import click
@@ -14,10 +15,11 @@ import qrcode
 from .api_client import AulaApiClient
 from .auth_flow import authenticate_and_create_client
 from .config import CONFIG_FILE, DEFAULT_TOKEN_FILE, load_config, save_config
-from .models import DailyOverview, Message, MessageThread, Notification, Profile
+from .models import DailyOverview, Group, Message, MessageThread, Notification, Profile
 from .token_storage import FileTokenStorage
 from .utils.json import to_json
 from .utils.output import (
+    build_contact_table,
     clip,
     format_calendar_context_lines,
     format_message_lines,
@@ -30,7 +32,9 @@ from .utils.output import (
     print_empty,
     print_error,
     print_heading,
+    scope_relations_to_children,
 )
+from .utils.table import print_row_table
 
 
 # Decorator to run async functions within Click commands
@@ -214,6 +218,85 @@ async def _get_client(ctx: click.Context) -> AulaApiClient:
     )
 
 
+async def _fetch_groups(client: AulaApiClient) -> list[Group] | None:
+    """Fetch the groups available in the user's context.
+
+    Returns None and prints an error if the profile or groups can't be fetched.
+    """
+    try:
+        prof: Profile = await client.get_profile()
+    except Exception as e:
+        print_error(f"fetching profile: {e}")
+        return None
+
+    # Guardians filter by child institution profile IDs, which surfaces the
+    # children's own class and SFO groups. Employees (and guardians with no
+    # children listed) fall back to their institution codes.
+    child_institution_profile_ids = [child.id for child in prof.children]
+
+    institution_codes: list[str] = []
+    if not child_institution_profile_ids and prof._raw:
+        for inst_profile in prof._raw.get("institutionProfiles", []):
+            code = inst_profile.get("institutionCode", "") if isinstance(inst_profile, dict) else ""
+            if code and str(code) not in institution_codes:
+                institution_codes.append(str(code))
+
+    if not child_institution_profile_ids and not institution_codes:
+        print_error("no children or institutions found on this profile")
+        return None
+
+    try:
+        return await client.get_groups(
+            institution_codes=institution_codes,
+            child_institution_profile_ids=child_institution_profile_ids,
+        )
+    except Exception as e:
+        print_error(f"fetching groups: {e}")
+        return None
+
+
+#: The contacts endpoints return at most this many profiles per page.
+CONTACTS_PAGE_SIZE = 20
+#: Safety stop so a server that never returns a short page can't loop forever.
+MAX_CONTACT_PAGES = 200
+
+
+async def _fetch_contact_pages(
+    fetch_page: Callable[[int], Awaitable[list[dict]]],
+    page: int | None = None,
+) -> list[dict]:
+    """Fetch one contact page, or walk every page when ``page`` is None.
+
+    Paging stops on the first short page, matching how the Aula web client
+    decides there is nothing more to load.
+    """
+    if page is not None:
+        return await fetch_page(page)
+
+    items: list[dict] = []
+    for current in range(1, MAX_CONTACT_PAGES + 1):
+        batch = await fetch_page(current)
+        items.extend(batch)
+        if len(batch) < CONTACTS_PAGE_SIZE:
+            return items
+
+    click.echo(
+        f"Warning: stopped after {MAX_CONTACT_PAGES} pages; "
+        "results may be incomplete. Use --page to fetch further pages."
+    )
+    return items
+
+
+def _format_group_row(group: Group) -> str:
+    """Render a group as a display row with its ID and metadata."""
+    parts = [f"ID {group.id}"]
+    if group.group_type:
+        parts.append(group.group_type)
+    if group.institution_code:
+        parts.append(f"Inst {group.institution_code}")
+    return format_row(group.name, *parts)
+
+
 async def _get_widget_context(
     client: AulaApiClient,
     prof: Profile,
@@ -322,12 +405,7 @@ async def groups(ctx, group_id, members, search_text):
 
             print_heading(f'Groups matching "{search_text}"')
             for g in result:
-                parts = [f"ID {g.id}"]
-                if g.group_type:
-                    parts.append(g.group_type)
-                if g.institution_code:
-                    parts.append(f"Inst {g.institution_code}")
-                click.echo(format_row(g.name, *parts))
+                click.echo(_format_group_row(g))
             return
 
         if group_id and members:
@@ -375,29 +453,8 @@ async def groups(ctx, group_id, members, search_text):
             return
 
         # List all groups for children
-        try:
-            prof: Profile = await client.get_profile()
-        except Exception as e:
-            print_error(f"fetching profile: {e}")
-            return
-
-        if not prof.children:
-            print_empty("children")
-            return
-
-        institution_codes: list[str] = []
-        child_profile_ids: list[int] = []
-        for child in prof.children:
-            child_profile_ids.append(child.id)
-            if child._raw:
-                code = child._raw.get("institutionProfile", {}).get("institutionCode", "")
-                if code and str(code) not in institution_codes:
-                    institution_codes.append(str(code))
-
-        try:
-            result = await client.get_groups(institution_codes, child_profile_ids)
-        except Exception as e:
-            print_error(f"fetching groups: {e}")
+        result = await _fetch_groups(client)
+        if result is None:
             return
 
         if output_json(ctx, [dict(g) for g in result]):
@@ -409,12 +466,7 @@ async def groups(ctx, group_id, members, search_text):
 
         print_heading("Groups")
         for g in result:
-            parts = [f"ID {g.id}"]
-            if g.group_type:
-                parts.append(g.group_type)
-            if g.institution_code:
-                parts.append(f"Inst {g.institution_code}")
-            click.echo(format_row(g.name, *parts))
+            click.echo(_format_group_row(g))
 
 
 @cli.command()
@@ -1075,27 +1127,80 @@ async def search(ctx, text, doc_type, limit):
 
 
 @cli.command()
-@click.option("--group-id", type=int, default=None, help="Filter contacts by group ID.")
+@click.option(
+    "--group-id",
+    type=int,
+    default=None,
+    help="Filter contacts by group ID. Omit to list the available group IDs.",
+)
 @click.option("--parents", is_flag=True, help="Show other parents instead of group contacts.")
+@click.option(
+    "--profile-type",
+    type=click.Choice(["guardian", "child", "boy", "girl", "employee"]),
+    default="guardian",
+    show_default=True,
+    help="Which profiles to list. A group only has contacts for the types it contains.",
+)
+@click.option(
+    "--page",
+    type=int,
+    default=None,
+    help="Fetch only this 1-based page (20 per page). Default: every page.",
+)
 @click.pass_context
 @async_cmd
-async def contacts(ctx, group_id, parents):
-    """List contacts from groups or other parents."""
+async def contacts(ctx, group_id, parents, profile_type, page):
+    """List contacts from groups or other parents.
+
+    Rows pair each child with their guardians. With neither --group-id nor
+    --parents, lists the available groups and their IDs.
+    """
     async with await _get_client(ctx) as client:
         if parents:
             try:
-                result = await client.get_contact_parents()
+                result = await _fetch_contact_pages(
+                    lambda p: client.get_contact_parents(page=p), page
+                )
             except Exception as e:
                 print_error(f"fetching parent contacts: {e}")
                 return
         elif group_id:
             try:
-                result = await client.get_contact_list(group_id)
+                result = await _fetch_contact_pages(
+                    lambda p: client.get_contact_list(group_id, page=p, profile_type=profile_type),
+                    page,
+                )
+                if profile_type == "guardian" and result:
+                    # Guardians carry every child they have, so scope the pairing
+                    # to the children who are actually in this group. Always read
+                    # the full membership, even when --page limited the guardians.
+                    group_children = await _fetch_contact_pages(
+                        lambda p: client.get_contact_list(group_id, page=p, profile_type="child")
+                    )
+                    result = scope_relations_to_children(result, group_children)
             except Exception as e:
                 print_error(f"fetching contacts: {e}")
                 return
         else:
-            click.echo("Please specify --group-id or --parents.")
+            # No group given: show the group IDs available to pick from.
+            groups_result = await _fetch_groups(client)
+            if groups_result is None:
+                return
+
+            if output_json(ctx, [dict(g) for g in groups_result]):
+                return
+
+            if not groups_result:
+                print_empty("groups")
+                return
+
+            print_row_table(
+                ["Group ID", "Name", "Institution"],
+                [(str(g.id), g.name, g.institution_code) for g in groups_result],
+                title="Available groups",
+            )
+            click.echo("")
+            click.echo("Specify one with --group-id <ID>, or use --parents for other parents.")
             return
 
         if output_json(ctx, result):
@@ -1105,11 +1210,8 @@ async def contacts(ctx, group_id, parents):
             print_empty("contacts")
             return
 
-        print_heading("Contacts")
-        for item in result:
-            name = item.get("name", item.get("fullName", "Unknown"))
-            role = item.get("portalRole", "")
-            click.echo(format_row(name, role))
+        headers, rows = build_contact_table(result)
+        print_row_table(headers, rows, title="Contacts")
 
 
 @cli.command("profile-details")

--- a/src/aula/utils/output.py
+++ b/src/aula/utils/output.py
@@ -1,7 +1,7 @@
 """Shared helpers for consistent human-readable CLI output."""
 
 import datetime
-from typing import Any
+from typing import Any, NamedTuple
 
 import click
 
@@ -55,6 +55,200 @@ def format_row(primary: str, secondary: str | None = None, tertiary: str | None 
         if value and value.strip():
             parts.append(value.strip())
     return " | ".join(parts)
+
+
+class ContactRow(NamedTuple):
+    """One child-guardian pairing, ready to render as a table row."""
+
+    child: str
+    guardian: str
+    relation: str
+    class_name: str
+    phone: str
+    address: str
+
+
+def build_contact_rows(item: dict[str, Any]) -> list[ContactRow]:
+    """Build child-guardian rows for one contact.
+
+    Aula returns a contact plus its ``relations``: a guardian carries their
+    children, a child carries their guardians. Either way the pairing is
+    rendered child-first, so one contact can yield several rows. A guardian's
+    children from other groups are included, since the relation list is not
+    scoped to the queried group; the class column tells them apart.
+
+    Phone and address always describe the *guardian*, read from whichever object
+    that is - the contact itself in a guardian listing, the relation in a child
+    listing. Child relations carry their own contact details, so taking them
+    from the wrong side would show the child's registered number instead. Cells
+    stay empty when the profile hides its contact information.
+
+    Contacts with no usable relations (employees, or profiles whose relations
+    are hidden) yield a single row with the role in place of the relation.
+    """
+    name = str(item.get("fullName") or item.get("name") or "Unknown")
+    role = str(item.get("role") or item.get("portalRole") or "")
+    relations = [r for r in (item.get("relations") or []) if isinstance(r, dict)]
+
+    if role == "guardian":
+        # ``relation`` on each child says how this guardian relates to them.
+        children = [r for r in relations if r.get("role") == "child"]
+        if children:
+            return [
+                ContactRow(
+                    child=_contact_name(child),
+                    guardian=name,
+                    relation=_relation_of(child),
+                    class_name=_class_of(child),
+                    phone=_phone_of(item),
+                    address=_address_of(item),
+                )
+                for child in children
+            ]
+
+    elif role == "child":
+        guardians = [r for r in relations if r.get("role") == "guardian"]
+        if guardians:
+            return [
+                ContactRow(
+                    child=name,
+                    guardian=_contact_name(guardian),
+                    relation=_relation_of(guardian),
+                    class_name=_class_of(item),
+                    phone=_phone_of(guardian),
+                    address=_address_of(guardian),
+                )
+                for guardian in guardians
+            ]
+
+    return [
+        ContactRow(
+            child=name,
+            guardian="",
+            relation=role,
+            class_name=_class_of(item),
+            phone=_phone_of(item),
+            address=_address_of(item),
+        )
+    ]
+
+
+#: Column layout for a listing where every row pairs a child with a guardian.
+PAIRED_CONTACT_HEADERS = ["Child", "Guardian", "Relation", "Class", "Phone", "Address"]
+#: Column layout for a listing with no relations to pair (employees).
+FLAT_CONTACT_HEADERS = ["Name", "Role", "Details", "Phone", "Address"]
+
+
+def build_contact_table(
+    contacts: list[dict[str, Any]],
+) -> tuple[list[str], list[tuple[str, ...]]]:
+    """Build ``(headers, rows)`` for a contact listing, sorted child-first.
+
+    Employee listings carry no relations, so they collapse to a flatter layout
+    rather than showing an empty Guardian column.
+    """
+    rows = sort_contact_rows([row for item in contacts for row in build_contact_rows(item)])
+
+    if any(item.get("relations") for item in contacts):
+        return PAIRED_CONTACT_HEADERS, [tuple(row) for row in rows]
+
+    return FLAT_CONTACT_HEADERS, [
+        (row.child, row.relation, row.class_name, row.phone, row.address) for row in rows
+    ]
+
+
+#: Danish sorts Æ, Ø, Å after Z, in that order; plain code points disagree (Å < Æ < Ø).
+_DANISH_LETTER_ORDER = str.maketrans({"æ": "zz1", "ø": "zz2", "å": "zz3"})
+
+
+def danish_sort_key(text: str) -> str:
+    """Case-insensitive sort key that places Æ, Ø and Å last, as Danish does."""
+    return text.casefold().translate(_DANISH_LETTER_ORDER)
+
+
+def sort_contact_rows(rows: list[ContactRow]) -> list[ContactRow]:
+    """Sort contact rows by child name, then guardian name."""
+    return sorted(rows, key=lambda row: (danish_sort_key(row.child), danish_sort_key(row.guardian)))
+
+
+def scope_relations_to_children(
+    contacts: list[dict[str, Any]],
+    group_children: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Drop child relations that belong to another group.
+
+    A guardian's ``relations`` list carries every child they have, not just the
+    ones in the queried group, so a class listing would otherwise show siblings
+    from other classes. ``group_children`` is the same group fetched with the
+    ``child`` filter; its ``id`` values are institution profile IDs and match
+    the ``id`` on each relation.
+
+    Guardians left without a single child in the group are dropped entirely.
+    Returns ``contacts`` unchanged when the group has no children at all (a
+    parents-only group), since there is nothing to scope against.
+    """
+    child_ids = {child.get("id") for child in group_children if child.get("id") is not None}
+    if not child_ids:
+        return contacts
+
+    scoped: list[dict[str, Any]] = []
+    for item in contacts:
+        relations = [r for r in (item.get("relations") or []) if isinstance(r, dict)]
+        if not relations:
+            scoped.append(item)
+            continue
+
+        kept = [r for r in relations if r.get("role") != "child" or r.get("id") in child_ids]
+        had_children = any(r.get("role") == "child" for r in relations)
+        if had_children and not any(r.get("role") == "child" for r in kept):
+            continue
+        scoped.append({**item, "relations": kept})
+    return scoped
+
+
+def _contact_name(entry: dict[str, Any]) -> str:
+    """Return a contact or relation's display name."""
+    return str(entry.get("fullName") or entry.get("name") or "Unknown")
+
+
+def _relation_of(entry: dict[str, Any]) -> str:
+    """Return the guardian relation (``Far``/``Mor``) carried by ``entry``."""
+    return str(entry.get("relation") or "").strip()
+
+
+def _class_of(entry: dict[str, Any]) -> str:
+    """Return a contact's class/metadata label (e.g. ``3.1``)."""
+    return str(entry.get("metadata") or "").strip()
+
+
+def _phone_of(entry: dict[str, Any]) -> str:
+    """Return the best available phone number, preferring mobile.
+
+    Hidden or unset numbers come back as ``None`` or an empty string, so both
+    are skipped.
+    """
+    for key in ("mobilePhoneNumber", "homePhoneNumber", "workPhoneNumber"):
+        number = str(entry.get(key) or "").strip()
+        if number:
+            return number
+    return ""
+
+
+def _address_of(entry: dict[str, Any]) -> str:
+    """Format a contact's address as ``street, postcode district``.
+
+    Any missing part is dropped rather than leaving a stray comma; profiles with
+    an unknown address carry the literal street ``Ukendt``.
+    """
+    address = entry.get("address")
+    if not isinstance(address, dict):
+        return ""
+
+    street = str(address.get("street") or "").strip()
+    postal_code = str(address.get("postalCode") or "").strip()
+    district = str(address.get("postalDistrict") or "").strip()
+    city = " ".join(part for part in (postal_code, district) if part)
+    return ", ".join(part for part in (street, city) if part)
 
 
 def format_message_lines(

--- a/src/aula/utils/table.py
+++ b/src/aula/utils/table.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from collections.abc import Sequence
 from datetime import date, time
 from typing import TypedDict
 
@@ -44,6 +45,62 @@ def build_calendar_table(events: list[CalendarEvent]) -> CalendarTableData:
         matrix.append(row)
 
     return {"dates": dates, "slots": slots, "matrix": matrix}
+
+
+def _print_rows_with_rich(
+    headers: Sequence[str], rows: Sequence[Sequence[str]], title: str | None
+) -> bool:
+    """Render a row table with ``rich``. Returns ``False`` if rich is not installed."""
+    try:
+        from rich.console import Console  # type: ignore[import-not-found]
+        from rich.table import Table  # type: ignore[import-not-found]
+    except ImportError:
+        return False
+
+    table = Table(title=title, show_header=True, header_style="bold magenta")
+    for header in headers:
+        table.add_column(header, overflow="fold")
+    for row in rows:
+        table.add_row(*row)
+    Console().print(table)
+    return True
+
+
+def _print_rows_plain(
+    headers: Sequence[str], rows: Sequence[Sequence[str]], title: str | None
+) -> None:
+    """Render a row table as fixed-width plain text."""
+    widths = [
+        max([len(str(header))] + [len(str(row[index])) for row in rows])
+        for index, header in enumerate(headers)
+    ]
+
+    def render(cells: Sequence[str]) -> str:
+        padded = [str(cell).ljust(width) for cell, width in zip(cells, widths, strict=True)]
+        return " | ".join(padded).rstrip()
+
+    if title:
+        click.echo(title)
+    header_line = render(headers)
+    click.echo(header_line)
+    click.echo("-" * len(header_line))
+    for row in rows:
+        click.echo(render(row))
+
+
+def print_row_table(
+    headers: Sequence[str],
+    rows: Sequence[Sequence[str]],
+    title: str | None = None,
+) -> None:
+    """Print a header + rows table using rich if available, else plain text.
+
+    Every row must have exactly as many cells as ``headers``.
+    """
+    if not rows:
+        return
+    if not _print_rows_with_rich(headers, rows, title):
+        _print_rows_plain(headers, rows, title)
 
 
 def _print_with_rich(

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1952,36 +1952,113 @@ class TestGetGroups:
 
     @pytest.mark.asyncio
     async def test_happy_path(self, client):
+        """The live API wraps groups in a list of per-profile contexts."""
         client._request_with_version_retry = AsyncMock(
             return_value=HttpResponse(
                 status_code=200,
                 data={
-                    "data": {
-                        "groups": [
-                            {
-                                "id": 1,
-                                "name": "Class 3A",
-                                "type": "primary",
-                                "institutionCode": "123456",
-                                "description": "Main group",
-                            }
-                        ]
-                    }
+                    "data": [
+                        {
+                            "profileId": 2043929,
+                            "displayName": "Parent Name",
+                            "groups": [
+                                {
+                                    "id": 1,
+                                    "name": "Class 3A",
+                                    "type": "primary",
+                                    "institutionCode": "123456",
+                                    "description": "Main group",
+                                }
+                            ],
+                        }
+                    ]
                 },
             )
         )
-        result = await client.get_groups(["123456"], [100])
+        result = await client.get_groups(institution_codes=["123456"])
         assert len(result) == 1
         assert result[0].id == 1
         assert result[0].name == "Class 3A"
         assert result[0].group_type == "primary"
 
     @pytest.mark.asyncio
+    async def test_institution_codes_filter(self, client):
+        client._request_with_version_retry = AsyncMock(
+            return_value=HttpResponse(status_code=200, data={"data": []})
+        )
+        await client.get_groups(institution_codes=["123456"])
+        params = client._request_with_version_retry.call_args.kwargs["params"]
+        assert params["institutionCodes[]"] == ["123456"]
+        assert "childInstitutionProfileIds[]" not in params
+
+    @pytest.mark.asyncio
+    async def test_child_filter_wins_and_is_exclusive(self, client):
+        """Sending both filters together answers HTTP 400, so only one goes out."""
+        client._request_with_version_retry = AsyncMock(
+            return_value=HttpResponse(status_code=200, data={"data": []})
+        )
+        await client.get_groups(
+            institution_codes=["123456"], child_institution_profile_ids=[100, 200]
+        )
+        params = client._request_with_version_retry.call_args.kwargs["params"]
+        assert params["childInstitutionProfileIds[]"] == [100, 200]
+        assert "institutionCodes[]" not in params
+
+    @pytest.mark.asyncio
+    async def test_requires_a_filter(self, client):
+        client._request_with_version_retry = AsyncMock()
+        with pytest.raises(ValueError, match="requires either"):
+            await client.get_groups()
+        client._request_with_version_retry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_flattens_and_dedupes_contexts(self, client):
+        client._request_with_version_retry = AsyncMock(
+            return_value=HttpResponse(
+                status_code=200,
+                data={
+                    "data": [
+                        {"profileId": 1, "groups": [{"id": 10, "name": "Shared"}]},
+                        {
+                            "profileId": 2,
+                            "groups": [
+                                {"id": 10, "name": "Shared"},
+                                {"id": 11, "name": "Other"},
+                            ],
+                        },
+                    ]
+                },
+            )
+        )
+        result = await client.get_groups(institution_codes=["123"])
+        assert [g.id for g in result] == [10, 11]
+
+    @pytest.mark.asyncio
+    async def test_dict_shaped_data(self, client):
+        """A dict-shaped ``data`` with a top-level groups list is still accepted."""
+        client._request_with_version_retry = AsyncMock(
+            return_value=HttpResponse(
+                status_code=200,
+                data={"data": {"groups": [{"id": 1, "name": "Class 3A"}]}},
+            )
+        )
+        result = await client.get_groups(institution_codes=["123"])
+        assert [g.name for g in result] == ["Class 3A"]
+
+    @pytest.mark.asyncio
     async def test_empty_data(self, client):
         client._request_with_version_retry = AsyncMock(
-            return_value=HttpResponse(status_code=200, data={"data": {"groups": []}})
+            return_value=HttpResponse(status_code=200, data={"data": []})
         )
-        result = await client.get_groups(["123"], [100])
+        result = await client.get_groups(institution_codes=["123"])
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_null_data(self, client):
+        client._request_with_version_retry = AsyncMock(
+            return_value=HttpResponse(status_code=200, data={"data": None})
+        )
+        result = await client.get_groups(institution_codes=["123"])
         assert result == []
 
     @pytest.mark.asyncio
@@ -1990,17 +2067,21 @@ class TestGetGroups:
             return_value=HttpResponse(
                 status_code=200,
                 data={
-                    "data": {
-                        "groups": [
-                            {"id": 1, "name": "Good"},
-                            "not-a-dict",
-                            {"no_id": True},
-                        ]
-                    }
+                    "data": [
+                        {
+                            "profileId": 1,
+                            "groups": [
+                                {"id": 1, "name": "Good"},
+                                "not-a-dict",
+                                {"no_id": True},
+                            ],
+                        },
+                        "not-a-context",
+                    ]
                 },
             )
         )
-        result = await client.get_groups(["123"], [100])
+        result = await client.get_groups(institution_codes=["123"])
         assert len(result) == 1
         assert result[0].name == "Good"
 
@@ -2686,6 +2767,34 @@ class TestGetContactList:
         result = await client.get_contact_list(42)
         assert result == []
 
+    @pytest.mark.asyncio
+    async def test_sends_all_required_params(self, client):
+        """The API 400s unless method casing and every param are exactly right."""
+        client._request_with_version_retry = AsyncMock(
+            return_value=HttpResponse(status_code=200, data={"data": []})
+        )
+        await client.get_contact_list(42)
+        params = client._request_with_version_retry.call_args.kwargs["params"]
+        assert params == {
+            "method": "profiles.getContactlist",
+            "groupId": 42,
+            "filter": "guardian",
+            "field": "name",
+            "page": 1,
+            "order": "asc",
+        }
+
+    @pytest.mark.asyncio
+    async def test_profile_type_and_page_forwarded(self, client):
+        client._request_with_version_retry = AsyncMock(
+            return_value=HttpResponse(status_code=200, data={"data": []})
+        )
+        await client.get_contact_list(42, page=3, order="desc", profile_type="child")
+        params = client._request_with_version_retry.call_args.kwargs["params"]
+        assert params["filter"] == "child"
+        assert params["page"] == 3
+        assert params["order"] == "desc"
+
 
 class TestGetContactParents:
     """Tests for AulaApiClient.get_contact_parents method."""
@@ -2712,3 +2821,17 @@ class TestGetContactParents:
         )
         result = await client.get_contact_parents()
         assert result == []
+
+    @pytest.mark.asyncio
+    async def test_sends_required_params(self, client):
+        """page and order are required; omitting them answers HTTP 400."""
+        client._request_with_version_retry = AsyncMock(
+            return_value=HttpResponse(status_code=200, data={"data": []})
+        )
+        await client.get_contact_parents()
+        params = client._request_with_version_retry.call_args.kwargs["params"]
+        assert params == {
+            "method": "profiles.getContactParents",
+            "page": 1,
+            "order": "asc",
+        }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,71 @@
+"""Tests for aula.cli helpers."""
+
+import pytest
+
+from aula.cli import CONTACTS_PAGE_SIZE, MAX_CONTACT_PAGES, _fetch_contact_pages
+
+
+def _pager(total: int):
+    """Return a fetch_page callable serving ``total`` items in 20-item pages."""
+    calls: list[int] = []
+
+    async def fetch_page(page: int) -> list[dict]:
+        calls.append(page)
+        start = (page - 1) * CONTACTS_PAGE_SIZE
+        return [{"id": i} for i in range(start, min(start + CONTACTS_PAGE_SIZE, total))]
+
+    return fetch_page, calls
+
+
+class TestFetchContactPages:
+    @pytest.mark.asyncio
+    async def test_walks_every_page_until_a_short_one(self):
+        fetch_page, calls = _pager(45)
+
+        result = await _fetch_contact_pages(fetch_page)
+
+        assert len(result) == 45
+        assert calls == [1, 2, 3]
+
+    @pytest.mark.asyncio
+    async def test_stops_on_first_empty_page_when_total_is_a_multiple(self):
+        """A full last page can't be detected as final, so one extra call happens."""
+        fetch_page, calls = _pager(40)
+
+        result = await _fetch_contact_pages(fetch_page)
+
+        assert len(result) == 40
+        assert calls == [1, 2, 3]
+
+    @pytest.mark.asyncio
+    async def test_single_page_makes_one_call(self):
+        fetch_page, calls = _pager(5)
+
+        result = await _fetch_contact_pages(fetch_page)
+
+        assert len(result) == 5
+        assert calls == [1]
+
+    @pytest.mark.asyncio
+    async def test_explicit_page_fetches_only_that_page(self):
+        fetch_page, calls = _pager(100)
+
+        result = await _fetch_contact_pages(fetch_page, page=3)
+
+        assert calls == [3]
+        assert [item["id"] for item in result] == list(range(40, 60))
+
+    @pytest.mark.asyncio
+    async def test_warns_instead_of_looping_forever(self, capsys):
+        """A server that never returns a short page must not spin indefinitely."""
+        calls: list[int] = []
+
+        async def always_full(page: int) -> list[dict]:
+            calls.append(page)
+            return [{"id": page}] * CONTACTS_PAGE_SIZE
+
+        result = await _fetch_contact_pages(always_full)
+
+        assert len(calls) == MAX_CONTACT_PAGES
+        assert len(result) == MAX_CONTACT_PAGES * CONTACTS_PAGE_SIZE
+        assert "may be incomplete" in capsys.readouterr().out

--- a/tests/utils/test_output.py
+++ b/tests/utils/test_output.py
@@ -4,6 +4,9 @@ import datetime
 
 from aula.models.notification import Notification
 from aula.utils.output import (
+    ContactRow,
+    build_contact_rows,
+    build_contact_table,
     clip,
     format_calendar_context_lines,
     format_heading_lines,
@@ -13,6 +16,8 @@ from aula.utils.output import (
     format_record_lines,
     format_report_intro_lines,
     format_row,
+    scope_relations_to_children,
+    sort_contact_rows,
 )
 
 
@@ -44,6 +49,305 @@ class TestFormatRow:
 
     def test_ignores_blank_parts(self):
         assert format_row("Title", "", "  ") == "Title"
+
+
+def _address(street: str, postal_code: object = None, district: str | None = None) -> dict:
+    return {"street": street, "postalCode": postal_code, "postalDistrict": district}
+
+
+class TestBuildContactRows:
+    def test_child_pairs_with_each_guardian(self):
+        item = {
+            "fullName": "Barn Et",
+            "role": "child",
+            "metadata": "3.1",
+            "relations": [
+                {
+                    "fullName": "Værge Far",
+                    "role": "guardian",
+                    "relation": "Far",
+                    "mobilePhoneNumber": "10000001",
+                    "address": _address("Testvej 1", 1000, "Testby"),
+                },
+                {
+                    "fullName": "Værge Mor",
+                    "role": "guardian",
+                    "relation": "Mor",
+                    "mobilePhoneNumber": "10000002",
+                    "address": _address("Testvej 2", 1000, "Testby"),
+                },
+            ],
+        }
+        assert build_contact_rows(item) == [
+            ContactRow(
+                child="Barn Et",
+                guardian="Værge Far",
+                relation="Far",
+                class_name="3.1",
+                phone="10000001",
+                address="Testvej 1, 1000 Testby",
+            ),
+            ContactRow(
+                child="Barn Et",
+                guardian="Værge Mor",
+                relation="Mor",
+                class_name="3.1",
+                phone="10000002",
+                address="Testvej 2, 1000 Testby",
+            ),
+        ]
+
+    def test_guardian_details_come_from_the_guardian_not_the_child(self):
+        """A child relation carries its own phone/address; the guardian's must win."""
+        item = {
+            "fullName": "Værge Et",
+            "role": "guardian",
+            "mobilePhoneNumber": "10000001",
+            "address": _address("Værgevej 1", 1000, "Testby"),
+            "relations": [
+                {
+                    "fullName": "Barn Et",
+                    "role": "child",
+                    "relation": "Far",
+                    "metadata": "3.1",
+                    "mobilePhoneNumber": "20000002",
+                    "address": _address("Barnevej 2", 2000, "Andenby"),
+                },
+            ],
+        }
+        assert build_contact_rows(item) == [
+            ContactRow(
+                child="Barn Et",
+                guardian="Værge Et",
+                relation="Far",
+                class_name="3.1",
+                phone="10000001",
+                address="Værgevej 1, 1000 Testby",
+            )
+        ]
+
+    def test_phone_falls_back_from_mobile_to_home_to_work(self):
+        base = {"fullName": "Barn Et", "role": "child", "relations": []}
+        assert build_contact_rows({**base, "mobilePhoneNumber": "1"})[0].phone == "1"
+        assert build_contact_rows({**base, "homePhoneNumber": "2"})[0].phone == "2"
+        assert build_contact_rows({**base, "workPhoneNumber": "3"})[0].phone == "3"
+
+    def test_blank_phone_values_are_skipped(self):
+        item = {
+            "fullName": "Barn Et",
+            "role": "child",
+            "relations": [],
+            "mobilePhoneNumber": "",
+            "homePhoneNumber": None,
+            "workPhoneNumber": "10000003",
+        }
+        assert build_contact_rows(item)[0].phone == "10000003"
+
+    def test_address_omits_missing_parts(self):
+        def address_for(address):
+            item = {"fullName": "Barn Et", "role": "child", "relations": [], "address": address}
+            return build_contact_rows(item)[0].address
+
+        assert address_for(_address("Ukendt")) == "Ukendt"
+        assert address_for(_address("Testvej 1", 1000)) == "Testvej 1, 1000"
+        assert address_for(_address("", 1000, "Testby")) == "1000 Testby"
+        assert address_for(None) == ""
+
+    def test_relations_of_the_wrong_role_are_ignored(self):
+        item = {
+            "fullName": "Barn Et",
+            "role": "child",
+            "relations": [{"fullName": "Barn To", "role": "child"}],
+        }
+        assert build_contact_rows(item) == [ContactRow("Barn Et", "", "child", "", "", "")]
+
+    def test_employee_falls_back_to_name_and_role(self):
+        item = {"fullName": "Ansat Et", "role": "employee", "relations": [], "metadata": "Lærer"}
+        assert build_contact_rows(item) == [ContactRow("Ansat Et", "", "employee", "Lærer", "", "")]
+
+    def test_guardian_without_relations_falls_back(self):
+        item = {"fullName": "Værge Et", "role": "guardian", "relations": None}
+        assert build_contact_rows(item) == [ContactRow("Værge Et", "", "guardian", "", "", "")]
+
+    def test_missing_relation_label_is_empty(self):
+        item = {
+            "fullName": "Barn Et",
+            "role": "child",
+            "relations": [{"fullName": "Værge Et", "role": "guardian"}],
+        }
+        assert build_contact_rows(item) == [ContactRow("Barn Et", "Værge Et", "", "", "", "")]
+
+    def test_non_dict_relations_are_skipped(self):
+        item = {"fullName": "Barn Et", "role": "child", "relations": ["nope", None]}
+        assert build_contact_rows(item) == [ContactRow("Barn Et", "", "child", "", "", "")]
+
+    def test_unknown_name_fallback(self):
+        assert build_contact_rows({"role": "employee"}) == [
+            ContactRow("Unknown", "", "employee", "", "", "")
+        ]
+
+
+class TestBuildContactTable:
+    def test_paired_listing_uses_child_guardian_columns(self):
+        contacts = [
+            {
+                "fullName": "Barn Et",
+                "role": "child",
+                "metadata": "3.1",
+                "relations": [{"fullName": "Værge Et", "role": "guardian", "relation": "Far"}],
+            }
+        ]
+
+        headers, rows = build_contact_table(contacts)
+
+        assert headers == ["Child", "Guardian", "Relation", "Class", "Phone", "Address"]
+        assert rows == [("Barn Et", "Værge Et", "Far", "3.1", "", "")]
+
+    def test_flat_listing_drops_the_empty_guardian_column(self):
+        contacts = [
+            {"fullName": "Ansat Et", "role": "employee", "metadata": "Lærer", "relations": []},
+        ]
+
+        headers, rows = build_contact_table(contacts)
+
+        assert headers == ["Name", "Role", "Details", "Phone", "Address"]
+        assert rows == [("Ansat Et", "employee", "Lærer", "", "")]
+
+    def test_rows_are_sorted_child_then_guardian(self):
+        contacts = [
+            {
+                "fullName": "Barn Bo",
+                "role": "child",
+                "relations": [{"fullName": "Værge Zeta", "role": "guardian"}],
+            },
+            {
+                "fullName": "Barn Ada",
+                "role": "child",
+                "relations": [
+                    {"fullName": "Værge Bent", "role": "guardian"},
+                    {"fullName": "Værge Anne", "role": "guardian"},
+                ],
+            },
+        ]
+
+        _, rows = build_contact_table(contacts)
+
+        assert [(row[0], row[1]) for row in rows] == [
+            ("Barn Ada", "Værge Anne"),
+            ("Barn Ada", "Værge Bent"),
+            ("Barn Bo", "Værge Zeta"),
+        ]
+
+    def test_every_row_matches_the_header_width(self):
+        contacts = [
+            {
+                "fullName": "Barn Et",
+                "role": "child",
+                "relations": [{"fullName": "Værge Et", "role": "guardian"}],
+            }
+        ]
+
+        headers, rows = build_contact_table(contacts)
+
+        assert all(len(row) == len(headers) for row in rows)
+
+    def test_empty_input(self):
+        headers, rows = build_contact_table([])
+
+        assert rows == []
+        assert headers == ["Name", "Role", "Details", "Phone", "Address"]
+
+
+def _row(child: str, guardian: str = "g") -> ContactRow:
+    return ContactRow(child, guardian, "", "", "", "")
+
+
+class TestSortContactRows:
+    def test_sorts_by_child_then_guardian(self):
+        rows = [_row("Bo", "Zeta"), _row("Ada", "Bent"), _row("Bo", "Alma"), _row("Ada", "Anne")]
+
+        assert [(r.child, r.guardian) for r in sort_contact_rows(rows)] == [
+            ("Ada", "Anne"),
+            ("Ada", "Bent"),
+            ("Bo", "Alma"),
+            ("Bo", "Zeta"),
+        ]
+
+    def test_sort_is_case_insensitive(self):
+        rows = [_row("bob"), _row("Alice")]
+
+        assert [r.child for r in sort_contact_rows(rows)] == ["Alice", "bob"]
+
+    def test_danish_letters_sort_after_z_in_danish_order(self):
+        rows = [_row(name) for name in ["Åge", "Bo", "Æbbe", "Øjvind", "Zenia"]]
+
+        assert [r.child for r in sort_contact_rows(rows)] == [
+            "Bo",
+            "Zenia",
+            "Æbbe",
+            "Øjvind",
+            "Åge",
+        ]
+
+    def test_does_not_mutate_the_input(self):
+        rows = [_row("Bo"), _row("Ada")]
+
+        sort_contact_rows(rows)
+
+        assert rows[0].child == "Bo"
+
+
+class TestScopeRelationsToChildren:
+    GUARDIAN = {
+        "fullName": "Værge Et",
+        "role": "guardian",
+        "relations": [
+            {"fullName": "Barn I Gruppen", "role": "child", "id": 1, "metadata": "3.1"},
+            {"fullName": "Søskende Udenfor", "role": "child", "id": 2, "metadata": "0.1"},
+        ],
+    }
+
+    def test_drops_children_from_other_groups(self):
+        scoped = scope_relations_to_children([self.GUARDIAN], [{"id": 1}])
+
+        assert [r["fullName"] for r in scoped[0]["relations"]] == ["Barn I Gruppen"]
+
+    def test_does_not_mutate_the_input(self):
+        scope_relations_to_children([self.GUARDIAN], [{"id": 1}])
+
+        assert len(self.GUARDIAN["relations"]) == 2
+
+    def test_drops_guardians_with_no_child_in_the_group(self):
+        assert scope_relations_to_children([self.GUARDIAN], [{"id": 999}]) == []
+
+    def test_returns_input_unchanged_for_a_group_without_children(self):
+        contacts = [self.GUARDIAN]
+
+        assert scope_relations_to_children(contacts, []) is contacts
+
+    def test_ignores_group_children_without_ids(self):
+        contacts = [self.GUARDIAN]
+
+        assert scope_relations_to_children(contacts, [{"fullName": "no id"}]) is contacts
+
+    def test_keeps_non_child_relations(self):
+        item = {
+            "fullName": "Værge Et",
+            "role": "guardian",
+            "relations": [
+                {"fullName": "Barn I Gruppen", "role": "child", "id": 1},
+                {"fullName": "Medværge", "role": "guardian", "id": 77},
+            ],
+        }
+
+        scoped = scope_relations_to_children([item], [{"id": 1}])
+
+        assert [r["fullName"] for r in scoped[0]["relations"]] == ["Barn I Gruppen", "Medværge"]
+
+    def test_keeps_contacts_that_never_had_child_relations(self):
+        item = {"fullName": "Ansat Et", "role": "employee", "relations": []}
+
+        assert scope_relations_to_children([item], [{"id": 1}]) == [item]
 
 
 class TestFormatNotificationLines:

--- a/tests/utils/test_table.py
+++ b/tests/utils/test_table.py
@@ -9,9 +9,11 @@ from aula.models.calendar_event import CalendarEvent
 from aula.utils.table import (
     CalendarTableData,
     _print_plain,
+    _print_rows_with_rich,
     _print_with_rich,
     build_calendar_table,
     print_calendar_table,
+    print_row_table,
 )
 
 
@@ -150,3 +152,54 @@ class TestPrintCalendarTable:
 
         assert "2026-03-02" in out
         assert "Math" in out
+
+
+class TestPrintRowTable:
+    HEADERS = ["Child", "Guardian", "Class"]
+    ROWS = [("Barn Et", "Værge Et (Far)", "3.1")]
+
+    def test_renders_with_rich(self, capsys):
+        pytest.importorskip("rich")
+
+        print_row_table(self.HEADERS, self.ROWS, title="Contacts")
+        out = capsys.readouterr().out
+
+        assert "Contacts" in out
+        assert "Guardian" in out
+        assert "Barn Et" in out
+
+    def test_rich_reports_failure_when_missing(self, monkeypatch):
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name.startswith("rich"):
+                raise ImportError("no rich")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        assert _print_rows_with_rich(self.HEADERS, self.ROWS, None) is False
+
+    def test_falls_back_to_plain_without_rich(self, monkeypatch, capsys):
+        monkeypatch.setattr("aula.utils.table._print_rows_with_rich", lambda *a: False)
+
+        print_row_table(self.HEADERS, self.ROWS, title="Contacts")
+        out = capsys.readouterr().out
+
+        assert "Contacts" in out
+        assert "Child" in out
+        assert "Værge Et (Far)" in out
+
+    def test_plain_columns_are_width_aligned(self, monkeypatch, capsys):
+        monkeypatch.setattr("aula.utils.table._print_rows_with_rich", lambda *a: False)
+
+        print_row_table(["A", "B"], [("short", "x"), ("much longer value", "y")])
+        lines = [line for line in capsys.readouterr().out.splitlines() if "|" in line]
+
+        # Every rendered row puts its separator at the same offset.
+        offsets = {line.index("|") for line in lines}
+        assert len(offsets) == 1
+
+    def test_no_output_for_empty_rows(self, capsys):
+        print_row_table(self.HEADERS, [], title="Contacts")
+        assert capsys.readouterr().out == ""


### PR DESCRIPTION
## Why

`uv run aula contacts` was unusable. With no arguments it only printed "Please specify
--group-id or --parents", and with a group ID it failed with `HTTP 400`. `aula groups`
failed the same way, so there was no way to discover a valid group ID either.

The root cause was three separate API-contract bugs. I recovered the real request shapes
from the Aula web client bundle (`app.*.js`) and verified each against the live API.

## The API fixes (`589e2fe`)

- **`groups.getGroupsByContext` accepts exactly one filter** and answers `400` when sent
  both. The web client branches on role: guardians pass `childInstitutionProfileIds`,
  employees pass `institutionCodes`. We were always sending both.
- **Its `data` is a list of per-profile contexts**, each carrying its own `groups` list —
  not a dict with `groups` at the top level. Parsing would have thrown even on a `200`.
  Contexts are now flattened and de-duplicated by group ID.
- **The contact-list method is `profiles.getContactlist`** — lowercase `l`. Also,
  `groupId`, `filter`, `field`, `page` and `order` are *all* required, and `page` is
  1-based (`page=0` also `400`s). We sent `GroupId`/`Page`/`Order` and omitted the rest.
- **`profiles.getContactParents` likewise requires `page` and `order`.**

Filtering by child profile IDs turned out to be the more useful call as well: it returns
the children's own class and SFO groups, where the institution-code filter only returned
the two parent groups.

## The CLI work (`1826f07`)

`aula contacts` with no arguments now lists the group IDs to choose from, sharing the
group lookup with `aula groups`. Contacts render as a rich table, with the plain-text
fallback the existing calendar table already uses when `rich` isn't installed.

| | |
|---|---|
| **Columns** | Child, Guardian, Relation, Class, Phone, Address — paired child-first from each contact's `relations` |
| **Paging** | every page by default (was silently capped at the first 20); `--page N` for one page |
| **Scoping** | guardian listings limited to children actually in the group, so siblings from other classes don't appear |
| **Sorting** | child name, then guardian, with Æ/Ø/Å ordered after Z as Danish does |
| **New flag** | `--profile-type child\|boy\|girl\|guardian\|employee` |

Two things worth calling out:

- **Phone and address always describe the guardian**, read from the contact itself in a
  guardian listing and from the relation in a child listing. Child relations carry their
  own registered contact details — often a parent's number filed against the child — so
  taking them from the wrong side produced plausible but wrong numbers.
- **Group membership comes from the same group re-fetched with the `child` filter**,
  because `groups.getMembershipsLight` returns zero members for a guardian account. This
  costs one extra paginated fetch per guardian listing, and runs even under `--page`,
  since a partial membership set would drop valid rows.

Employee listings have no relations and collapse to a flatter `Name | Role | Details |
Phone | Address` layout rather than showing an empty Guardian column.

## Verification

Checked against the live API on a real account:

- Group listing went from failing to 9 groups (children's classes and SFO groups).
- The SFO group went from 20 rows to 217 — 145 guardians across 8 pages.
- Scoping on class `3.1`: all 18 in-group children matched by `id`, 14 sibling entries
  dropped, and no guardian lost every child. The class column now shows only `3.1`. The
  SFO group still spans `0.1`–`6.1`, which is correct — those children really are members.
- Guardians who hide their contact info render blank Phone/Address cells (16 of 20 in
  class `3.1` expose details).

`ruff check` and `ruff format` are clean. 460 tests pass at HEAD, 423 at the fix commit —
each commit stands alone, and the intermediate state is functional.

New tests cover the pagination walk, the guardian-vs-child detail sourcing, the phone
fallback chain, address part-omission, the scoping filter, the Danish sort, both table
layouts, and the exact params of all three fixed API calls. The old API tests asserted
only on parsed output, which is why the wrong method name went unnoticed; they now pin
the params. Test fixtures use placeholder names, numbers and addresses — no real contact
data.

## Known limitations

- `contacts --parents` now returns `403` rather than `400`. That's an account-level
  permission on the "other parents" list, not something the client can fix.
- `--json` still emits the raw, unscoped, unsorted API objects, matching this codebase's
  `_raw` convention. Easy to change if you'd rather it mirror the table.
- Six columns want roughly 130+ terminal columns; below that the names and addresses wrap.
- `get_groups`'s signature changed (`child_institution_profile_ids` is now keyword and
  optional). The method returned `400` unconditionally before, so no working caller existed.
