### PR TITLE
feat: add ActivityType enum for presence templates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aula"
-version = "1.3.2"
+version = "1.4.0"
 description = "Python API wrapper for Aula."
 readme = "README.md"
 authors = [

--- a/src/aula/__init__.py
+++ b/src/aula/__init__.py
@@ -21,11 +21,13 @@ from .http import (
 )
 from .http_httpx import HttpxHttpClient
 from .models import (
+    ActivityType,
     CalendarEvent,
     Child,
     DailyOverview,
     Message,
     MessageThread,
+    PresenceState,
     Profile,
     WidgetConfiguration,
 )
@@ -55,5 +57,7 @@ __all__ = [
     "Message",
     "CalendarEvent",
     "WidgetConfiguration",
+    "ActivityType",
+    "PresenceState",
     "__version__",
 ]

--- a/src/aula/api_client.py
+++ b/src/aula/api_client.py
@@ -26,6 +26,7 @@ from .http import (
     HttpResponse,
 )
 from .models import (
+    ActivityType,
     Appointment,
     AutoReply,
     CalendarEvent,
@@ -488,7 +489,7 @@ class AulaApiClient:
         *,
         entry_time: str,
         exit_time: str,
-        activity_type: int = 0,
+        activity_type: ActivityType | int = ActivityType.PICKED_UP_BY,
         exit_with: str | None = None,
         comment: str | None = None,
         template_id: int | None = None,
@@ -502,8 +503,8 @@ class AulaApiClient:
             by_date: The date for the template.
             entry_time: Arrival time in HH:mm format (e.g., "08:00").
             exit_time: Departure time in HH:mm format (e.g., "16:30").
-            activity_type: Activity type enum value (0=PICKED_UP_BY, 1=SELF_DECIDER,
-                2=SEND_HOME, 3=GO_HOME_WITH, 4=DROP_OFF_TIME).
+            activity_type: How the child leaves at the end of the day. Prefer an
+                ``ActivityType`` member; raw ints are accepted for compatibility.
             exit_with: Name of person picking up, including relation suffix
                 (e.g., "Nick Hansen (Far)"). Required for PICKED_UP_BY and GO_HOME_WITH.
             comment: Optional daily comment/remark (empty string if not set).
@@ -531,26 +532,32 @@ class AulaApiClient:
             end_year = year + 1 if by_date.month > 6 else year
             expires_at = f"{end_year}-06-30T00:00:00+00:00"
 
+        # Unknown ints fall through to the flat shape rather than raising, so a
+        # newly-added Aula activity type still reaches the backend.
+        activity_value = (
+            activity_type.value if isinstance(activity_type, ActivityType) else activity_type
+        )
+
         # Build the activity sub-object based on activity_type
-        activity: dict[str, Any] = {"activityType": activity_type}
-        if activity_type == 0:  # PICKED_UP_BY
+        activity: dict[str, Any] = {"activityType": activity_value}
+        if activity_value == ActivityType.PICKED_UP_BY.value:
             activity["pickup"] = {
                 "entryTime": entry_time,
                 "exitTime": exit_time,
                 "exitWith": exit_with or "",
             }
-        elif activity_type == 1:  # SELF_DECIDER
+        elif activity_value == ActivityType.SELF_DECIDER.value:
             activity["selfDecider"] = {
                 "entryTime": entry_time,
                 "exitStartTime": exit_time,
                 "exitEndTime": exit_time,
             }
-        elif activity_type == 2:  # SEND_HOME
+        elif activity_value == ActivityType.SEND_HOME.value:
             activity["sendHome"] = {
                 "entryTime": entry_time,
                 "exitTime": exit_time,
             }
-        elif activity_type == 3:  # GO_HOME_WITH
+        elif activity_value == ActivityType.GO_HOME_WITH.value:
             activity["goHomeWith"] = {
                 "entryTime": entry_time,
                 "exitTime": exit_time,

--- a/src/aula/models/__init__.py
+++ b/src/aula/models/__init__.py
@@ -24,6 +24,8 @@ from .notification_settings import NotificationSetting as NotificationSetting
 from .pickup_responsible import ChildPickupResponsibles as ChildPickupResponsibles
 from .pickup_responsible import PickupPerson as PickupPerson
 from .post import Post as Post
+from .presence import ActivityType as ActivityType
+from .presence import PresenceState as PresenceState
 from .presence_registration import ChildPresenceState as ChildPresenceState
 from .presence_registration import PresenceActivity as PresenceActivity
 from .presence_registration import PresenceConfiguration as PresenceConfiguration

--- a/src/aula/models/presence.py
+++ b/src/aula/models/presence.py
@@ -41,3 +41,50 @@ class PresenceState(Enum):
             return cls(value).display_name
         except ValueError:
             return "Unknown Status"
+
+
+_ACTIVITY_DISPLAY_NAMES: dict[int, tuple[str, str]] = {
+    0: ("Collected By", "Hentes af"),
+    1: ("Self Decider", "Selvbestemmer"),
+    2: ("Sent Home", "Sendes hjem"),
+    3: ("Goes Home With", "Går hjem med"),
+    4: ("Drop-off Time", "Afleveringstid"),
+}
+
+
+class ActivityType(Enum):
+    """How a child leaves at the end of the day.
+
+    Used by ``DayTemplate.activity_type`` and by
+    ``AulaApiClient.update_presence_template``. ``PICKED_UP_BY`` and
+    ``GO_HOME_WITH`` both require a name in ``exit_with``.
+    """
+
+    PICKED_UP_BY = 0
+    SELF_DECIDER = 1
+    SEND_HOME = 2
+    GO_HOME_WITH = 3
+    DROP_OFF_TIME = 4
+
+    @property
+    def display_name(self) -> str:
+        """Return a user-friendly English display name."""
+        return _ACTIVITY_DISPLAY_NAMES[self.value][0]
+
+    @property
+    def danish_name(self) -> str:
+        """Return the Danish display name, as Aula labels it."""
+        return _ACTIVITY_DISPLAY_NAMES[self.value][1]
+
+    @property
+    def requires_exit_with(self) -> bool:
+        """Return True if Aula requires a named person in ``exit_with``."""
+        return self in (ActivityType.PICKED_UP_BY, ActivityType.GO_HOME_WITH)
+
+    @classmethod
+    def get_display_name(cls, value: int) -> str:
+        """Return a user-friendly display name for the activity type value."""
+        try:
+            return cls(value).display_name
+        except ValueError:
+            return "Unknown Activity Type"

--- a/tests/models/test_presence.py
+++ b/tests/models/test_presence.py
@@ -1,6 +1,8 @@
 """Tests for aula.models.presence."""
 
-from aula.models.presence import PresenceState
+import pytest
+
+from aula.models.presence import ActivityType, PresenceState
 
 
 def test_presence_state_values():
@@ -57,3 +59,58 @@ def test_presence_state_danish_name_property():
     assert PresenceState.SPARE_TIME_ACTIVITY.danish_name == "Til aktivitet"
     assert PresenceState.PHYSICAL_PLACEMENT.danish_name == "Fysisk placering"
     assert PresenceState.CHECKED_OUT.danish_name == "Gået"
+
+
+def test_activity_type_values():
+    assert ActivityType.PICKED_UP_BY.value == 0
+    assert ActivityType.SELF_DECIDER.value == 1
+    assert ActivityType.SEND_HOME.value == 2
+    assert ActivityType.GO_HOME_WITH.value == 3
+    assert ActivityType.DROP_OFF_TIME.value == 4
+
+
+def test_activity_type_from_value():
+    activity = ActivityType(3)
+    assert activity == ActivityType.GO_HOME_WITH
+    assert activity.name == "GO_HOME_WITH"
+
+
+def test_activity_type_display_name_property():
+    assert ActivityType.PICKED_UP_BY.display_name == "Collected By"
+    assert ActivityType.SELF_DECIDER.display_name == "Self Decider"
+    assert ActivityType.SEND_HOME.display_name == "Sent Home"
+    assert ActivityType.GO_HOME_WITH.display_name == "Goes Home With"
+    assert ActivityType.DROP_OFF_TIME.display_name == "Drop-off Time"
+
+
+def test_activity_type_danish_name_property():
+    assert ActivityType.PICKED_UP_BY.danish_name == "Hentes af"
+    assert ActivityType.SELF_DECIDER.danish_name == "Selvbestemmer"
+    assert ActivityType.SEND_HOME.danish_name == "Sendes hjem"
+    assert ActivityType.GO_HOME_WITH.danish_name == "Går hjem med"
+    assert ActivityType.DROP_OFF_TIME.danish_name == "Afleveringstid"
+
+
+def test_activity_type_get_display_name():
+    assert ActivityType.get_display_name(0) == "Collected By"
+    assert ActivityType.get_display_name(4) == "Drop-off Time"
+
+
+def test_activity_type_get_display_name_unknown():
+    assert ActivityType.get_display_name(99) == "Unknown Activity Type"
+
+
+def test_activity_type_unknown_value_raises():
+    with pytest.raises(ValueError, match="99"):
+        ActivityType(99)
+
+
+def test_activity_type_requires_exit_with():
+    assert ActivityType.PICKED_UP_BY.requires_exit_with is True
+    assert ActivityType.GO_HOME_WITH.requires_exit_with is True
+
+
+def test_activity_type_does_not_require_exit_with():
+    assert ActivityType.SELF_DECIDER.requires_exit_with is False
+    assert ActivityType.SEND_HOME.requires_exit_with is False
+    assert ActivityType.DROP_OFF_TIME.requires_exit_with is False

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -2835,3 +2835,115 @@ class TestGetContactParents:
             "page": 1,
             "order": "asc",
         }
+
+
+class TestUpdatePresenceTemplate:
+    """Tests for AulaApiClient.update_presence_template method."""
+
+    @pytest.fixture
+    def mock_client(self):
+        """Create a mock API client with a stubbed request layer."""
+        client = AulaApiClient(http_client=AsyncMock(), access_token="test_token")
+        mock_response = HttpResponse(status_code=200, data={"status": {"code": 200}})
+        mock_response.raise_for_status = MagicMock()  # type: ignore[assignment]
+        client._request_with_version_retry = AsyncMock(return_value=mock_response)
+        return client
+
+    @staticmethod
+    def _payload(mock_client):
+        """Return the JSON body of the recorded request."""
+        return mock_client._request_with_version_retry.await_args.kwargs["json"]
+
+    @pytest.mark.asyncio
+    async def test_accepts_activity_type_enum(self, mock_client):
+        """An ActivityType member is serialised as its int value."""
+        from aula.models.presence import ActivityType
+
+        await mock_client.update_presence_template(
+            institution_profile_id=10,
+            by_date=date(2026, 2, 25),
+            entry_time="08:00",
+            exit_time="16:00",
+            activity_type=ActivityType.GO_HOME_WITH,
+            exit_with="Nick Nissen (Far)",
+        )
+
+        activity = self._payload(mock_client)["presenceActivity"]
+        assert activity["activityType"] == 3
+        assert activity["goHomeWith"] == {
+            "entryTime": "08:00",
+            "exitTime": "16:00",
+            "exitWith": "Nick Nissen (Far)",
+        }
+
+    @pytest.mark.asyncio
+    async def test_accepts_raw_int_for_compatibility(self, mock_client):
+        """A raw int still selects the same activity shape as the enum."""
+        await mock_client.update_presence_template(
+            institution_profile_id=10,
+            by_date=date(2026, 2, 25),
+            entry_time="08:00",
+            exit_time="16:00",
+            activity_type=1,
+        )
+
+        activity = self._payload(mock_client)["presenceActivity"]
+        assert activity["activityType"] == 1
+        assert activity["selfDecider"] == {
+            "entryTime": "08:00",
+            "exitStartTime": "16:00",
+            "exitEndTime": "16:00",
+        }
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_picked_up_by(self, mock_client):
+        """Omitting activity_type keeps the previous default of 0."""
+        await mock_client.update_presence_template(
+            institution_profile_id=10,
+            by_date=date(2026, 2, 25),
+            entry_time="08:00",
+            exit_time="16:00",
+            exit_with="Mor",
+        )
+
+        activity = self._payload(mock_client)["presenceActivity"]
+        assert activity["activityType"] == 0
+        assert activity["pickup"]["exitWith"] == "Mor"
+
+    @pytest.mark.asyncio
+    async def test_unknown_activity_type_uses_flat_shape(self, mock_client):
+        """An int Aula adds later is passed through rather than rejected."""
+        await mock_client.update_presence_template(
+            institution_profile_id=10,
+            by_date=date(2026, 2, 25),
+            entry_time="08:00",
+            exit_time="16:00",
+            activity_type=99,
+        )
+
+        activity = self._payload(mock_client)["presenceActivity"]
+        assert activity == {
+            "activityType": 99,
+            "entryTime": "08:00",
+            "exitTime": "16:00",
+        }
+
+    @pytest.mark.asyncio
+    async def test_drop_off_time_uses_flat_shape(self, mock_client):
+        """DROP_OFF_TIME has no nested sub-object."""
+        from aula.models.presence import ActivityType
+
+        await mock_client.update_presence_template(
+            institution_profile_id=10,
+            by_date=date(2026, 2, 25),
+            entry_time="08:00",
+            exit_time="16:00",
+            activity_type=ActivityType.DROP_OFF_TIME,
+        )
+
+        activity = self._payload(mock_client)["presenceActivity"]
+        assert activity == {
+            "activityType": 4,
+            "entryTime": "08:00",
+            "exitTime": "16:00",
+        }

--- a/uv.lock
+++ b/uv.lock
@@ -16,7 +16,7 @@ wheels = [
 
 [[package]]
 name = "aula"
-version = "1.3.2"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Why

`update_presence_template` accepts `activity_type` as a bare `int`. The only place the 0–4 mapping was written down was a docstring line, so every caller had to re-encode both the values and their meaning. The Home Assistant integration hit this directly and ended up carrying its own `ACTIVITY_TYPES` dict plus a duplicate of the "which types need `exit_with`" rule.

## What

- **`ActivityType` enum** in `models/presence.py`, mirroring the existing `PresenceState` shape: `display_name`, `danish_name`, `get_display_name()`. Adds `requires_exit_with`, so callers can validate `exit_with` without re-deriving that `PICKED_UP_BY` and `GO_HOME_WITH` are the two types that need it.
- **`update_presence_template` accepts `ActivityType | int`**, defaulting to `ActivityType.PICKED_UP_BY`. The payload-building branches now compare against enum values instead of bare literals with trailing comments.
- **Exports**: `ActivityType` and `PresenceState` from both `aula` and `aula.models`. `PresenceState` was never reachable from the public API — consumers had to import `aula.models.presence` directly.

## Compatibility

Non-breaking:

- Raw ints still work, and `activity_type=0` is still the default behaviour.
- An unrecognised int (say a type Aula adds later) still falls through to the flat `entryTime`/`exitTime` payload rather than raising `ValueError` — normalisation deliberately avoids `ActivityType(value)` for that reason. Covered by a test.
- `DayTemplate.activity_type` is left as `int | None`; changing it would break anyone reading the field. A convenience property could come later.

## Tests

11 new enum tests and 5 for `update_presence_template` (enum input, raw-int input, default, unknown int, and the flat `DROP_OFF_TIME` shape). Full suite: 472 passed, 2 skipped. `models/presence.py` at 100% coverage.

Version bumped to 1.4.0 (minor — new feature).