### PR TITLE
feat: support all MitID auth options

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,31 @@ Legacy direct widget methods on `AulaApiClient` are deprecated and will be remov
 ### What You Need
 
 - **MitID username** — your MitID username (not your Aula username). Find it at [mitid.dk](https://mitid.dk/).
-- **MitID app** — installed and set up on your phone.
+- **A MitID authenticator** — either the MitID app on your phone, or a MitID kodeviser (code display device) plus your MitID password.
+
+### Authentication Methods
+
+Pick with `--auth-method` (or the `AULA_AUTH_METHOD` env var):
+
+| Method | Flag | What happens |
+|---|---|---|
+| MitID app | `--auth-method app` (default) | QR codes are printed in the terminal for you to scan. If your app asks for a code instead of a scan, that code is printed too. |
+| MitID kodeviser | `--auth-method token` | You're asked for the 6 digits on your kodeviser, then your MitID password. |
+
+MitID chip and audio code readers (kodeoplæser) are not supported. If your account offers one, it's listed in a warning at `-v` and the login falls back to whatever else you have.
 
 ### First Login
 
-On first run you'll be prompted to approve the login in your MitID app. You may need to scan a QR code or enter an OTP shown in the terminal. Tokens are saved to the storage file and reused on subsequent runs — no app interaction needed until they expire.
+On first run you'll be prompted to approve the login. Tokens are saved to the storage file and reused on subsequent runs — no authenticator interaction needed until they expire.
+
+For the kodeviser method you can skip the prompts:
+
+```bash
+export AULA_MITID_PASSWORD='...'      # or --password
+aula --auth-method token --token-code 123456 messages
+```
+
+The kodeviser code rotates, so `--token-code` is only useful for a single run. The password is never written to the config file; supply it per-run or via the environment.
 
 ### Token Security
 
@@ -195,6 +215,8 @@ The username can also be set via the `AULA_MITID_USERNAME` environment variable 
 | `--username` | MitID username (or `AULA_MITID_USERNAME` env var) |
 | `--output text\|json` | Output format (or `AULA_OUTPUT` env var) |
 | `--auth-method app\|token` | MitID auth method (or `AULA_AUTH_METHOD` env var) |
+| `--password` | MitID password for `--auth-method token` (or `AULA_MITID_PASSWORD` env var) |
+| `--token-code` | 6 digits from your MitID kodeviser (or `AULA_MITID_TOKEN_CODE` env var) |
 | `-v` / `-vv` / `-vvv` | Increase verbosity (warning / info / debug) |
 
 ### JSON output

--- a/src/aula/auth/browser_client.py
+++ b/src/aula/auth/browser_client.py
@@ -8,6 +8,7 @@ import json
 import logging
 import time
 from collections.abc import Callable
+from typing import Self
 
 import httpx
 import qrcode
@@ -38,6 +39,30 @@ def _pkcs7_pad(s: str) -> str:
     return s + pad_len * chr(pad_len)
 
 
+class _ComputeTimer:
+    """Accumulate local compute time across several blocks, skipping the gaps.
+
+    MitID's ``frontEndProcessingTime`` reports how long the browser client spent
+    on crypto. Timing whole request/response cycles instead would fold network
+    latency into a figure no real browser produces.
+    """
+
+    def __init__(self) -> None:
+        self._elapsed = 0.0
+        self._started_at = 0.0
+
+    def __enter__(self) -> Self:
+        self._started_at = time.monotonic()
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self._elapsed += time.monotonic() - self._started_at
+
+    @property
+    def milliseconds(self) -> int:
+        return int(self._elapsed * 1000)
+
+
 def _extract_next_authenticator(response_json: dict) -> dict[str, str]:
     """Extract authenticator fields from a /next response."""
     next_auth = response_json["nextAuthenticator"]
@@ -66,11 +91,13 @@ class BrowserClient:
         authentication_session_id: str,
         http_client: httpx.AsyncClient,
         on_qr_codes: Callable[[qrcode.QRCode, qrcode.QRCode], None] | None = None,
+        on_otp_code: Callable[[str], None] | None = None,
     ):
         self._client = http_client
         self._client_hash = client_hash
         self._authentication_session_id = authentication_session_id
         self._on_qr_codes = on_qr_codes
+        self._on_otp_code = on_otp_code
 
         # Authenticator state (populated after identify step)
         self._user_id: str | None = None
@@ -172,9 +199,21 @@ class BrowserClient:
         _check_authenticator_errors(data)
         self._set_authenticator_state(_extract_next_authenticator(data))
 
+        combinations = data["combinations"]
+        unsupported = [
+            combo["id"] for combo in combinations if combo["id"] not in _COMBINATION_ID_TO_NAME
+        ]
+        if unsupported:
+            # MitID chip and audio code readers land here; naming them beats a
+            # silent drop when a user asks why their authenticator is missing.
+            _LOGGER.warning(
+                "Ignoring MitID authenticator combinations with no client support: %s",
+                ", ".join(unsupported),
+            )
+
         return {
             _COMBINATION_ID_TO_NAME[combo["id"]]: combo["combinationItems"][0]["name"]
-            for combo in data["combinations"]
+            for combo in combinations
             if combo["id"] in _COMBINATION_ID_TO_NAME
         }
 
@@ -247,11 +286,14 @@ class BrowserClient:
                 continue
 
             if status == "channel_validation_otp":
-                self.otp_code = data["channelBindingValue"]
-                self.status_message = (
-                    f"Please use the following OTP code in the app: {self.otp_code}"
-                )
-                _LOGGER.debug("OTP channel validation requested")
+                otp_code = data["channelBindingValue"]
+                self.status_message = f"Please use the following OTP code in the app: {otp_code}"
+                # The poll repeats every half second; only announce a code once.
+                if otp_code != self.otp_code:
+                    self.otp_code = otp_code
+                    _LOGGER.debug("OTP channel validation requested")
+                    if self._on_otp_code:
+                        self._on_otp_code(otp_code)
                 await asyncio.sleep(0.5)
                 continue
 
@@ -300,13 +342,14 @@ class BrowserClient:
 
     async def _perform_srp_handshake(self, response: str, response_signature: str) -> None:
         """Execute the full SRP handshake (init → prove → verify → next)."""
-        timer_start = time.monotonic()
+        timer = _ComputeTimer()
 
         if self._authenticator_session_flow_key is None or self._authenticator_session_id is None:
             raise MitIDError("SRP handshake requires authenticator session to be established")
 
-        srp = CustomSRP()
-        public_a = srp.srp_stage1()
+        with timer:
+            srp = CustomSRP()
+            public_a = srp.srp_stage1()
 
         r = await self._client.post(
             f"{self._app_auth_url()}/init",
@@ -319,13 +362,14 @@ class BrowserClient:
         srp_salt = init_data["srpSalt"]["value"]
         random_b = init_data["randomB"]["value"]
 
-        password = hashlib.sha256(
-            base64.b64decode(response) + self._authenticator_session_flow_key.encode("utf-8")
-        ).hexdigest()
+        with timer:
+            password = hashlib.sha256(
+                base64.b64decode(response) + self._authenticator_session_flow_key.encode("utf-8")
+            ).hexdigest()
 
-        m1 = srp.srp_stage3(srp_salt, random_b, password, self._authenticator_session_id)
+            m1 = srp.srp_stage3(srp_salt, random_b, password, self._authenticator_session_id)
 
-        flow_value_proof = self._compute_flow_value_proof(srp.session_key_bytes)
+            flow_value_proof = self._compute_flow_value_proof(srp.session_key_bytes)
 
         r = await self._client.post(
             f"{self._app_auth_url()}/prove",
@@ -334,15 +378,16 @@ class BrowserClient:
         if not r.is_success:
             raise MitIDError(f"Failed to submit app response proof: HTTP {r.status_code}")
 
-        m2 = r.json()["m2"]["value"]
-        if not srp.srp_stage5(m2):
-            raise MitIDError("m2 could not be validated during proving of app response")
+        with timer:
+            m2 = r.json()["m2"]["value"]
+            if not srp.srp_stage5(m2):
+                raise MitIDError("m2 could not be validated during proving of app response")
 
-        auth_enc = base64.b64encode(
-            srp.auth_enc(base64.b64decode(_pkcs7_pad(response_signature)))
-        ).decode("ascii")
+            auth_enc = base64.b64encode(
+                srp.auth_enc(base64.b64decode(_pkcs7_pad(response_signature)))
+            ).decode("ascii")
 
-        front_end_time_ms = int((time.monotonic() - timer_start) * 1000)
+        front_end_time_ms = timer.milliseconds
 
         r = await self._client.post(
             f"{self._app_auth_url()}/verify",
@@ -371,11 +416,12 @@ class BrowserClient:
 
     async def _authenticate_token_phase(self, token_digits: str) -> None:
         """Execute the TOTP code token authentication phase."""
-        timer_start = time.monotonic()
+        timer = _ComputeTimer()
         await self._select_authenticator("TOKEN")
 
-        srp = CustomSRP()
-        public_a = srp.srp_stage1()
+        with timer:
+            srp = CustomSRP()
+            public_a = srp.srp_stage1()
 
         r = await self._client.post(
             f"{self._code_token_auth_url()}/codetoken-init",
@@ -391,16 +437,17 @@ class BrowserClient:
         if self._authenticator_session_flow_key is None or self._authenticator_session_id is None:
             raise MitIDError("Token auth requires authenticator session to be established")
 
-        # For TOKEN auth the SRP password is the hex-encoded flow key
-        password = self._authenticator_session_flow_key.encode("utf-8").hex()
+        with timer:
+            # For TOKEN auth the SRP password is the hex-encoded flow key
+            password = self._authenticator_session_flow_key.encode("utf-8").hex()
 
-        m1 = srp.srp_stage3(srp_salt, random_b, password, self._authenticator_session_id)
+            m1 = srp.srp_stage3(srp_salt, random_b, password, self._authenticator_session_id)
 
-        flow_value_proof = self._compute_flow_value_proof(
-            srp.session_key_bytes, proof_key_prefix="OTP" + token_digits
-        )
+            flow_value_proof = self._compute_flow_value_proof(
+                srp.session_key_bytes, proof_key_prefix="OTP" + token_digits
+            )
 
-        front_end_time_ms = int((time.monotonic() - timer_start) * 1000)
+        front_end_time_ms = timer.milliseconds
 
         r = await self._client.post(
             f"{self._code_token_auth_url()}/codetoken-prove",
@@ -436,13 +483,14 @@ class BrowserClient:
 
     async def _authenticate_password_phase(self, password: str) -> None:
         """Execute the MitID password authentication phase."""
-        timer_start = time.monotonic()
+        timer = _ComputeTimer()
 
         if self._authenticator_type != "PASSWORD":
             raise MitIDError("Password phase requires PASSWORD authenticator to be active")
 
-        srp = CustomSRP()
-        public_a = srp.srp_stage1()
+        with timer:
+            srp = CustomSRP()
+            public_a = srp.srp_stage1()
 
         r = await self._client.post(
             f"{self._password_auth_url()}/init",
@@ -456,20 +504,26 @@ class BrowserClient:
         srp_salt = init_data["srpSalt"]["value"]
         random_b = init_data["randomB"]["value"]
 
-        # Derive the SRP password using PBKDF2 (offloaded to avoid blocking the event loop)
-        derived = await asyncio.to_thread(
-            hashlib.pbkdf2_hmac, "sha256", password.encode(), bytes.fromhex(pbkdf2_salt), 20000, 32
-        )
-        srp_password = derived.hex()
-
         if self._authenticator_session_id is None:
             raise MitIDError("Password auth requires authenticator session to be established")
 
-        m1 = srp.srp_stage3(srp_salt, random_b, srp_password, self._authenticator_session_id)
+        with timer:
+            # Derive the SRP password using PBKDF2 (offloaded to avoid blocking the event loop)
+            derived = await asyncio.to_thread(
+                hashlib.pbkdf2_hmac,
+                "sha256",
+                password.encode(),
+                bytes.fromhex(pbkdf2_salt),
+                20000,
+                32,
+            )
+            srp_password = derived.hex()
 
-        flow_value_proof = self._compute_flow_value_proof(srp.session_key_bytes)
+            m1 = srp.srp_stage3(srp_salt, random_b, srp_password, self._authenticator_session_id)
 
-        front_end_time_ms = int((time.monotonic() - timer_start) * 1000)
+            flow_value_proof = self._compute_flow_value_proof(srp.session_key_bytes)
+
+        front_end_time_ms = timer.milliseconds
 
         r = await self._client.post(
             f"{self._password_auth_url()}/password-prove",

--- a/src/aula/auth/mitid_client.py
+++ b/src/aula/auth/mitid_client.py
@@ -89,6 +89,7 @@ class MitIDAuthClient:
         auth_method: str = "app",
         on_token_digits: Callable[[], Awaitable[str]] | None = None,
         on_password: Callable[[], Awaitable[str]] | None = None,
+        on_otp_code: Callable[[str], None] | None = None,
     ):
         self._owns_client = httpx_client is None
         self._client = httpx_client or httpx.AsyncClient(follow_redirects=False, timeout=timeout)
@@ -99,6 +100,7 @@ class MitIDAuthClient:
         self._auth_method = auth_method
         self._on_token_digits = on_token_digits
         self._on_password = on_password
+        self._on_otp_code = on_otp_code
 
         # The real Android app just sends User-Agent: Android — the server
         # doesn't validate browser-style headers (sec-ch-ua, etc.).
@@ -335,7 +337,11 @@ class MitIDAuthClient:
         authentication_session_id = aux["parameters"]["authenticationSessionId"]
 
         self._mitid_client = BrowserClient(
-            client_hash, authentication_session_id, self._client, self._on_qr_codes
+            client_hash,
+            authentication_session_id,
+            self._client,
+            self._on_qr_codes,
+            self._on_otp_code,
         )
 
         await self._mitid_client.initialize()
@@ -349,14 +355,12 @@ class MitIDAuthClient:
         _LOGGER.debug("Available authenticators: %s", available_authenticators)
 
         if self._auth_method == "token":
-            if "TOKEN" not in available_authenticators:
-                raise MitIDError("TOKEN authentication method not available for this user")
+            self._require_authenticator("TOKEN", available_authenticators)
             token_digits = await self._get_token_digits()
             password = await self._get_password()
             await self._mitid_client.authenticate_with_token_and_password(token_digits, password)
         else:
-            if "APP" not in available_authenticators:
-                raise MitIDError("APP authentication method not available for this user")
+            self._require_authenticator("APP", available_authenticators)
             await self._mitid_client.authenticate_with_app()
 
         authorization_code = (
@@ -364,6 +368,16 @@ class MitIDAuthClient:
         )
         _LOGGER.debug("MitID authorization code obtained")
         return authorization_code
+
+    @staticmethod
+    def _require_authenticator(wanted: str, available: dict[str, str]) -> None:
+        """Fail with the authenticators the user does have, not just the missing one."""
+        if wanted in available:
+            return
+        offered = ", ".join(sorted(available)) or "none"
+        raise MitIDError(
+            f"{wanted} authentication is not available for this MitID user (available: {offered})"
+        )
 
     async def _get_token_digits(self) -> str:
         """Get the 6-digit TOTP code from the callback."""

--- a/src/aula/auth_flow.py
+++ b/src/aula/auth_flow.py
@@ -142,6 +142,7 @@ async def authenticate(
     auth_method: str = "app",
     on_token_digits: Callable[[], Awaitable[str]] | None = None,
     on_password: Callable[[], Awaitable[str]] | None = None,
+    on_otp_code: Callable[[str], None] | None = None,
 ) -> dict[str, Any]:
     """Authenticate via MitID (or cached tokens) and return credential data.
 
@@ -157,6 +158,8 @@ async def authenticate(
             provided, cached tokens are loaded/saved automatically.  When
             *None*, a fresh MitID login is always performed.
         on_qr_codes: Callback for displaying QR codes during MitID flow.
+        on_otp_code: Callback for displaying the OTP code the user types into
+            the MitID app instead of scanning the QR codes.
         on_login_required: Callback invoked when fresh login is needed.
         httpx_client: Optional ``httpx.AsyncClient`` to use for the MitID
             auth flow.  When provided, the caller retains ownership and must
@@ -178,6 +181,7 @@ async def authenticate(
         auth_method=auth_method,
         on_token_digits=on_token_digits,
         on_password=on_password,
+        on_otp_code=on_otp_code,
     ) as auth_client:
         token_data = (
             None if force_login else (await token_storage.load() if token_storage else None)
@@ -249,6 +253,7 @@ async def authenticate_and_create_client(
     auth_method: str = "app",
     on_token_digits: Callable[[], Awaitable[str]] | None = None,
     on_password: Callable[[], Awaitable[str]] | None = None,
+    on_otp_code: Callable[[str], None] | None = None,
 ) -> AulaApiClient:
     """Authenticate via MitID (or cached tokens) and return a ready-to-use client.
 
@@ -273,6 +278,7 @@ async def authenticate_and_create_client(
         auth_method=auth_method,
         on_token_digits=on_token_digits,
         on_password=on_password,
+        on_otp_code=on_otp_code,
     )
     try:
         return await create_client(token_data)
@@ -292,6 +298,7 @@ async def authenticate_and_create_client(
             auth_method=auth_method,
             on_token_digits=on_token_digits,
             on_password=on_password,
+            on_otp_code=on_otp_code,
         )
         return await create_client(fresh_token_data)
 

--- a/src/aula/cli.py
+++ b/src/aula/cli.py
@@ -104,6 +104,18 @@ def get_mitid_username(ctx: click.Context) -> str:
     help="MitID auth method: 'app' (QR/OTP) or 'token' (code token + password).",
 )
 @click.option(
+    "--password",
+    envvar="AULA_MITID_PASSWORD",
+    help="MitID password for --auth-method token (or AULA_MITID_PASSWORD env var). "
+    "Prompted for when omitted.",
+)
+@click.option(
+    "--token-code",
+    envvar="AULA_MITID_TOKEN_CODE",
+    help="6 digits from your MitID kodeviser (or AULA_MITID_TOKEN_CODE env var). "
+    "Prompted for when omitted; the code rotates, so this is only useful per-run.",
+)
+@click.option(
     "--output",
     "output_format",
     type=click.Choice(["text", "json"], case_sensitive=False),
@@ -112,7 +124,15 @@ def get_mitid_username(ctx: click.Context) -> str:
     help="Output format: 'text' (human-readable) or 'json' (machine-readable).",
 )
 @click.pass_context
-def cli(ctx, username: str | None, verbose: int, auth_method: str, output_format: str):
+def cli(
+    ctx,
+    username: str | None,
+    verbose: int,
+    auth_method: str,
+    password: str | None,
+    token_code: str | None,
+    output_format: str,
+):
     """CLI for interacting with Aula API"""
     # Configure logging based on verbosity
     log_level = logging.ERROR  # Default: errors only (no warnings in normal output)
@@ -140,6 +160,8 @@ def cli(ctx, username: str | None, verbose: int, auth_method: str, output_format
 
     ctx.obj["AUTH_METHOD"] = auth_method
     ctx.obj["OUTPUT_FORMAT"] = output_format
+    ctx.obj["MITID_PASSWORD"] = password
+    ctx.obj["MITID_TOKEN_CODE"] = token_code
 
     if username:
         ctx.obj["MITID_USERNAME"] = username
@@ -194,12 +216,35 @@ async def _select_identity(identities: list[str]) -> int:
     return choice - 1
 
 
-async def _prompt_token_digits() -> str:
-    return click.prompt("MitID token code (6 digits)", type=str)
+def _print_otp_code(code: str) -> None:
+    """Show the code the user types into the MitID app in place of scanning."""
+    click.echo("=" * 60)
+    click.echo(f"ENTER THIS CODE IN YOUR MITID APP: {code}")
+    click.echo("=" * 60)
 
 
-async def _prompt_password() -> str:
-    return click.prompt("MitID password", hide_input=True, type=str)
+def _token_digits_provider(ctx: click.Context) -> Callable[[], Awaitable[str]]:
+    """Supply the kodeviser digits from the CLI/env, falling back to a prompt."""
+
+    async def provide() -> str:
+        supplied = ctx.obj.get("MITID_TOKEN_CODE")
+        if supplied:
+            return supplied
+        return click.prompt("MitID token code (6 digits)", type=str)
+
+    return provide
+
+
+def _password_provider(ctx: click.Context) -> Callable[[], Awaitable[str]]:
+    """Supply the MitID password from the CLI/env, falling back to a prompt."""
+
+    async def provide() -> str:
+        supplied = ctx.obj.get("MITID_PASSWORD")
+        if supplied:
+            return supplied
+        return click.prompt("MitID password", hide_input=True, type=str)
+
+    return provide
 
 
 async def _get_client(ctx: click.Context) -> AulaApiClient:
@@ -210,11 +255,12 @@ async def _get_client(ctx: click.Context) -> AulaApiClient:
         username,
         token_storage,
         on_qr_codes=_print_qr_codes_in_terminal,
+        on_otp_code=_print_otp_code,
         on_login_required=_on_login_required,
         on_identity_selected=_select_identity,
         auth_method=ctx.obj.get("AUTH_METHOD", "app"),
-        on_token_digits=_prompt_token_digits,
-        on_password=_prompt_password,
+        on_token_digits=_token_digits_provider(ctx),
+        on_password=_password_provider(ctx),
     )
 
 

--- a/src/aula/widgets/client.py
+++ b/src/aula/widgets/client.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any, Protocol
 
 from ..const import (
@@ -22,6 +23,35 @@ from ..models import (
     MUWeeklyPerson,
     UserReminders,
 )
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _as_list(data: Any, provider: str) -> list[Any]:
+    """Return ``data`` if it is a list of dicts, else log and return an empty list.
+
+    Widget providers sometimes answer 2xx with an error object instead of the
+    documented array, e.g. Meebook's ``{"message": "JWT-Token expired, please
+    renew."}``. Iterating that yields the keys as strings, which blows up in
+    ``from_dict``. ``data`` is also ``None`` when the body was not valid JSON.
+    """
+    if not isinstance(data, list):
+        _LOGGER.warning(
+            "%s returned %s instead of a list, treating as empty: %s",
+            provider,
+            type(data).__name__,
+            data,
+        )
+        return []
+
+    items = [item for item in data if isinstance(item, dict)]
+    if len(items) != len(data):
+        _LOGGER.warning(
+            "%s returned %d non-dict item(s), skipping them",
+            provider,
+            len(data) - len(items),
+        )
+    return items
 
 
 class _WidgetRequestClient(Protocol):
@@ -193,7 +223,8 @@ class AulaWidgetsClient:
             headers=headers,
         )
         resp.raise_for_status()
-        return [MeebookStudentPlan.from_dict(s) for s in resp.json()]
+        plans = _as_list(resp.json(), "Meebook weekplan")
+        return [MeebookStudentPlan.from_dict(s) for s in plans]
 
     async def get_momo_courses(
         self,
@@ -218,7 +249,8 @@ class AulaWidgetsClient:
             headers={"Aula-Authorization": token},
         )
         resp.raise_for_status()
-        return [MomoUserCourses.from_dict(u) for u in resp.json()]
+        courses = _as_list(resp.json(), "Huskelisten courses")
+        return [MomoUserCourses.from_dict(u) for u in courses]
 
     async def get_momo_reminders(
         self,
@@ -247,7 +279,8 @@ class AulaWidgetsClient:
             headers={"Aula-Authorization": token},
         )
         resp.raise_for_status()
-        return [UserReminders.from_dict(u) for u in resp.json()]
+        reminders = _as_list(resp.json(), "Huskelisten reminders")
+        return [UserReminders.from_dict(u) for u in reminders]
 
     async def get_library_status(
         self,
@@ -273,4 +306,12 @@ class AulaWidgetsClient:
             headers={"Authorization": token, "Accept": "application/json"},
         )
         resp.raise_for_status()
-        return LibraryStatus.from_dict(resp.json())
+        data = resp.json()
+        if not isinstance(data, dict):
+            _LOGGER.warning(
+                "Library status returned %s instead of an object, treating as empty: %s",
+                type(data).__name__,
+                data,
+            )
+            return LibraryStatus()
+        return LibraryStatus.from_dict(data)

--- a/tests/auth/test_browser_client.py
+++ b/tests/auth/test_browser_client.py
@@ -1,0 +1,285 @@
+"""Tests for aula.auth.browser_client — the MitID kodeviser (TOKEN) flow."""
+
+import asyncio
+import json
+import logging
+
+import httpx
+import pytest
+
+from aula.auth.browser_client import BrowserClient
+from aula.auth.exceptions import MitIDError, PasswordInvalidError, TokenInvalidError
+
+SESSION_ID = "auth-session-1"
+TOKEN_SESSION_ID = "token-session-1"
+PASSWORD_SESSION_ID = "password-session-1"
+FINALIZATION_SESSION_ID = "final-session-1"
+AUTHORIZATION_CODE = "authorization-code-xyz"
+
+CORE = "https://www.mitid.dk/mitid-core-client-backend"
+TOKEN_AUTH = "https://www.mitid.dk/mitid-code-token-auth/v1/authenticator-sessions"
+PASSWORD_AUTH = "https://www.mitid.dk/mitid-password-auth/v1/authenticator-sessions"
+
+
+def _authenticator(auth_type: str, session_id: str) -> dict:
+    return {
+        "authenticatorType": auth_type,
+        "authenticatorSessionFlowKey": "flow-key",
+        "eafeHash": "eafe-hash",
+        "authenticatorSessionId": session_id,
+    }
+
+
+def _srp_init(with_pbkdf2: bool = False) -> dict:
+    """SRP values the real backend returns; any well-formed hex works here."""
+    payload = {"srpSalt": {"value": "a1b2c3d4"}, "randomB": {"value": "4f5e6d7c8b"}}
+    if with_pbkdf2:
+        payload["pbkdf2Salt"] = {"value": "0f1e2d3c"}
+    return payload
+
+
+class FakeMitID:
+    """Minimal MitID backend covering identify -> kodeviser -> password -> finalize."""
+
+    def __init__(
+        self,
+        *,
+        latency: float = 0.0,
+        totp_invalid: bool = False,
+        password_invalid: bool = False,
+        authenticator_after_token: str = "PASSWORD",
+        extra_combinations: list[dict] | None = None,
+    ):
+        self.latency = latency
+        self.totp_invalid = totp_invalid
+        self.password_invalid = password_invalid
+        self.authenticator_after_token = authenticator_after_token
+        self.extra_combinations = extra_combinations or []
+
+        self.paths: list[str] = []
+        self.bodies: dict[str, dict] = {}
+        self._token_proved = False
+        self._password_proved = False
+
+    async def __call__(self, request: httpx.Request) -> httpx.Response:
+        if self.latency:
+            await asyncio.sleep(self.latency)
+
+        url = str(request.url)
+        self.paths.append(f"{request.method} {request.url.path}")
+
+        if request.method == "GET" and url == f"{CORE}/v1/authentication-sessions/{SESSION_ID}":
+            return httpx.Response(
+                200,
+                json={
+                    "brokerSecurityContext": "broker-context",
+                    "serviceProviderName": "Aula",
+                    "referenceTextHeader": "Log ind",
+                    "referenceTextBody": "Aula",
+                },
+            )
+
+        if request.method == "PUT" and url == f"{CORE}/v1/authentication-sessions/{SESSION_ID}":
+            return httpx.Response(200, json={})
+
+        if url == f"{CORE}/v2/authentication-sessions/{SESSION_ID}/next":
+            return self._handle_next(request)
+
+        if url == f"{TOKEN_AUTH}/{TOKEN_SESSION_ID}/codetoken-init":
+            return httpx.Response(200, json=_srp_init())
+
+        if url == f"{TOKEN_AUTH}/{TOKEN_SESSION_ID}/codetoken-prove":
+            self.bodies["codetoken-prove"] = _json_body(request)
+            self._token_proved = True
+            return httpx.Response(204)
+
+        if url == f"{PASSWORD_AUTH}/{PASSWORD_SESSION_ID}/init":
+            return httpx.Response(200, json=_srp_init(with_pbkdf2=True))
+
+        if url == f"{PASSWORD_AUTH}/{PASSWORD_SESSION_ID}/password-prove":
+            self.bodies["password-prove"] = _json_body(request)
+            self._password_proved = True
+            return httpx.Response(204)
+
+        if url == f"{CORE}/v1/authentication-sessions/{FINALIZATION_SESSION_ID}/finalization":
+            return httpx.Response(200, json={"authorizationCode": AUTHORIZATION_CODE})
+
+        raise AssertionError(f"unexpected request: {request.method} {url}")
+
+    def _handle_next(self, request: httpx.Request) -> httpx.Response:
+        combination_id = _json_body(request)["combinationId"]
+
+        # Selecting the kodeviser explicitly.
+        if combination_id == "S1":
+            return httpx.Response(
+                200,
+                json={"errors": [], "nextAuthenticator": _authenticator("TOKEN", TOKEN_SESSION_ID)},
+            )
+
+        # Advancing after the password proof: hand back the finalization session.
+        if self._password_proved:
+            if self.password_invalid:
+                return httpx.Response(
+                    200,
+                    json={"errors": [{"errorCode": "PASSWORD_INVALID", "message": "wrong"}]},
+                )
+            return httpx.Response(
+                200, json={"errors": [], "nextSessionId": FINALIZATION_SESSION_ID}
+            )
+
+        # Advancing after the kodeviser proof: the backend asks for the password.
+        if self._token_proved:
+            if self.totp_invalid:
+                return httpx.Response(
+                    200, json={"errors": [{"errorCode": "TOTP_INVALID", "message": "wrong"}]}
+                )
+            return httpx.Response(
+                200,
+                json={
+                    "errors": [],
+                    "nextAuthenticator": _authenticator(
+                        self.authenticator_after_token, PASSWORD_SESSION_ID
+                    ),
+                },
+            )
+
+        # The identify step: MitID defaults to the app authenticator.
+        return httpx.Response(
+            200,
+            json={
+                "errors": [],
+                "nextAuthenticator": _authenticator("APP", "app-session-1"),
+                "combinations": [
+                    {"id": "S3", "combinationItems": [{"name": "MitID app"}]},
+                    {"id": "S1", "combinationItems": [{"name": "MitID kodeviser"}]},
+                    *self.extra_combinations,
+                ],
+            },
+        )
+
+
+def _json_body(request: httpx.Request) -> dict:
+    return json.loads(request.content)
+
+
+async def _identified_client(server: FakeMitID) -> tuple[BrowserClient, dict[str, str]]:
+    """Run initialize + identify, leaving the client ready to authenticate."""
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(server))
+    client = BrowserClient("client-hash", SESSION_ID, http_client)
+    await client.initialize()
+    authenticators = await client.identify_as_user_and_get_available_authenticators("tester")
+    return client, authenticators
+
+
+class TestKodeviserFlow:
+    @pytest.mark.asyncio
+    async def test_returns_authorization_code(self):
+        server = FakeMitID()
+        client, _ = await _identified_client(server)
+
+        await client.authenticate_with_token_and_password("123456", "hunter2")
+        code = await client.finalize_authentication_and_get_authorization_code()
+
+        assert code == AUTHORIZATION_CODE
+
+    @pytest.mark.asyncio
+    async def test_walks_the_two_phase_handshake_in_order(self):
+        """Kodeviser proof must precede the password phase; MitID rejects any other order."""
+        server = FakeMitID()
+        client, _ = await _identified_client(server)
+
+        await client.authenticate_with_token_and_password("123456", "hunter2")
+        await client.finalize_authentication_and_get_authorization_code()
+
+        proof_steps = [p for p in server.paths if p.endswith(("prove", "finalization"))]
+        assert proof_steps == [
+            f"POST /mitid-code-token-auth/v1/authenticator-sessions/{TOKEN_SESSION_ID}"
+            "/codetoken-prove",
+            f"POST /mitid-password-auth/v1/authenticator-sessions/{PASSWORD_SESSION_ID}"
+            "/password-prove",
+            f"PUT /mitid-core-client-backend/v1/authentication-sessions"
+            f"/{FINALIZATION_SESSION_ID}/finalization",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_identify_reports_kodeviser_as_available(self):
+        server = FakeMitID()
+        _, authenticators = await _identified_client(server)
+
+        assert authenticators == {"APP": "MitID app", "TOKEN": "MitID kodeviser"}
+
+    @pytest.mark.asyncio
+    async def test_each_proof_carries_m1_and_flow_value_proof(self):
+        server = FakeMitID()
+        client, _ = await _identified_client(server)
+
+        await client.authenticate_with_token_and_password("123456", "hunter2")
+
+        for step in ("codetoken-prove", "password-prove"):
+            body = server.bodies[step]
+            assert body["m1"]["value"]
+            assert body["flowValueProof"]["value"]
+
+    @pytest.mark.asyncio
+    async def test_rejected_token_code_raises_token_invalid(self):
+        server = FakeMitID(totp_invalid=True)
+        client, _ = await _identified_client(server)
+
+        with pytest.raises(TokenInvalidError):
+            await client.authenticate_with_token_and_password("000000", "hunter2")
+
+    @pytest.mark.asyncio
+    async def test_rejected_password_raises_password_invalid(self):
+        server = FakeMitID(password_invalid=True)
+        client, _ = await _identified_client(server)
+
+        with pytest.raises(PasswordInvalidError):
+            await client.authenticate_with_token_and_password("123456", "wrong")
+
+    @pytest.mark.asyncio
+    async def test_unexpected_authenticator_after_token_is_rejected(self):
+        """A backend that asks for something other than the password is not a flow we can drive."""
+        server = FakeMitID(authenticator_after_token="CHIP")
+        client, _ = await _identified_client(server)
+
+        with pytest.raises(MitIDError, match="Expected PASSWORD"):
+            await client.authenticate_with_token_and_password("123456", "hunter2")
+
+    @pytest.mark.asyncio
+    async def test_unsupported_combinations_are_logged_not_dropped_silently(self, caplog):
+        """Chip and audio readers show up here; users need to know why they're unusable."""
+        server = FakeMitID(
+            extra_combinations=[{"id": "S9", "combinationItems": [{"name": "MitID chip"}]}]
+        )
+
+        with caplog.at_level(logging.WARNING, logger="aula.auth.browser_client"):
+            _, authenticators = await _identified_client(server)
+
+        assert "S9" not in authenticators
+        assert "S9" in caplog.text
+
+
+class TestFrontEndProcessingTime:
+    """MitID is told how long the client spent on crypto; network time is not that."""
+
+    @pytest.mark.asyncio
+    async def test_excludes_network_latency(self):
+        latency = 0.2
+        server = FakeMitID(latency=latency)
+        client, _ = await _identified_client(server)
+
+        await client.authenticate_with_token_and_password("123456", "hunter2")
+
+        # Two round trips (authenticator select + codetoken-init) precede this proof,
+        # so a timer spanning them would report at least 2 * latency.
+        assert server.bodies["codetoken-prove"]["frontEndProcessingTime"] < latency * 2 * 1000
+
+    @pytest.mark.asyncio
+    async def test_still_measures_real_compute(self):
+        """PBKDF2 at 20k iterations is the bulk of it; reporting zero would be a lie."""
+        server = FakeMitID()
+        client, _ = await _identified_client(server)
+
+        await client.authenticate_with_token_and_password("123456", "hunter2")
+
+        assert server.bodies["password-prove"]["frontEndProcessingTime"] > 0

--- a/tests/auth/test_mitid_client_credentials.py
+++ b/tests/auth/test_mitid_client_credentials.py
@@ -1,0 +1,85 @@
+"""Tests for aula.auth.mitid_client — authenticator choice and credential callbacks."""
+
+import pytest
+
+from aula.auth.exceptions import MitIDError
+from aula.auth.mitid_client import MitIDAuthClient
+
+
+def _client(**kwargs) -> MitIDAuthClient:
+    return MitIDAuthClient(mitid_username="tester", **kwargs)
+
+
+def _returning(value: str):
+    async def callback() -> str:
+        return value
+
+    return callback
+
+
+class TestRequireAuthenticator:
+    def test_passes_when_available(self):
+        MitIDAuthClient._require_authenticator("TOKEN", {"TOKEN": "MitID kodeviser"})
+
+    def test_names_what_the_user_actually_has(self):
+        """ "Not available" alone leaves users guessing which method to pick instead."""
+        with pytest.raises(MitIDError, match=r"available: APP"):
+            MitIDAuthClient._require_authenticator("TOKEN", {"APP": "MitID app"})
+
+    def test_reports_none_when_nothing_is_supported(self):
+        with pytest.raises(MitIDError, match=r"available: none"):
+            MitIDAuthClient._require_authenticator("APP", {})
+
+
+class TestTokenDigits:
+    @pytest.mark.asyncio
+    async def test_accepts_six_digits(self):
+        client = _client(on_token_digits=_returning("123456"))
+
+        assert await client._get_token_digits() == "123456"
+
+    @pytest.mark.asyncio
+    async def test_strips_surrounding_whitespace(self):
+        """Codes get pasted in with a stray space more often than not."""
+        client = _client(on_token_digits=_returning("  123456 "))
+
+        assert await client._get_token_digits() == "123456"
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_numeric(self):
+        client = _client(on_token_digits=_returning("12a456"))
+
+        with pytest.raises(MitIDError, match="numeric"):
+            await client._get_token_digits()
+
+    @pytest.mark.asyncio
+    async def test_rejects_wrong_length(self):
+        client = _client(on_token_digits=_returning("12345"))
+
+        with pytest.raises(MitIDError, match="exactly 6 digits"):
+            await client._get_token_digits()
+
+    @pytest.mark.asyncio
+    async def test_requires_a_callback(self):
+        with pytest.raises(MitIDError, match="on_token_digits"):
+            await _client()._get_token_digits()
+
+
+class TestPassword:
+    @pytest.mark.asyncio
+    async def test_returns_supplied_password(self):
+        client = _client(on_password=_returning("hunter2"))
+
+        assert await client._get_password() == "hunter2"
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty(self):
+        client = _client(on_password=_returning(""))
+
+        with pytest.raises(MitIDError, match="must not be empty"):
+            await client._get_password()
+
+    @pytest.mark.asyncio
+    async def test_requires_a_callback(self):
+        with pytest.raises(MitIDError, match="on_password"):
+            await _client()._get_password()

--- a/tests/test_auth_flow.py
+++ b/tests/test_auth_flow.py
@@ -509,6 +509,7 @@ class TestAuthenticateAndCreateClient:
             auth_method="app",
             on_token_digits=None,
             on_password=None,
+            on_otp_code=None,
         )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,18 @@
 """Tests for aula.cli helpers."""
 
+from unittest.mock import MagicMock
+
+import click
 import pytest
 
-from aula.cli import CONTACTS_PAGE_SIZE, MAX_CONTACT_PAGES, _fetch_contact_pages
+from aula.cli import (
+    CONTACTS_PAGE_SIZE,
+    MAX_CONTACT_PAGES,
+    _fetch_contact_pages,
+    _password_provider,
+    _print_otp_code,
+    _token_digits_provider,
+)
 
 
 def _pager(total: int):
@@ -69,3 +79,60 @@ class TestFetchContactPages:
         assert len(calls) == MAX_CONTACT_PAGES
         assert len(result) == MAX_CONTACT_PAGES * CONTACTS_PAGE_SIZE
         assert "may be incomplete" in capsys.readouterr().out
+
+
+def _ctx(**obj) -> click.Context:
+    ctx = click.Context(click.Command("aula"))
+    ctx.obj = obj
+    return ctx
+
+
+class TestCredentialProviders:
+    """MitID credentials come from a flag, an env var, or a prompt — in that order."""
+
+    @pytest.mark.asyncio
+    async def test_token_code_from_context_skips_the_prompt(self, monkeypatch):
+        prompt = MagicMock()
+        monkeypatch.setattr(click, "prompt", prompt)
+
+        provide = _token_digits_provider(_ctx(MITID_TOKEN_CODE="123456"))
+
+        assert await provide() == "123456"
+        prompt.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_token_code_falls_back_to_the_prompt(self, monkeypatch):
+        monkeypatch.setattr(click, "prompt", MagicMock(return_value="654321"))
+
+        provide = _token_digits_provider(_ctx(MITID_TOKEN_CODE=None))
+
+        assert await provide() == "654321"
+
+    @pytest.mark.asyncio
+    async def test_password_from_context_skips_the_prompt(self, monkeypatch):
+        prompt = MagicMock()
+        monkeypatch.setattr(click, "prompt", prompt)
+
+        provide = _password_provider(_ctx(MITID_PASSWORD="hunter2"))
+
+        assert await provide() == "hunter2"
+        prompt.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_password_prompt_hides_input(self, monkeypatch):
+        """A MitID password echoed into the terminal would linger in scrollback."""
+        prompt = MagicMock(return_value="typed")
+        monkeypatch.setattr(click, "prompt", prompt)
+
+        provide = _password_provider(_ctx(MITID_PASSWORD=None))
+
+        assert await provide() == "typed"
+        assert prompt.call_args.kwargs["hide_input"] is True
+
+
+class TestOtpDisplay:
+    def test_prints_the_code(self, capsys):
+        """App users who cannot scan need the code MitID expects them to type."""
+        _print_otp_code("A1B2")
+
+        assert "A1B2" in capsys.readouterr().out

--- a/tests/test_widgets_client.py
+++ b/tests/test_widgets_client.py
@@ -486,3 +486,119 @@ class TestWidgetsClient:
             "Accept": "application/json",
         }
         assert library_response.method_calls == [call.raise_for_status(), call.json()]
+
+
+class TestWidgetsClientMalformedResponses:
+    """Providers sometimes answer 2xx with an error object instead of an array.
+
+    Meebook returns ``{"message": "JWT-Token expired, please renew."}`` when its
+    widget token has expired; iterating that yields the keys as strings.
+    """
+
+    JWT_EXPIRED = {"message": "JWT-Token expired, please renew."}
+
+    @pytest.fixture
+    def client(self):
+        return AulaApiClient(http_client=AsyncMock(), access_token="token")
+
+    @staticmethod
+    def _responses(client, body):
+        token_response = Mock()
+        token_response.raise_for_status = Mock()
+        token_response.json = Mock(return_value={"data": "token-123"})
+
+        provider_response = Mock()
+        provider_response.raise_for_status = Mock()
+        provider_response.json = Mock(return_value=body)
+
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[token_response, provider_response]
+        )
+
+    @pytest.mark.asyncio
+    async def test_meebook_weekplan_returns_empty_on_jwt_expiry_message(self, client, caplog):
+        self._responses(client, self.JWT_EXPIRED)
+
+        plans = await client.widgets.get_meebook_weekplan(
+            child_filter=["child-1"],
+            institution_filter=["inst-1"],
+            week="2026-W09",
+            session_uuid="session-1",
+        )
+
+        assert plans == []
+        assert "Meebook weekplan returned dict instead of a list" in caplog.text
+        assert "JWT-Token expired" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_meebook_weekplan_skips_non_dict_items(self, client, caplog):
+        self._responses(client, [{"name": "Child", "unilogin": "abc123"}, "junk", None])
+
+        plans = await client.widgets.get_meebook_weekplan(
+            child_filter=["child-1"],
+            institution_filter=["inst-1"],
+            week="2026-W09",
+            session_uuid="session-1",
+        )
+
+        assert [plan.name for plan in plans] == ["Child"]
+        assert "Meebook weekplan returned 2 non-dict item(s)" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_meebook_weekplan_returns_empty_on_unparseable_body(self, client):
+        # http_httpx sets data to None when the body is not valid JSON.
+        self._responses(client, None)
+
+        plans = await client.widgets.get_meebook_weekplan(
+            child_filter=["child-1"],
+            institution_filter=["inst-1"],
+            week="2026-W09",
+            session_uuid="session-1",
+        )
+
+        assert plans == []
+
+    @pytest.mark.asyncio
+    async def test_momo_courses_returns_empty_on_error_object(self, client, caplog):
+        self._responses(client, self.JWT_EXPIRED)
+
+        courses = await client.widgets.get_momo_courses(
+            children=["child-1"],
+            institutions=["inst-1"],
+            session_uuid="session-1",
+        )
+
+        assert courses == []
+        assert "Huskelisten courses returned dict instead of a list" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_momo_reminders_returns_empty_on_error_object(self, client, caplog):
+        self._responses(client, self.JWT_EXPIRED)
+
+        reminders = await client.widgets.get_momo_reminders(
+            children=["child-1"],
+            institutions=["inst-1"],
+            session_uuid="session-1",
+            from_date="2026-03-01",
+            due_no_later_than="2026-03-31",
+        )
+
+        assert reminders == []
+        assert "Huskelisten reminders returned dict instead of a list" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_library_status_returns_empty_on_list_body(self, client, caplog):
+        self._responses(client, ["unexpected"])
+
+        status = await client.widgets.get_library_status(
+            widget_id=WIDGET_HUSKELISTEN,
+            children=["child-1"],
+            institutions=["inst-1"],
+            session_uuid="session-1",
+        )
+
+        assert status.loans == []
+        assert status.longterm_loans == []
+        assert status.reservations == []
+        assert status.branch_ids == []
+        assert "Library status returned list instead of an object" in caplog.text


### PR DESCRIPTION
Covers every MitID authenticator this client can actually drive, and lets the kodeviser (code display) login run without interactive prompts.

## Why

Users without a smartphone log in with a MitID kodeviser instead of the app. That path already existed but was untested, and two related gaps meant "all options" was not really true:

- App users whose app asks for a typed code instead of a QR scan got a silent terminal. The code was captured into `otp_code` and then dropped, so nobody ever saw it.
- Authenticators the client cannot drive (chip, audio code reader) were filtered out silently, leaving affected users with no explanation.

## What changed

- **App OTP code is now shown.** New `on_otp_code` callback threaded through `browser_client` -> `mitid_client` -> `auth_flow` -> CLI. It fires once per code rather than on every half second poll.
- **Non-interactive credentials.** `--password` / `AULA_MITID_PASSWORD` and `--token-code` / `AULA_MITID_TOKEN_CODE`, each falling back to the existing prompt. Neither is written to `config.json`, so the MitID password never sits in plaintext next to the token cache.
- **Unsupported authenticators are named.** Combinations outside `S1/S3/S4/L2` are logged instead of discarded, and "method not available" errors now list what the account does offer.
- **`frontEndProcessingTime` reports compute, not network.** All three SRP handshakes previously timed crypto plus the HTTP round trips between them. On a 200ms link the kodeviser phase reported roughly 400ms of "browser compute" that was really two requests, which is an odd signal to hand a bot filter. A new `_ComputeTimer` accumulates only the compute blocks.

## Notes

MitID chip and audio code readers are still unsupported. They need combination IDs and protocol endpoints that are not documented anywhere I could reference, and the upstream `scaarup/aula` client does not implement them either. They now degrade to a clear warning rather than vanishing.

This branch is independent of `fix/stil-bot-challenge-fingerprint`. The two were verified to merge cleanly into `main` in either order.

## Test plan

- New `tests/auth/test_browser_client.py` drives the full two phase kodeviser handshake against a fake MitID backend: step ordering, `TOTP_INVALID` -> `TokenInvalidError`, `PASSWORD_INVALID` -> `PasswordInvalidError`, rejection of an unexpected next authenticator, and the unsupported combination warning.
- Regression test asserts `frontEndProcessingTime` stays below the injected network latency while remaining non zero.
- New `tests/auth/test_mitid_client_credentials.py` covers authenticator selection and credential callback validation.
- New CLI tests cover the credential providers (including that the password prompt hides input) and the OTP display.
- Full suite: 498 passed, 2 skipped. `ruff check`, `ruff format`, and `ty check` all clean.