### PR TITLE
fix: read EasyIQ homework and weekplan from the school portal

### DIFF
--- a/src/aula/api_client.py
+++ b/src/aula/api_client.py
@@ -623,7 +623,59 @@ class AulaApiClient:
         from_date: date,
         to_date: date,
     ) -> list[PresenceRegistration]:
-        """Fetch presence registrations for the given profiles and date range."""
+        """Fetch presence registrations for the given profiles and date range.
+
+        Aula rejects the whole batch when any one profile cannot be queried -
+        a school child alongside a daycare child is enough to turn the request
+        into an HTTP 400. Rather than lose every child's data to one of them,
+        a failed batch is retried per profile and the profiles that still fail
+        are skipped with a warning. The error is only raised when no profile
+        can be read at all.
+        """
+        try:
+            return await self._fetch_presence_registrations(
+                institution_profile_ids, from_date, to_date
+            )
+        except HttpRequestError as e:
+            if len(institution_profile_ids) <= 1:
+                raise
+            _LOGGER.warning(
+                "Presence registrations failed for %d profiles at once (%s), retrying one by one",
+                len(institution_profile_ids),
+                e,
+            )
+            batch_error = e
+
+        result: list[PresenceRegistration] = []
+        failed: list[int] = []
+        for profile_id in institution_profile_ids:
+            try:
+                result.extend(
+                    await self._fetch_presence_registrations([profile_id], from_date, to_date)
+                )
+            except HttpRequestError as e:
+                _LOGGER.debug(
+                    "Presence registrations unavailable for profile %s: %s", profile_id, e
+                )
+                failed.append(profile_id)
+
+        if len(failed) == len(institution_profile_ids):
+            raise batch_error
+        if failed:
+            _LOGGER.warning(
+                "Skipped presence registrations for profile(s) %s; "
+                "their institution likely does not use the presence module",
+                ", ".join(str(profile_id) for profile_id in failed),
+            )
+        return result
+
+    async def _fetch_presence_registrations(
+        self,
+        institution_profile_ids: list[int],
+        from_date: date,
+        to_date: date,
+    ) -> list[PresenceRegistration]:
+        """Fetch presence registrations for exactly the profiles given."""
         params: dict[str, Any] = {
             "method": "presence.getPresenceRegistrations",
             "institutionProfileIds[]": institution_profile_ids,

--- a/src/aula/cli.py
+++ b/src/aula/cli.py
@@ -1497,6 +1497,71 @@ async def notification_settings(ctx):
             click.echo(format_row(s.module, f"Enabled: {enabled}{channels}"))
 
 
+@cli.command("debug:easyiq")
+@click.option(
+    "--week",
+    type=str,
+    default=None,
+    help="Week number (e.g. 8) or full format (2026-W8). Defaults to current week.",
+)
+@click.option(
+    "--include-values",
+    is_flag=True,
+    help="Also print raw response bodies. These contain your children's names and "
+    "homework text, so do not paste that output anywhere public.",
+)
+@click.pass_context
+@async_cmd
+async def debug_easyiq(ctx, week, include_values):
+    """Report how the EasyIQ portal responds, for troubleshooting.
+
+    EasyIQ behaves differently per institution and is undocumented, so fixing
+    it depends on reports from people whose schools use it. This asks every
+    open question in one pass and prints only the shape of the answers: status
+    codes, row counts, item types and JSON key names. No names, subjects or
+    IDs are included, so the output is safe to paste into a GitHub issue.
+    """
+    from .utils.easyiq_probe import probe_easyiq, render_report
+    from .utils.week import monday_of_week
+
+    week = _resolve_week(week)
+    async with await _get_client(ctx) as client:
+        try:
+            prof: Profile = await client.get_profile()
+            profile_context = await client.get_profile_context()
+            guardian_login = str(profile_context["data"]["userId"])
+        except Exception as e:
+            print_error(f"fetching profile: {e}")
+            return
+
+        if not prof.children:
+            print_empty("children")
+            return
+
+        institution_filter: list[str] = []
+        for child in prof.children:
+            if child._raw:
+                inst_code = child._raw.get("institutionProfile", {}).get("institutionCode", "")
+                if inst_code and str(inst_code) not in institution_filter:
+                    institution_filter.append(str(inst_code))
+
+        report = await probe_easyiq(
+            client,
+            prof.children,
+            guardian_login,
+            monday_of_week(week),
+            institution_filter,
+            include_values=include_values,
+        )
+
+        if ctx.obj.get("OUTPUT_FORMAT") == "json":
+            click.echo(to_json(report))
+            return
+
+        for line in render_report(report, include_values=include_values):
+            click.echo(line)
+
+
 @cli.command("widgets")
 @click.pass_context
 @async_cmd
@@ -3461,6 +3526,11 @@ async def presence(ctx, from_date, to_date, week, states):
             )
         except Exception as e:
             print_error(f"fetching presence registrations: {e}")
+            click.echo(
+                "No institution on this account accepted the request. "
+                "Institutions that do not use presence registrations reject it; "
+                "try 'aula presence --states' instead."
+            )
             return
 
         if output_json(ctx, [dict(r) for r in registrations]):

--- a/src/aula/cli.py
+++ b/src/aula/cli.py
@@ -1724,10 +1724,15 @@ async def easyiq_ugeplan(ctx, week):
                 child_id = str(child._raw["userId"])
                 try:
                     appointments = await client.widgets.get_easyiq_weekplan(
-                        week, session_uuid, institution_filter, child_id
+                        week,
+                        session_uuid,
+                        institution_filter,
+                        child_id,
+                        child_profile_id=str(child.id),
                     )
                     all_appointments.extend(dict(a) for a in appointments)
-                except Exception:
+                except Exception as e:
+                    print_error(f"fetching EasyIQ weekplan for {child.name}: {e}", err=True)
                     continue
             click.echo(to_json(all_appointments))
             return
@@ -1742,7 +1747,11 @@ async def easyiq_ugeplan(ctx, week):
 
             try:
                 appointments = await client.widgets.get_easyiq_weekplan(
-                    week, session_uuid, institution_filter, child_id
+                    week,
+                    session_uuid,
+                    institution_filter,
+                    child_id,
+                    child_profile_id=str(child.id),
                 )
             except Exception as e:
                 print_error(f"fetching EasyIQ weekplan for {child.name}: {e}")
@@ -1817,10 +1826,15 @@ async def easyiq_homework(ctx, week):
                 child_id = str(child._raw["userId"])
                 try:
                     homework = await client.widgets.get_easyiq_homework(
-                        week, session_uuid, institution_filter, child_id
+                        week,
+                        session_uuid,
+                        institution_filter,
+                        child_id,
+                        child_profile_id=str(child.id),
                     )
                     all_homework.extend(dict(hw) for hw in homework)
-                except Exception:
+                except Exception as e:
+                    print_error(f"fetching EasyIQ homework for {child.name}: {e}", err=True)
                     continue
             click.echo(to_json(all_homework))
             return
@@ -1835,7 +1849,11 @@ async def easyiq_homework(ctx, week):
 
             try:
                 homework = await client.widgets.get_easyiq_homework(
-                    week, session_uuid, institution_filter, child_id
+                    week,
+                    session_uuid,
+                    institution_filter,
+                    child_id,
+                    child_profile_id=str(child.id),
                 )
             except Exception as e:
                 print_error(f"fetching EasyIQ homework for {child.name}: {e}")
@@ -2693,7 +2711,11 @@ async def weekly_summary(ctx, child, week, providers):
 
                 try:
                     appointments = await client.widgets.get_easyiq_weekplan(
-                        week, session_uuid, c_institutions or institution_filter, c_user_id
+                        week,
+                        session_uuid,
+                        c_institutions or institution_filter,
+                        c_user_id,
+                        child_profile_id=str(c.id),
                     )
                 except Exception as e:
                     _log.warning("Could not fetch EasyIQ weekplan for %s: %s", c.name, e)
@@ -2740,7 +2762,11 @@ async def weekly_summary(ctx, child, week, providers):
 
                 try:
                     homework = await client.widgets.get_easyiq_homework(
-                        week, session_uuid, c_institutions or institution_filter, c_user_id
+                        week,
+                        session_uuid,
+                        c_institutions or institution_filter,
+                        c_user_id,
+                        child_profile_id=str(c.id),
                     )
                 except Exception as e:
                     _log.warning("Could not fetch EasyIQ homework for %s: %s", c.name, e)

--- a/src/aula/cli.py
+++ b/src/aula/cli.py
@@ -377,6 +377,32 @@ async def _get_widget_context(
     return child_filter, institution_filter, session_uuid
 
 
+def _easyiq_child_user_ids(profile_context: dict) -> list[str]:
+    """Every child's UniLogin, which EasyIQ's portal wants as ``x-childfilter``.
+
+    Read from ``profiles.getProfileContext`` rather than ``prof.children``
+    because the portal matches on the UniLogin, which Aula calls ``userId``.
+    Children appear under the active institution profile's ``relations`` and
+    again under each institution the guardian has a child at, so both are
+    read and de-duplicated: a child at a second institution must not be left
+    out of the filter.
+    """
+    data = profile_context.get("data") or {}
+    relations = (data.get("institutionProfile") or {}).get("relations") or []
+    institution_children = [
+        child
+        for institution in data.get("institutions") or []
+        if isinstance(institution, dict)
+        for child in institution.get("children") or []
+    ]
+    user_ids = (
+        str(entry["userId"])
+        for entry in [*relations, *institution_children]
+        if isinstance(entry, dict) and entry.get("userId")
+    )
+    return list(dict.fromkeys(user_ids))
+
+
 # Define commands
 @cli.command()
 @click.pass_context
@@ -1551,6 +1577,7 @@ async def debug_easyiq(ctx, week, include_values):
             guardian_login,
             monday_of_week(week),
             institution_filter,
+            _easyiq_child_user_ids(profile_context),
             include_values=include_values,
         )
 
@@ -1778,6 +1805,7 @@ async def easyiq_ugeplan(ctx, week):
         except Exception as e:
             print_error(f"fetching profile context: {e}")
             return
+        all_child_user_ids = _easyiq_child_user_ids(profile_context)
 
         from .utils.html import html_to_plain
 
@@ -1794,6 +1822,7 @@ async def easyiq_ugeplan(ctx, week):
                         institution_filter,
                         child_id,
                         child_profile_id=str(child.id),
+                        all_child_user_ids=all_child_user_ids,
                     )
                     all_appointments.extend(dict(a) for a in appointments)
                 except Exception as e:
@@ -1817,6 +1846,7 @@ async def easyiq_ugeplan(ctx, week):
                     institution_filter,
                     child_id,
                     child_profile_id=str(child.id),
+                    all_child_user_ids=all_child_user_ids,
                 )
             except Exception as e:
                 print_error(f"fetching EasyIQ weekplan for {child.name}: {e}")
@@ -1880,6 +1910,7 @@ async def easyiq_homework(ctx, week):
         except Exception as e:
             print_error(f"fetching profile context: {e}")
             return
+        all_child_user_ids = _easyiq_child_user_ids(profile_context)
 
         from .utils.html import html_to_plain
 
@@ -1896,6 +1927,7 @@ async def easyiq_homework(ctx, week):
                         institution_filter,
                         child_id,
                         child_profile_id=str(child.id),
+                        all_child_user_ids=all_child_user_ids,
                     )
                     all_homework.extend(dict(hw) for hw in homework)
                 except Exception as e:
@@ -1919,6 +1951,7 @@ async def easyiq_homework(ctx, week):
                     institution_filter,
                     child_id,
                     child_profile_id=str(child.id),
+                    all_child_user_ids=all_child_user_ids,
                 )
             except Exception as e:
                 print_error(f"fetching EasyIQ homework for {child.name}: {e}")
@@ -2648,6 +2681,12 @@ async def weekly_summary(ctx, child, week, providers):
 
         child_filter, institution_filter, session_uuid = widget_ctx
 
+        try:
+            all_child_user_ids = _easyiq_child_user_ids(await client.get_profile_context())
+        except Exception as e:
+            _log.warning("Could not read children for the EasyIQ child filter: %s", e)
+            all_child_user_ids = []
+
         # Filter child_filter to selected children only
         if child:
             selected_user_ids = {
@@ -2781,6 +2820,7 @@ async def weekly_summary(ctx, child, week, providers):
                         c_institutions or institution_filter,
                         c_user_id,
                         child_profile_id=str(c.id),
+                        all_child_user_ids=all_child_user_ids,
                     )
                 except Exception as e:
                     _log.warning("Could not fetch EasyIQ weekplan for %s: %s", c.name, e)
@@ -2832,6 +2872,7 @@ async def weekly_summary(ctx, child, week, providers):
                         c_institutions or institution_filter,
                         c_user_id,
                         child_profile_id=str(c.id),
+                        all_child_user_ids=all_child_user_ids,
                     )
                 except Exception as e:
                     _log.warning("Could not fetch EasyIQ homework for %s: %s", c.name, e)

--- a/src/aula/const.py
+++ b/src/aula/const.py
@@ -6,7 +6,12 @@ SYSTEMATIC_API = "https://systematic-momo.dk/api/aula"
 EASYIQ_API = "https://api.easyiqcloud.dk/api/aula"
 # EasyIQ serves homework and weekplan rows from its school portal, not from the
 # aula REST API. ``/api/aula/homeworkinfo`` was removed upstream and now 404s.
+# The two data types live on separate controllers: the calendar one never
+# returns homework rows.
 EASYIQ_PORTAL = "https://skoleportal.easyiqcloud.dk"
+EASYIQ_CALENDAR_PATH = "/Calendar/CalendarGetWeekplanEvents"
+EASYIQ_HOMEWORK_PATH = "/AulaHuskeliste/GetWeekplanEvents"
+EASYIQ_CHILDREN_PATH = "/Aula/GetChildren"
 MEEBOOK_API = "https://app.meebook.com/aulaapi"
 CICERO_API = "https://surf.cicero-suite.com/portal-api/rest/aula"
 

--- a/src/aula/const.py
+++ b/src/aula/const.py
@@ -12,6 +12,9 @@ EASYIQ_PORTAL = "https://skoleportal.easyiqcloud.dk"
 EASYIQ_CALENDAR_PATH = "/Calendar/CalendarGetWeekplanEvents"
 EASYIQ_HOMEWORK_PATH = "/AulaHuskeliste/GetWeekplanEvents"
 EASYIQ_CHILDREN_PATH = "/Aula/GetChildren"
+# The portal's controllers need the session cookies this sets; the Aula widget
+# token on its own is not enough.
+EASYIQ_AUTHENTICATE_PATH = "/Aula/AuthenticateAulaUser"
 MEEBOOK_API = "https://app.meebook.com/aulaapi"
 CICERO_API = "https://surf.cicero-suite.com/portal-api/rest/aula"
 

--- a/src/aula/const.py
+++ b/src/aula/const.py
@@ -4,11 +4,13 @@ API_VERSION = "24"
 MIN_UDDANNELSE_API = "https://api.minuddannelse.net/aula"
 SYSTEMATIC_API = "https://systematic-momo.dk/api/aula"
 EASYIQ_API = "https://api.easyiqcloud.dk/api/aula"
+# EasyIQ serves homework and weekplan rows from its school portal, not from the
+# aula REST API. ``/api/aula/homeworkinfo`` was removed upstream and now 404s.
+EASYIQ_PORTAL = "https://skoleportal.easyiqcloud.dk"
 MEEBOOK_API = "https://app.meebook.com/aulaapi"
 CICERO_API = "https://surf.cicero-suite.com/portal-api/rest/aula"
 
 # Widget IDs for third-party integrations
-WIDGET_EASYIQ = "0001"
 WIDGET_EASYIQ_WEEKPLAN = "0128"
 WIDGET_EASYIQ_HOMEWORK = "0142"
 WIDGET_BIBLIOTEKET = "0019"

--- a/src/aula/models/__init__.py
+++ b/src/aula/models/__init__.py
@@ -6,6 +6,9 @@ from .comment import Comment as Comment
 from .consent import ConsentResponse as ConsentResponse
 from .daily_overview import DailyOverview as DailyOverview
 from .document import SecureDocument as SecureDocument
+from .easyiq_calendar_event import HOMEWORK_ITEM_TYPES as HOMEWORK_ITEM_TYPES
+from .easyiq_calendar_event import WEEKPLAN_ITEM_TYPES as WEEKPLAN_ITEM_TYPES
+from .easyiq_calendar_event import EasyIQCalendarEvent as EasyIQCalendarEvent
 from .easyiq_homework import EasyIQHomework as EasyIQHomework
 from .group import Group as Group
 from .group import GroupMember as GroupMember

--- a/src/aula/models/easyiq_calendar_event.py
+++ b/src/aula/models/easyiq_calendar_event.py
@@ -1,3 +1,4 @@
+import datetime
 import html
 from dataclasses import dataclass, field
 from typing import Any
@@ -55,6 +56,33 @@ def _first_text(folded: dict[str, Any], keys: tuple[str, ...]) -> str:
     return ""
 
 
+#: EasyIQ's display timestamps, used when the ``*ISO`` field is absent.
+_TIMESTAMP_FORMATS = ("%Y/%m/%d %H:%M:%S", "%Y/%m/%d %H:%M")
+
+
+def _first_timestamp(folded: dict[str, Any], keys: tuple[str, ...]) -> str:
+    """Return the first timestamp among ``keys``, normalised to ISO 8601.
+
+    A row can carry ``StartTimeISO`` but leave ``EndTimeISO`` null, so the
+    start and end of one event would otherwise come back in two different
+    formats. Anything unrecognised is passed through untouched rather than
+    dropped, since a value we cannot parse is still better than nothing.
+    """
+    text = _first_text(folded, keys)
+    if not text:
+        return ""
+    try:
+        return datetime.datetime.fromisoformat(text).isoformat()
+    except ValueError:
+        pass
+    for fmt in _TIMESTAMP_FORMATS:
+        try:
+            return datetime.datetime.strptime(text, fmt).isoformat()
+        except ValueError:
+            continue
+    return text
+
+
 def _item_type(folded: dict[str, Any]) -> int | None:
     """Return the EasyIQ item type as an int, tolerating string encodings."""
     for key in _ITEM_TYPE_KEYS:
@@ -96,8 +124,8 @@ class EasyIQCalendarEvent(AulaDataClass):
             _raw=data,
             item_type=_item_type(folded),
             event_id=_first_text(folded, _ID_KEYS),
-            start=_first_text(folded, _START_KEYS),
-            end=_first_text(folded, _END_KEYS),
+            start=_first_timestamp(folded, _START_KEYS),
+            end=_first_timestamp(folded, _END_KEYS),
             courses=_first_text(folded, _COURSE_KEYS),
             activities=_first_text(folded, _ACTIVITY_KEYS),
             description=_first_text(folded, _DESCRIPTION_KEYS),

--- a/src/aula/models/easyiq_calendar_event.py
+++ b/src/aula/models/easyiq_calendar_event.py
@@ -8,18 +8,26 @@ from .base import AulaDataClass
 WEEKPLAN_ITEM_TYPES = (8, 9)
 HOMEWORK_ITEM_TYPES = (4,)
 
-_START_KEYS = ("start", "startDateTime", "startTime", "from")
-_END_KEYS = ("end", "endDateTime", "endTime", "to")
+#: Keys are matched case-insensitively: EasyIQ's calendar controller answers in
+#: camelCase (``itemType``) and its homework controller in PascalCase
+#: (``ItemType``), so a case-sensitive lookup silently parses nothing.
+_START_KEYS = ("start", "startdatetime", "starttime", "from")
+_END_KEYS = ("end", "enddatetime", "endtime", "to")
 _COURSE_KEYS = ("courses", "course", "subject", "title", "name")
-_ACTIVITY_KEYS = ("activities", "activity", "lesson", "className")
+_ACTIVITY_KEYS = ("activities", "activity", "lesson", "classname")
 _DESCRIPTION_KEYS = ("description", "details", "note", "content")
-_ITEM_TYPE_KEYS = ("itemType", "itemTypeId", "type")
+_ITEM_TYPE_KEYS = ("itemtype", "itemtypeid", "type")
 
 
-def _first_text(data: dict[str, Any], keys: tuple[str, ...]) -> str:
+def _fold_keys(data: dict[str, Any]) -> dict[str, Any]:
+    """Index a row by lowercased key so either casing resolves."""
+    return {str(key).lower(): value for key, value in data.items()}
+
+
+def _first_text(folded: dict[str, Any], keys: tuple[str, ...]) -> str:
     """Return the first non-empty string value among ``keys``."""
     for key in keys:
-        value = data.get(key)
+        value = folded.get(key)
         if isinstance(value, list):
             value = ", ".join(str(v) for v in value if v)
         if value is None or isinstance(value, bool):
@@ -30,10 +38,10 @@ def _first_text(data: dict[str, Any], keys: tuple[str, ...]) -> str:
     return ""
 
 
-def _item_type(data: dict[str, Any]) -> int | None:
+def _item_type(folded: dict[str, Any]) -> int | None:
     """Return the EasyIQ item type as an int, tolerating string encodings."""
     for key in _ITEM_TYPE_KEYS:
-        value = data.get(key)
+        value = folded.get(key)
         if isinstance(value, dict):
             value = value.get("id", value.get("value"))
         if value is None or isinstance(value, bool):
@@ -65,14 +73,15 @@ class EasyIQCalendarEvent(AulaDataClass):
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> EasyIQCalendarEvent:
+        folded = _fold_keys(data)
         return cls(
             _raw=data,
-            item_type=_item_type(data),
-            start=_first_text(data, _START_KEYS),
-            end=_first_text(data, _END_KEYS),
-            courses=_first_text(data, _COURSE_KEYS),
-            activities=_first_text(data, _ACTIVITY_KEYS),
-            description=_first_text(data, _DESCRIPTION_KEYS),
+            item_type=_item_type(folded),
+            start=_first_text(folded, _START_KEYS),
+            end=_first_text(folded, _END_KEYS),
+            courses=_first_text(folded, _COURSE_KEYS),
+            activities=_first_text(folded, _ACTIVITY_KEYS),
+            description=_first_text(folded, _DESCRIPTION_KEYS),
         )
 
     @property

--- a/src/aula/models/easyiq_calendar_event.py
+++ b/src/aula/models/easyiq_calendar_event.py
@@ -1,0 +1,81 @@
+from dataclasses import dataclass, field
+from typing import Any
+
+from .base import AulaDataClass
+
+#: EasyIQ tags every calendar row with an ``itemType``. Lessons and regular
+#: calendar entries make up the weekly plan; homework is its own type.
+WEEKPLAN_ITEM_TYPES = (8, 9)
+HOMEWORK_ITEM_TYPES = (4,)
+
+_START_KEYS = ("start", "startDateTime", "startTime", "from")
+_END_KEYS = ("end", "endDateTime", "endTime", "to")
+_COURSE_KEYS = ("courses", "course", "subject", "title", "name")
+_ACTIVITY_KEYS = ("activities", "activity", "lesson", "className")
+_DESCRIPTION_KEYS = ("description", "details", "note", "content")
+_ITEM_TYPE_KEYS = ("itemType", "itemTypeId", "type")
+
+
+def _first_text(data: dict[str, Any], keys: tuple[str, ...]) -> str:
+    """Return the first non-empty string value among ``keys``."""
+    for key in keys:
+        value = data.get(key)
+        if isinstance(value, list):
+            value = ", ".join(str(v) for v in value if v)
+        if value is None or isinstance(value, bool):
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return ""
+
+
+def _item_type(data: dict[str, Any]) -> int | None:
+    """Return the EasyIQ item type as an int, tolerating string encodings."""
+    for key in _ITEM_TYPE_KEYS:
+        value = data.get(key)
+        if isinstance(value, dict):
+            value = value.get("id", value.get("value"))
+        if value is None or isinstance(value, bool):
+            continue
+        if isinstance(value, int):
+            return value
+        try:
+            return int(str(value).strip())
+        except ValueError:
+            continue
+    return None
+
+
+@dataclass
+class EasyIQCalendarEvent(AulaDataClass):
+    """One row from EasyIQ's ``CalendarGetWeekplanEvents`` endpoint.
+
+    A single request returns the whole week for a child: lessons, calendar
+    entries and homework interleaved, told apart by ``item_type``.
+    """
+
+    item_type: int | None = None
+    start: str = ""
+    end: str = ""
+    courses: str = ""
+    activities: str = ""
+    description: str = ""
+    _raw: dict | None = field(default=None, repr=False)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EasyIQCalendarEvent:
+        return cls(
+            _raw=data,
+            item_type=_item_type(data),
+            start=_first_text(data, _START_KEYS),
+            end=_first_text(data, _END_KEYS),
+            courses=_first_text(data, _COURSE_KEYS),
+            activities=_first_text(data, _ACTIVITY_KEYS),
+            description=_first_text(data, _DESCRIPTION_KEYS),
+        )
+
+    @property
+    def title(self) -> str:
+        """Best available label for the row, preferring the subject."""
+        return self.courses or self.activities or "(untitled)"

--- a/src/aula/models/easyiq_calendar_event.py
+++ b/src/aula/models/easyiq_calendar_event.py
@@ -1,22 +1,33 @@
+import html
 from dataclasses import dataclass, field
 from typing import Any
 
 from .base import AulaDataClass
 
-#: EasyIQ tags every calendar row with an ``itemType``. Lessons and regular
-#: calendar entries make up the weekly plan; homework is its own type.
+#: EasyIQ tags every calendar row with an ``itemType``. Its own widget source
+#: (``/ts/Model/AulaHuskeliste/CalendarItem.js``) names them: 1 OpgaveFraForløb,
+#: 2 LektieFraForløb, 3 Event, 4 Lektie, 5 Plan, 6 Holiday, 7 TimeTableEvent,
+#: 8 VigtigInformation, 9 Ugeplan, 10 ClassroomStart, 11 ArbejdeFraForløb.
+#:
+#: The homework widget displays 1, 2, 3, 4 and 8, so homework set as part of a
+#: course counts too, not only a bare ``Lektie``. The weekly plan pair is
+#: empirical rather than read from source, confirmed against a live EasyIQ
+#: account; the two overlap on 8 because both views show important notices.
 WEEKPLAN_ITEM_TYPES = (8, 9)
-HOMEWORK_ITEM_TYPES = (4,)
+HOMEWORK_ITEM_TYPES = (1, 2, 3, 4, 8)
 
 #: Keys are matched case-insensitively: EasyIQ's calendar controller answers in
 #: camelCase (``itemType``) and its homework controller in PascalCase
-#: (``ItemType``), so a case-sensitive lookup silently parses nothing.
-_START_KEYS = ("start", "startdatetime", "starttime", "from")
-_END_KEYS = ("end", "enddatetime", "endtime", "to")
-_COURSE_KEYS = ("courses", "course", "subject", "title", "name")
-_ACTIVITY_KEYS = ("activities", "activity", "lesson", "classname")
+#: (``ItemType``), so a case-sensitive lookup silently parses nothing. The
+#: ``*Display`` and ``*ISO`` variants come first because they are the ones the
+#: widget itself reads.
+_START_KEYS = ("starttimeiso", "start", "startdatetime", "starttime", "from")
+_END_KEYS = ("endtimeiso", "end", "enddatetime", "endtime", "to")
+_COURSE_KEYS = ("coursesdisplay", "courses", "course", "subject", "title", "name")
+_ACTIVITY_KEYS = ("activitiesdisplay", "activities", "activity", "lesson", "classname")
 _DESCRIPTION_KEYS = ("description", "details", "note", "content")
 _ITEM_TYPE_KEYS = ("itemtype", "itemtypeid", "type")
+_ID_KEYS = ("id", "workid")
 
 
 def _fold_keys(data: dict[str, Any]) -> dict[str, Any]:
@@ -25,14 +36,20 @@ def _fold_keys(data: dict[str, Any]) -> dict[str, Any]:
 
 
 def _first_text(folded: dict[str, Any], keys: tuple[str, ...]) -> str:
-    """Return the first non-empty string value among ``keys``."""
+    """Return the first non-empty string value among ``keys``.
+
+    Values are unescaped: the portal sends HTML entities in its text fields
+    (``l&aelig;st``), unlike every other Aula source. A field holding only
+    whitespace counts as empty, since the portal pads unused titles with a
+    single space.
+    """
     for key in keys:
         value = folded.get(key)
         if isinstance(value, list):
             value = ", ".join(str(v) for v in value if v)
         if value is None or isinstance(value, bool):
             continue
-        text = str(value).strip()
+        text = html.unescape(str(value)).strip()
         if text:
             return text
     return ""
@@ -64,6 +81,7 @@ class EasyIQCalendarEvent(AulaDataClass):
     """
 
     item_type: int | None = None
+    event_id: str = ""
     start: str = ""
     end: str = ""
     courses: str = ""
@@ -77,6 +95,7 @@ class EasyIQCalendarEvent(AulaDataClass):
         return cls(
             _raw=data,
             item_type=_item_type(folded),
+            event_id=_first_text(folded, _ID_KEYS),
             start=_first_text(folded, _START_KEYS),
             end=_first_text(folded, _END_KEYS),
             courses=_first_text(folded, _COURSE_KEYS),
@@ -86,5 +105,9 @@ class EasyIQCalendarEvent(AulaDataClass):
 
     @property
     def title(self) -> str:
-        """Best available label for the row, preferring the subject."""
-        return self.courses or self.activities or "(untitled)"
+        """Best available label for the row, preferring the subject.
+
+        Empty when the row carries neither, so callers render their own
+        placeholder rather than receiving one as data.
+        """
+        return self.courses or self.activities

--- a/src/aula/models/easyiq_homework.py
+++ b/src/aula/models/easyiq_homework.py
@@ -36,9 +36,10 @@ class EasyIQHomework(AulaDataClass):
         ``False``. The subject doubles as the title, matching how the EasyIQ
         widget itself labels homework.
         """
+        row = {str(k).lower(): v for k, v in (event._raw or {}).items()}
         return cls(
             _raw=event._raw,
-            id=str(event._raw.get("id", "") if event._raw else "") or event.start,
+            id=str(row.get("id") or "") or event.start,
             title=event.title,
             description=event.description,
             due_date=event.start,

--- a/src/aula/models/easyiq_homework.py
+++ b/src/aula/models/easyiq_homework.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from .base import AulaDataClass
+from .easyiq_calendar_event import EasyIQCalendarEvent
 
 
 @dataclass
@@ -24,4 +25,23 @@ class EasyIQHomework(AulaDataClass):
             due_date=data.get("dueDate", ""),
             subject=data.get("subject", ""),
             is_completed=data.get("isCompleted", False),
+        )
+
+    @classmethod
+    def from_calendar_event(cls, event: EasyIQCalendarEvent) -> EasyIQHomework:
+        """Build homework from an EasyIQ calendar row of item type 4.
+
+        The portal's calendar rows carry no assignment id or completion flag,
+        so ``id`` falls back to the start timestamp and ``is_completed`` stays
+        ``False``. The subject doubles as the title, matching how the EasyIQ
+        widget itself labels homework.
+        """
+        return cls(
+            _raw=event._raw,
+            id=str(event._raw.get("id", "") if event._raw else "") or event.start,
+            title=event.title,
+            description=event.description,
+            due_date=event.start,
+            subject=event.courses,
+            is_completed=False,
         )

--- a/src/aula/models/easyiq_homework.py
+++ b/src/aula/models/easyiq_homework.py
@@ -29,17 +29,15 @@ class EasyIQHomework(AulaDataClass):
 
     @classmethod
     def from_calendar_event(cls, event: EasyIQCalendarEvent) -> EasyIQHomework:
-        """Build homework from an EasyIQ calendar row of item type 4.
+        """Build homework from an EasyIQ homework row.
 
-        The portal's calendar rows carry no assignment id or completion flag,
-        so ``id`` falls back to the start timestamp and ``is_completed`` stays
+        The portal carries no completion flag, so ``is_completed`` stays
         ``False``. The subject doubles as the title, matching how the EasyIQ
         widget itself labels homework.
         """
-        row = {str(k).lower(): v for k, v in (event._raw or {}).items()}
         return cls(
             _raw=event._raw,
-            id=str(row.get("id") or "") or event.start,
+            id=event.event_id or event.start,
             title=event.title,
             description=event.description,
             due_date=event.start,

--- a/src/aula/utils/easyiq_probe.py
+++ b/src/aula/utils/easyiq_probe.py
@@ -131,16 +131,19 @@ async def probe_easyiq(
     guardian_login: str,
     date: str,
     institution_filter: list[str] | None = None,
+    all_child_user_ids: list[str] | None = None,
     include_values: bool = False,
 ) -> ProbeReport:
     """Run the probe and return its report.
 
     ``date`` is an ISO timestamp inside the week to ask about.
-    ``institution_filter`` must be the same list the real commands send:
-    EasyIQ answers differently without it, so a probe that omitted it would
-    report failures the working code never sees.
+    ``institution_filter`` and ``all_child_user_ids`` must be the same values
+    the real commands send: EasyIQ answers differently without them, so a
+    probe that omitted either would report failures the working code never
+    sees.
     """
     institution_filter = institution_filter or []
+    all_child_user_ids = all_child_user_ids or []
     report = ProbeReport()
 
     try:
@@ -166,8 +169,16 @@ async def probe_easyiq(
     if not tokens:
         return report
 
+    # Establish the portal session first: without it every controller 500s,
+    # so a probe that skipped it would report nothing but failures.
+    await client.widgets.ensure_easyiq_session(
+        institution_filter, guardian_login, all_child_user_ids
+    )
+
     any_token = next(iter(tokens.values()))
-    headers = client.widgets.easyiq_headers(any_token, institution_filter, guardian_login)
+    headers = client.widgets.easyiq_headers(
+        any_token, institution_filter, guardian_login, all_child_user_ids
+    )
     entries: list[dict[str, Any]] = []
     try:
         resp = await client._request_with_version_retry(
@@ -194,21 +205,33 @@ async def probe_easyiq(
             token = tokens.get(widget_id)
             if token is None:
                 continue
-            base = client.widgets.easyiq_headers(token, institution_filter, guardian_login)
+            base = client.widgets.easyiq_headers(
+                token,
+                institution_filter,
+                guardian_login,
+                all_child_user_ids,
+                aula_ids["user_id"],
+            )
+            easyiq_id = client.widgets.resolve_easyiq_child_id(aula_ids["user_id"])
+            named = {**aula_ids, "easyiq_id": easyiq_id or ""}
             attempts: list[Attempt] = []
             for login_id, child_header in client.widgets.easyiq_identifier_variants(
-                aula_ids["institution_profile_id"], aula_ids["user_id"], guardian_login
+                aula_ids["institution_profile_id"],
+                aula_ids["user_id"],
+                guardian_login,
+                easyiq_id,
             ):
                 attempt = Attempt(
-                    login_id_source=_name_of(login_id, aula_ids, guardian_login),
-                    child_header_source=_name_of(child_header, aula_ids, guardian_login),
+                    login_id_source=_name_of(login_id, named, guardian_login),
+                    child_header_source=_name_of(child_header, named, guardian_login),
                 )
                 try:
                     resp = await client._request_with_version_retry(
                         "get",
                         f"{EASYIQ_PORTAL}{path}",
                         params={**extra_params, "date": date, "loginId": login_id},
-                        headers={**base, "x-child": child_header, "x-childfilter": child_header},
+                        # x-childfilter stays the full list from base.
+                        headers={**base, "x-child": child_header},
                     )
                     attempt.status = resp.status_code
                     payload = resp.json()

--- a/src/aula/utils/easyiq_probe.py
+++ b/src/aula/utils/easyiq_probe.py
@@ -1,0 +1,289 @@
+"""Structural probe of the EasyIQ portal, safe to paste into a public issue.
+
+EasyIQ's portal is undocumented and behaves differently per institution: which
+identifier it accepts as ``loginId``, which controller carries homework, and
+even the casing of the JSON keys have all had to be learned from users running
+the CLI against their own accounts. This module asks those questions in one
+pass and reports only the *shape* of what came back.
+
+Nothing here prints a name, a subject, a description or an ID. Identifiers are
+reported as comparisons ("EasyIQ's Id equals the Aula institution profile ID")
+because that is the fact the code needs, and it carries no personal data. Raw
+bodies are available behind an explicit opt-in for local debugging only.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..const import (
+    EASYIQ_CALENDAR_PATH,
+    EASYIQ_CHILDREN_PATH,
+    EASYIQ_HOMEWORK_PATH,
+    EASYIQ_PORTAL,
+    WIDGET_EASYIQ_HOMEWORK,
+    WIDGET_EASYIQ_WEEKPLAN,
+)
+
+#: The controllers to probe, with the query parameters each one expects.
+PROBE_TARGETS = (
+    (
+        EASYIQ_CALENDAR_PATH,
+        WIDGET_EASYIQ_WEEKPLAN,
+        {"activityFilter": "-1", "courseFilter": "-1", "textFilter": "", "ownWeekPlan": "false"},
+    ),
+    (EASYIQ_HOMEWORK_PATH, WIDGET_EASYIQ_HOMEWORK, {"activityFilter": ""}),
+)
+
+
+@dataclass
+class Attempt:
+    """One controller called with one identifier combination."""
+
+    login_id_source: str
+    child_header_source: str
+    status: int | None = None
+    error: str = ""
+    rows: int | None = None
+    item_types: dict[str, int] = field(default_factory=dict)
+    keys: list[str] = field(default_factory=list)
+    body: Any = None
+
+
+@dataclass
+class ChildProbe:
+    """Everything learned about one child."""
+
+    label: str
+    easyiq_entry_found: bool = False
+    easyiq_id_matches: list[str] = field(default_factory=list)
+    attempts: dict[str, list[Attempt]] = field(default_factory=dict)
+
+
+@dataclass
+class ProbeReport:
+    widgets: list[tuple[str, str, str]] = field(default_factory=list)
+    tokens: dict[str, str] = field(default_factory=dict)
+    children_status: int | None = None
+    children_error: str = ""
+    children_count: int | None = None
+    children_fields: list[str] = field(default_factory=list)
+    children: list[ChildProbe] = field(default_factory=list)
+
+
+def _describe_rows(payload: Any) -> tuple[int | None, dict[str, int], list[str]]:
+    """Summarise a response as (row count, item type histogram, first row keys)."""
+    rows = payload if isinstance(payload, list) else None
+    if rows is None and isinstance(payload, dict):
+        for key in ("events", "calendarEvents", "items", "data", "result", "Children"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                rows = value
+                break
+    if rows is None:
+        return None, {}, []
+
+    dicts = [row for row in rows if isinstance(row, dict)]
+    histogram: dict[str, int] = {}
+    for row in dicts:
+        folded = {str(k).lower(): v for k, v in row.items()}
+        item_type = folded.get("itemtype", folded.get("type"))
+        name = "missing" if item_type is None else str(item_type)
+        histogram[name] = histogram.get(name, 0) + 1
+    keys = [str(key) for key in dicts[0]] if dicts else []
+    return len(rows), histogram, keys
+
+
+def _entries(payload: Any) -> list[dict[str, Any]]:
+    """Return the child entries from a ``GetChildren`` payload."""
+    if isinstance(payload, dict):
+        for key in ("Children", "children"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return [item for item in value if isinstance(item, dict)]
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    return []
+
+
+def _match_easyiq_entry(
+    entries: list[dict[str, Any]], aula_ids: dict[str, str]
+) -> tuple[bool, list[str]]:
+    """Find this child among EasyIQ's own list and say which Aula ID its Id equals.
+
+    Returns ``(found, matches)`` where ``matches`` names the Aula identifiers
+    that EasyIQ's ``Id`` is equal to. An empty list on a found entry means
+    EasyIQ uses an ID of its own, which is the case worth knowing about.
+    """
+    wanted = {str(value).casefold() for value in aula_ids.values() if value}
+    for entry in entries:
+        folded = {str(k).lower(): str(v) for k, v in entry.items()}
+        identifying = {folded.get("login", ""), folded.get("id", "")}
+        if not {value.casefold() for value in identifying if value} & wanted:
+            continue
+        easyiq_id = folded.get("id", "")
+        return True, [name for name, value in aula_ids.items() if value and value == easyiq_id]
+    return False, []
+
+
+async def probe_easyiq(
+    client: Any,
+    children: list[Any],
+    guardian_login: str,
+    date: str,
+    institution_filter: list[str] | None = None,
+    include_values: bool = False,
+) -> ProbeReport:
+    """Run the probe and return its report.
+
+    ``date`` is an ISO timestamp inside the week to ask about.
+    ``institution_filter`` must be the same list the real commands send:
+    EasyIQ answers differently without it, so a probe that omitted it would
+    report failures the working code never sees.
+    """
+    institution_filter = institution_filter or []
+    report = ProbeReport()
+
+    try:
+        widgets = await client.get_widgets()
+        report.widgets = [
+            (w.widget_id, w.name, w.widget_type)
+            for w in widgets
+            if "easyiq" in (w.name or "").casefold()
+            or "easyiq" in (w.widget_supplier or "").casefold()
+        ]
+    except Exception as e:
+        report.widgets = []
+        report.tokens["widget list"] = f"failed: {type(e).__name__}"
+
+    tokens: dict[str, str] = {}
+    for widget_id in (WIDGET_EASYIQ_WEEKPLAN, WIDGET_EASYIQ_HOMEWORK):
+        try:
+            tokens[widget_id] = await client.widgets._get_bearer_token(widget_id)
+            report.tokens[widget_id] = "ok"
+        except Exception as e:
+            report.tokens[widget_id] = f"failed: {type(e).__name__}"
+
+    if not tokens:
+        return report
+
+    any_token = next(iter(tokens.values()))
+    headers = client.widgets.easyiq_headers(any_token, institution_filter, guardian_login)
+    entries: list[dict[str, Any]] = []
+    try:
+        resp = await client._request_with_version_retry(
+            "get", f"{EASYIQ_PORTAL}{EASYIQ_CHILDREN_PATH}", headers=headers
+        )
+        report.children_status = resp.status_code
+        entries = _entries(resp.json())
+        report.children_count = len(entries)
+        report.children_fields = [str(key) for key in entries[0]] if entries else []
+    except Exception as e:
+        report.children_error = f"{type(e).__name__}: {e}"
+
+    for index, child in enumerate(children, start=1):
+        raw = child._raw or {}
+        aula_ids = {
+            "institution_profile_id": str(child.id),
+            "profile_id": str(child.profile_id),
+            "user_id": str(raw.get("userId", "")),
+        }
+        probe = ChildProbe(label=f"Child {index} of {len(children)}")
+        probe.easyiq_entry_found, probe.easyiq_id_matches = _match_easyiq_entry(entries, aula_ids)
+
+        for path, widget_id, extra_params in PROBE_TARGETS:
+            token = tokens.get(widget_id)
+            if token is None:
+                continue
+            base = client.widgets.easyiq_headers(token, institution_filter, guardian_login)
+            attempts: list[Attempt] = []
+            for login_id, child_header in client.widgets.easyiq_identifier_variants(
+                aula_ids["institution_profile_id"], aula_ids["user_id"], guardian_login
+            ):
+                attempt = Attempt(
+                    login_id_source=_name_of(login_id, aula_ids, guardian_login),
+                    child_header_source=_name_of(child_header, aula_ids, guardian_login),
+                )
+                try:
+                    resp = await client._request_with_version_retry(
+                        "get",
+                        f"{EASYIQ_PORTAL}{path}",
+                        params={**extra_params, "date": date, "loginId": login_id},
+                        headers={**base, "x-child": child_header, "x-childfilter": child_header},
+                    )
+                    attempt.status = resp.status_code
+                    payload = resp.json()
+                    attempt.rows, attempt.item_types, attempt.keys = _describe_rows(payload)
+                    if include_values:
+                        attempt.body = payload
+                except Exception as e:
+                    attempt.error = f"{type(e).__name__}: {e}"
+                attempts.append(attempt)
+            probe.attempts[path] = attempts
+
+        report.children.append(probe)
+
+    return report
+
+
+def _name_of(value: str, aula_ids: dict[str, str], guardian_login: str) -> str:
+    """Name an identifier by where it came from, so no ID is printed."""
+    for name, candidate in aula_ids.items():
+        if candidate and candidate == value:
+            return name
+    if value == guardian_login:
+        return "guardian_login"
+    return "unknown"
+
+
+def render_report(report: ProbeReport, include_values: bool = False) -> list[str]:
+    """Render the report as lines, safe to paste unless ``include_values``."""
+    lines = ["EasyIQ probe", "============", ""]
+
+    if report.widgets:
+        lines.append("Widgets:")
+        lines.extend(f"  {wid}  {name}  ({wtype})" for wid, name, wtype in report.widgets)
+    else:
+        lines.append("Widgets: no EasyIQ widget on this account")
+    lines.append("Tokens: " + ", ".join(f"{k} {v}" for k, v in report.tokens.items()))
+    lines.append("")
+
+    lines.append(f"{EASYIQ_CHILDREN_PATH}")
+    if report.children_error:
+        lines.append(f"  failed: {report.children_error}")
+    else:
+        lines.append(f"  status {report.children_status}, {report.children_count} entries")
+        if report.children_fields:
+            lines.append(f"  fields: {', '.join(report.children_fields)}")
+    lines.append("")
+
+    for probe in report.children:
+        lines.append(probe.label)
+        if not probe.easyiq_entry_found:
+            lines.append("  not listed by EasyIQ (likely not an EasyIQ institution)")
+        elif probe.easyiq_id_matches:
+            lines.append(f"  EasyIQ Id equals the Aula {' and '.join(probe.easyiq_id_matches)}")
+        else:
+            lines.append("  listed by EasyIQ, but its Id matches no Aula identifier")
+
+        for path, attempts in probe.attempts.items():
+            lines.append(f"  {path}")
+            for attempt in attempts:
+                label = f"loginId={attempt.login_id_source} child={attempt.child_header_source}"
+                if attempt.error:
+                    lines.append(f"    {label}  {attempt.error}")
+                    continue
+                detail = f"    {label}  {attempt.status}"
+                if attempt.rows is not None:
+                    detail += f"  {attempt.rows} rows  itemType {attempt.item_types or '{}'}"
+                lines.append(detail)
+                if attempt.keys:
+                    lines.append(f"      keys: {', '.join(attempt.keys)}")
+                if include_values and attempt.body is not None:
+                    lines.append(f"      body: {attempt.body}")
+        lines.append("")
+
+    if not include_values:
+        lines.append("No names, subjects or IDs are included above.")
+    else:
+        lines.append("WARNING: --include-values printed raw responses. Do not paste this publicly.")
+    return lines

--- a/src/aula/utils/output.py
+++ b/src/aula/utils/output.py
@@ -34,9 +34,13 @@ def print_empty(resource: str) -> None:
     click.echo(f"No {resource} found.")
 
 
-def print_error(message: str) -> None:
-    """Print the shared error sentence."""
-    click.echo(f"Error: {message}")
+def print_error(message: str, err: bool = False) -> None:
+    """Print the shared error sentence.
+
+    Pass ``err=True`` to route it to stderr, which commands must do while
+    emitting JSON so the error does not land in the middle of the document.
+    """
+    click.echo(f"Error: {message}", err=err)
 
 
 def clip(text: str, max_len: int = 120) -> str:

--- a/src/aula/utils/week.py
+++ b/src/aula/utils/week.py
@@ -1,0 +1,23 @@
+"""Helpers for turning Aula's ``YYYY-Wnn`` week strings into dates."""
+
+import datetime
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def monday_of_week(week: str) -> str:
+    """Return the Monday of ``YYYY-Wnn`` as an ISO timestamp with a ``Z`` suffix.
+
+    EasyIQ's portal takes a single ``date`` and answers with the week that
+    contains it, so any day of the week would do; Monday keeps it unambiguous.
+    Falls back to today when ``week`` cannot be parsed, which is better than
+    sending nothing.
+    """
+    try:
+        year_part, week_part = week.split("-W")
+        monday = datetime.date.fromisocalendar(int(year_part), int(week_part), 1)
+    except ValueError, AttributeError:
+        _LOGGER.warning("Could not parse week %r, using today's date instead", week)
+        monday = datetime.date.today()
+    return f"{monday.isoformat()}T00:00:00Z"

--- a/src/aula/widgets/client.py
+++ b/src/aula/widgets/client.py
@@ -1,10 +1,11 @@
-import datetime
 import logging
 from typing import Any, Protocol
 
 from ..const import (
     CICERO_API,
     EASYIQ_API,
+    EASYIQ_CALENDAR_PATH,
+    EASYIQ_HOMEWORK_PATH,
     EASYIQ_PORTAL,
     MEEBOOK_API,
     MIN_UDDANNELSE_API,
@@ -28,6 +29,7 @@ from ..models import (
     MUWeeklyPerson,
     UserReminders,
 )
+from ..utils.week import monday_of_week
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,22 +59,6 @@ def _as_list(data: Any, provider: str) -> list[Any]:
             len(data) - len(items),
         )
     return items
-
-
-def _monday_of_week(week: str) -> str:
-    """Return the Monday of ``YYYY-Wnn`` as the timestamp EasyIQ's portal wants.
-
-    The portal takes a single ``date`` and answers with the week containing it,
-    so any day in the week would do; Monday keeps it unambiguous. Falls back to
-    today when ``week`` cannot be parsed, which is better than sending nothing.
-    """
-    try:
-        year_part, week_part = week.split("-W")
-        monday = datetime.date.fromisocalendar(int(year_part), int(week_part), 1)
-    except ValueError, AttributeError:
-        _LOGGER.warning("Could not parse week %r, using today's date instead", week)
-        monday = datetime.date.today()
-    return f"{monday.isoformat()}T00:00:00Z"
 
 
 def _ordered_unique(pairs: list[tuple[str, str]]) -> list[tuple[str, str]]:
@@ -194,50 +180,30 @@ class AulaWidgetsClient:
         resp.raise_for_status()
         return [MUWeeklyPerson.from_dict(p) for p in resp.json().get("personer", [])]
 
-    async def get_easyiq_calendar_events(
-        self,
-        *,
-        week: str,
-        institution_filter: list[str],
-        child_profile_id: str,
-        child_user_id: str,
-        guardian_login: str,
-        widget_id: str = WIDGET_EASYIQ_WEEKPLAN,
-    ) -> list[EasyIQCalendarEvent]:
-        """Fetch a child's whole EasyIQ week from the school portal.
-
-        One request returns lessons, calendar entries and homework together;
-        callers split them on ``item_type``.
-
-        EasyIQ accepts different Aula identifiers for ``loginId`` and the child
-        headers depending on the institution, and answers 200-with-nothing for
-        the combinations it does not recognise. Rather than guess, this tries
-        the known combinations in turn and keeps the one that returns rows,
-        remembering it so later weeks cost a single request. A remembered
-        combination that stops working just costs one wasted request before
-        the rest are tried again.
-        """
-        token = await self._get_bearer_token(widget_id)
-        base_headers = {
+    def easyiq_headers(
+        self, token: str, institution_filter: list[str], guardian_login: str
+    ) -> dict[str, str]:
+        """Headers the EasyIQ portal expects from its embedded widgets."""
+        return {
             "Authorization": token,
             "Accept": "application/json",
             "x-institutionfilter": ",".join(institution_filter),
             "x-userprofile": "guardian",
             "x-login": guardian_login,
             "x-requested-with": "XMLHttpRequest",
-            # EasyIQ only serves the calendar to callers that look like the
-            # embedded widget.
+            # EasyIQ only serves these controllers to callers that look like
+            # the embedded widget.
             "Referer": f"{EASYIQ_PORTAL}/UgeplanWidget",
         }
-        params = {
-            "date": _monday_of_week(week),
-            "activityFilter": "-1",
-            "courseFilter": "-1",
-            "textFilter": "",
-            "ownWeekPlan": "false",
-        }
 
-        variants = _ordered_unique(
+    def easyiq_identifier_variants(
+        self, child_profile_id: str, child_user_id: str, guardian_login: str
+    ) -> list[tuple[str, str]]:
+        """Return the ``(loginId, child header)`` pairs to try, best guess first.
+
+        A pair already known to work for this child is moved to the front.
+        """
+        return _ordered_unique(
             self._easyiq_identifiers.get(child_user_id, [])
             + [
                 (child_profile_id, child_user_id),
@@ -247,22 +213,50 @@ class AulaWidgetsClient:
             ]
         )
 
+    async def _get_easyiq_events(
+        self,
+        *,
+        path: str,
+        extra_params: dict[str, str],
+        week: str,
+        institution_filter: list[str],
+        child_profile_id: str,
+        child_user_id: str,
+        guardian_login: str,
+        widget_id: str,
+    ) -> list[EasyIQCalendarEvent]:
+        """Read one of the EasyIQ portal's week controllers for a child.
+
+        EasyIQ accepts different Aula identifiers for ``loginId`` and the child
+        headers depending on the institution, and answers either 500 or
+        200-with-nothing for the ones it does not recognise. Rather than guess,
+        this tries the known combinations in turn and keeps the one that
+        returns rows, remembering it so later weeks cost a single request. A
+        remembered combination that stops working costs one wasted request
+        before the rest are tried again.
+        """
+        token = await self._get_bearer_token(widget_id)
+        base_headers = self.easyiq_headers(token, institution_filter, guardian_login)
+        params = {"date": monday_of_week(week), **extra_params}
+
         first_empty: list[EasyIQCalendarEvent] | None = None
         last_error: Exception | None = None
 
-        for login_id, child_header in variants:
+        for login_id, child_header in self.easyiq_identifier_variants(
+            child_profile_id, child_user_id, guardian_login
+        ):
             headers = {**base_headers, "x-child": child_header, "x-childfilter": child_header}
             try:
                 resp = await self._api_client._request_with_version_retry(
                     "get",
-                    f"{EASYIQ_PORTAL}/Calendar/CalendarGetWeekplanEvents",
+                    f"{EASYIQ_PORTAL}{path}",
                     params={**params, "loginId": login_id},
                     headers=headers,
                 )
                 resp.raise_for_status()
             except Exception as e:
                 last_error = e
-                _LOGGER.debug("EasyIQ calendar rejected loginId=%s: %s", login_id, e)
+                _LOGGER.debug("EasyIQ %s rejected loginId=%s: %s", path, login_id, e)
                 continue
 
             events = [EasyIQCalendarEvent.from_dict(e) for e in _extract_events(resp.json())]
@@ -277,6 +271,64 @@ class AulaWidgetsClient:
         if last_error is not None:
             raise last_error
         return []
+
+    async def get_easyiq_calendar_events(
+        self,
+        *,
+        week: str,
+        institution_filter: list[str],
+        child_profile_id: str,
+        child_user_id: str,
+        guardian_login: str,
+        widget_id: str = WIDGET_EASYIQ_WEEKPLAN,
+    ) -> list[EasyIQCalendarEvent]:
+        """Fetch a child's EasyIQ week of lessons and calendar entries.
+
+        This controller carries the weekly plan only. Homework has its own,
+        see :meth:`get_easyiq_homework_events`.
+        """
+        return await self._get_easyiq_events(
+            path=EASYIQ_CALENDAR_PATH,
+            extra_params={
+                "activityFilter": "-1",
+                "courseFilter": "-1",
+                "textFilter": "",
+                "ownWeekPlan": "false",
+            },
+            week=week,
+            institution_filter=institution_filter,
+            child_profile_id=child_profile_id,
+            child_user_id=child_user_id,
+            guardian_login=guardian_login,
+            widget_id=widget_id,
+        )
+
+    async def get_easyiq_homework_events(
+        self,
+        *,
+        week: str,
+        institution_filter: list[str],
+        child_profile_id: str,
+        child_user_id: str,
+        guardian_login: str,
+        widget_id: str = WIDGET_EASYIQ_HOMEWORK,
+    ) -> list[EasyIQCalendarEvent]:
+        """Fetch a child's EasyIQ homework rows for a week.
+
+        The weekly plan controller never returns homework, so this reads the
+        homework widget's own controller. Guardians send an empty
+        ``activityFilter``, which is what the widget itself does.
+        """
+        return await self._get_easyiq_events(
+            path=EASYIQ_HOMEWORK_PATH,
+            extra_params={"activityFilter": ""},
+            week=week,
+            institution_filter=institution_filter,
+            child_profile_id=child_profile_id,
+            child_user_id=child_user_id,
+            guardian_login=guardian_login,
+            widget_id=widget_id,
+        )
 
     async def get_easyiq_weekplan(
         self,
@@ -364,19 +416,25 @@ class AulaWidgetsClient:
         ``child_id`` is the child's Aula user ID and ``child_profile_id`` their
         institution profile ID; EasyIQ wants both.
         """
-        events = await self.get_easyiq_calendar_events(
+        events = await self.get_easyiq_homework_events(
             week=week,
             institution_filter=institution_filter,
             child_profile_id=child_profile_id,
             child_user_id=child_id,
             guardian_login=session_uuid,
-            widget_id=WIDGET_EASYIQ_HOMEWORK,
         )
-        return [
-            EasyIQHomework.from_calendar_event(event)
-            for event in events
-            if event.item_type in HOMEWORK_ITEM_TYPES
-        ]
+        homework = [event for event in events if event.item_type in HOMEWORK_ITEM_TYPES]
+        if events and not homework:
+            # The controller only serves homework, so an unfamiliar item type
+            # is no reason to drop the rows and report nothing.
+            _LOGGER.info(
+                "EasyIQ homework returned %d row(s) of item type %s, none of type %s; keeping them",
+                len(events),
+                sorted({event.item_type for event in events}, key=str),
+                HOMEWORK_ITEM_TYPES,
+            )
+            homework = events
+        return [EasyIQHomework.from_calendar_event(event) for event in homework]
 
     async def get_meebook_weekplan(
         self,

--- a/src/aula/widgets/client.py
+++ b/src/aula/widgets/client.py
@@ -4,7 +4,9 @@ from typing import Any, Protocol
 from ..const import (
     CICERO_API,
     EASYIQ_API,
+    EASYIQ_AUTHENTICATE_PATH,
     EASYIQ_CALENDAR_PATH,
+    EASYIQ_CHILDREN_PATH,
     EASYIQ_HOMEWORK_PATH,
     EASYIQ_PORTAL,
     MEEBOOK_API,
@@ -113,6 +115,10 @@ class AulaWidgetsClient:
         self._api_client = api_client
         # child user ID -> the (loginId, child header) pair EasyIQ accepted.
         self._easyiq_identifiers: dict[str, list[tuple[str, str]]] = {}
+        # Whether POST /Aula/AuthenticateAulaUser has run for this client.
+        self._easyiq_session_ready = False
+        # child UniLogin (casefolded) -> EasyIQ's own ID, from GetChildren.
+        self._easyiq_child_ids: dict[str, str] = {}
 
     async def _get_bearer_token(self, widget_id: str) -> str:
         resp = await self._api_client._request_with_version_retry(
@@ -181,30 +187,114 @@ class AulaWidgetsClient:
         return [MUWeeklyPerson.from_dict(p) for p in resp.json().get("personer", [])]
 
     def easyiq_headers(
-        self, token: str, institution_filter: list[str], guardian_login: str
+        self,
+        token: str,
+        institution_filter: list[str],
+        guardian_login: str,
+        child_user_ids: list[str],
+        child_user_id: str = "",
     ) -> dict[str, str]:
-        """Headers the EasyIQ portal expects from its embedded widgets."""
+        """Headers the EasyIQ portal expects from its embedded widgets.
+
+        Mirrors the widget's own ``GetAulaHeaders`` (``/ts/Code/Util.js``).
+        ``x-child`` is one child's UniLogin and ``x-childfilter`` is all of
+        the guardian's children's UniLogins; both are required on every
+        portal call, not just the session bootstrap. A guardian login in
+        either is rejected, and omitting them makes ``GetChildren`` answer
+        200 with an empty list, which reads as "no children" rather than as
+        a malformed request.
+        """
         return {
             "Authorization": token,
             "Accept": "application/json",
             "x-institutionfilter": ",".join(institution_filter),
             "x-userprofile": "guardian",
             "x-login": guardian_login,
+            "x-child": child_user_id or (child_user_ids[0] if child_user_ids else ""),
+            "x-childfilter": ",".join(child_user_ids),
             "x-requested-with": "XMLHttpRequest",
             # EasyIQ only serves these controllers to callers that look like
             # the embedded widget.
             "Referer": f"{EASYIQ_PORTAL}/UgeplanWidget",
         }
 
+    async def ensure_easyiq_session(
+        self,
+        institution_filter: list[str],
+        guardian_login: str,
+        child_user_ids: list[str],
+    ) -> None:
+        """Establish the EasyIQ portal session once, and learn its child IDs.
+
+        ``POST /Aula/AuthenticateAulaUser`` is what the embedded widget does
+        before anything else (``/ts/Code/Aula.js``); it sets the session
+        cookies the portal's other controllers require. ``GetChildren`` then
+        returns EasyIQ's own ``Id`` per child, which is the ``loginId`` those
+        controllers expect and which appears nowhere in the Aula API.
+
+        Best-effort: a failure is logged rather than raised, leaving the
+        identifier guessing in :meth:`easyiq_identifier_variants` as a
+        fallback for institutions this flow does not suit.
+        """
+        if self._easyiq_session_ready or not child_user_ids:
+            return
+
+        token = await self._get_bearer_token(WIDGET_EASYIQ_HOMEWORK)
+        headers = self.easyiq_headers(token, institution_filter, guardian_login, child_user_ids)
+        try:
+            resp = await self._api_client._request_with_version_retry(
+                "post", f"{EASYIQ_PORTAL}{EASYIQ_AUTHENTICATE_PATH}", headers=headers
+            )
+            resp.raise_for_status()
+        except Exception as e:
+            _LOGGER.info("EasyIQ session bootstrap failed (%s); falling back to guessing", e)
+            return
+
+        self._easyiq_session_ready = True
+
+        try:
+            resp = await self._api_client._request_with_version_retry(
+                "get", f"{EASYIQ_PORTAL}{EASYIQ_CHILDREN_PATH}", headers=headers
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+        except Exception as e:
+            _LOGGER.info("EasyIQ GetChildren failed (%s); falling back to guessing", e)
+            return
+
+        entries = payload.get("Children", []) if isinstance(payload, dict) else []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            folded = {str(k).lower(): v for k, v in entry.items()}
+            # Match on Login, the child's UniLogin, which is the same value
+            # Aula calls userId. Names are neither unique nor stable.
+            login = str(folded.get("login") or "").casefold()
+            easyiq_id = str(folded.get("id") or "")
+            if login and easyiq_id:
+                self._easyiq_child_ids[login] = easyiq_id
+
+    def resolve_easyiq_child_id(self, child_user_id: str) -> str | None:
+        """Return EasyIQ's own ID for a child, once the session has been made."""
+        return self._easyiq_child_ids.get(child_user_id.casefold())
+
     def easyiq_identifier_variants(
-        self, child_profile_id: str, child_user_id: str, guardian_login: str
+        self,
+        child_profile_id: str,
+        child_user_id: str,
+        guardian_login: str,
+        easyiq_child_id: str | None = None,
     ) -> list[tuple[str, str]]:
         """Return the ``(loginId, child header)`` pairs to try, best guess first.
 
-        A pair already known to work for this child is moved to the front.
+        A pair already known to work for this child leads, then EasyIQ's own
+        ID for the child when the session bootstrap resolved one, then the
+        Aula-derived guesses that are all that is left without it.
         """
+        resolved = [(easyiq_child_id, child_user_id)] if easyiq_child_id else []
         return _ordered_unique(
             self._easyiq_identifiers.get(child_user_id, [])
+            + resolved
             + [
                 (child_profile_id, child_user_id),
                 (child_user_id, child_user_id),
@@ -222,30 +312,38 @@ class AulaWidgetsClient:
         institution_filter: list[str],
         child_profile_id: str,
         child_user_id: str,
+        all_child_user_ids: list[str],
         guardian_login: str,
         widget_id: str,
     ) -> list[EasyIQCalendarEvent]:
         """Read one of the EasyIQ portal's week controllers for a child.
 
-        EasyIQ accepts different Aula identifiers for ``loginId`` and the child
-        headers depending on the institution, and answers either 500 or
-        200-with-nothing for the ones it does not recognise. Rather than guess,
-        this tries the known combinations in turn and keeps the one that
-        returns rows, remembering it so later weeks cost a single request. A
-        remembered combination that stops working costs one wasted request
-        before the rest are tried again.
+        The session bootstrap normally supplies EasyIQ's own ID for this
+        child, which is the ``loginId`` these controllers want. When it does
+        not, EasyIQ answers either 500 or 200-with-nothing for identifiers it
+        does not recognise, so the known Aula-derived combinations are tried
+        in turn and the one that returns rows is remembered. A remembered
+        combination that stops working costs one wasted request before the
+        rest are tried again.
         """
+        await self.ensure_easyiq_session(institution_filter, guardian_login, all_child_user_ids)
         token = await self._get_bearer_token(widget_id)
-        base_headers = self.easyiq_headers(token, institution_filter, guardian_login)
+        base_headers = self.easyiq_headers(
+            token, institution_filter, guardian_login, all_child_user_ids, child_user_id
+        )
         params = {"date": monday_of_week(week), **extra_params}
 
         first_empty: list[EasyIQCalendarEvent] | None = None
         last_error: Exception | None = None
 
         for login_id, child_header in self.easyiq_identifier_variants(
-            child_profile_id, child_user_id, guardian_login
+            child_profile_id,
+            child_user_id,
+            guardian_login,
+            self.resolve_easyiq_child_id(child_user_id),
         ):
-            headers = {**base_headers, "x-child": child_header, "x-childfilter": child_header}
+            # x-childfilter stays the full list; only x-child varies per try.
+            headers = {**base_headers, "x-child": child_header}
             try:
                 resp = await self._api_client._request_with_version_retry(
                     "get",
@@ -279,6 +377,7 @@ class AulaWidgetsClient:
         institution_filter: list[str],
         child_profile_id: str,
         child_user_id: str,
+        all_child_user_ids: list[str],
         guardian_login: str,
         widget_id: str = WIDGET_EASYIQ_WEEKPLAN,
     ) -> list[EasyIQCalendarEvent]:
@@ -299,6 +398,7 @@ class AulaWidgetsClient:
             institution_filter=institution_filter,
             child_profile_id=child_profile_id,
             child_user_id=child_user_id,
+            all_child_user_ids=all_child_user_ids,
             guardian_login=guardian_login,
             widget_id=widget_id,
         )
@@ -310,6 +410,7 @@ class AulaWidgetsClient:
         institution_filter: list[str],
         child_profile_id: str,
         child_user_id: str,
+        all_child_user_ids: list[str],
         guardian_login: str,
         widget_id: str = WIDGET_EASYIQ_HOMEWORK,
     ) -> list[EasyIQCalendarEvent]:
@@ -326,6 +427,7 @@ class AulaWidgetsClient:
             institution_filter=institution_filter,
             child_profile_id=child_profile_id,
             child_user_id=child_user_id,
+            all_child_user_ids=all_child_user_ids,
             guardian_login=guardian_login,
             widget_id=widget_id,
         )
@@ -339,6 +441,7 @@ class AulaWidgetsClient:
         widget_id: str = WIDGET_EASYIQ_WEEKPLAN,
         *,
         child_profile_id: str | None = None,
+        all_child_user_ids: list[str] | None = None,
     ) -> list[Appointment]:
         """Fetch a child's EasyIQ weekly plan.
 
@@ -346,7 +449,8 @@ class AulaWidgetsClient:
         portal's calendar, which is the only source that still serves some
         institutions. The fallback needs ``child_profile_id`` (the child's
         institution profile ID) to identify the child, so it is skipped when
-        the caller cannot supply one.
+        the caller cannot supply one. ``all_child_user_ids`` is every child's
+        UniLogin, which the portal requires as ``x-childfilter``.
         """
         token = await self._get_bearer_token(widget_id)
         headers = {
@@ -385,13 +489,15 @@ class AulaWidgetsClient:
             institution_filter=institution_filter,
             child_profile_id=child_profile_id,
             child_user_id=child_id,
+            all_child_user_ids=all_child_user_ids or [child_id],
             guardian_login=session_uuid,
             widget_id=widget_id,
         )
         return [
             Appointment(
                 _raw=event._raw,
-                appointment_id=event.start,
+                # The row's own ID: two lessons can start at the same minute.
+                appointment_id=event.event_id or event.start,
                 title=event.title,
                 start=event.start,
                 end=event.end,
@@ -410,17 +516,20 @@ class AulaWidgetsClient:
         child_id: str,
         *,
         child_profile_id: str,
+        all_child_user_ids: list[str] | None = None,
     ) -> list[EasyIQHomework]:
         """Fetch a child's EasyIQ homework for a week.
 
         ``child_id`` is the child's Aula user ID and ``child_profile_id`` their
-        institution profile ID; EasyIQ wants both.
+        institution profile ID; EasyIQ wants both. ``all_child_user_ids`` is
+        every child's UniLogin, which the portal requires as ``x-childfilter``.
         """
         events = await self.get_easyiq_homework_events(
             week=week,
             institution_filter=institution_filter,
             child_profile_id=child_profile_id,
             child_user_id=child_id,
+            all_child_user_ids=all_child_user_ids or [child_id],
             guardian_login=session_uuid,
         )
         homework = [event for event in events if event.item_type in HOMEWORK_ITEM_TYPES]

--- a/src/aula/widgets/client.py
+++ b/src/aula/widgets/client.py
@@ -1,20 +1,25 @@
+import datetime
 import logging
 from typing import Any, Protocol
 
 from ..const import (
     CICERO_API,
     EASYIQ_API,
+    EASYIQ_PORTAL,
     MEEBOOK_API,
     MIN_UDDANNELSE_API,
     SYSTEMATIC_API,
-    WIDGET_EASYIQ,
     WIDGET_EASYIQ_HOMEWORK,
+    WIDGET_EASYIQ_WEEKPLAN,
     WIDGET_HUSKELISTEN,
     WIDGET_MEEBOOK,
 )
 from ..http import HttpResponse
 from ..models import (
+    HOMEWORK_ITEM_TYPES,
+    WEEKPLAN_ITEM_TYPES,
     Appointment,
+    EasyIQCalendarEvent,
     EasyIQHomework,
     LibraryStatus,
     MeebookStudentPlan,
@@ -54,6 +59,53 @@ def _as_list(data: Any, provider: str) -> list[Any]:
     return items
 
 
+def _monday_of_week(week: str) -> str:
+    """Return the Monday of ``YYYY-Wnn`` as the timestamp EasyIQ's portal wants.
+
+    The portal takes a single ``date`` and answers with the week containing it,
+    so any day in the week would do; Monday keeps it unambiguous. Falls back to
+    today when ``week`` cannot be parsed, which is better than sending nothing.
+    """
+    try:
+        year_part, week_part = week.split("-W")
+        monday = datetime.date.fromisocalendar(int(year_part), int(week_part), 1)
+    except ValueError, AttributeError:
+        _LOGGER.warning("Could not parse week %r, using today's date instead", week)
+        monday = datetime.date.today()
+    return f"{monday.isoformat()}T00:00:00Z"
+
+
+def _ordered_unique(pairs: list[tuple[str, str]]) -> list[tuple[str, str]]:
+    """Drop repeats while keeping first-seen order."""
+    seen: set[tuple[str, str]] = set()
+    unique = []
+    for pair in pairs:
+        if pair not in seen:
+            seen.add(pair)
+            unique.append(pair)
+    return unique
+
+
+def _extract_events(payload: Any) -> list[dict[str, Any]]:
+    """Pull the event list out of EasyIQ's calendar response.
+
+    The portal has answered with both a bare array and an object wrapping one,
+    so both shapes are unwrapped rather than assumed.
+    """
+    if isinstance(payload, list):
+        return [event for event in payload if isinstance(event, dict)]
+    if isinstance(payload, dict):
+        for key in ("events", "calendarEvents", "items", "data", "result"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return [event for event in value if isinstance(event, dict)]
+            if isinstance(value, dict):
+                nested = _extract_events(value)
+                if nested:
+                    return nested
+    return []
+
+
 class _WidgetRequestClient(Protocol):
     api_url: str
 
@@ -73,6 +125,8 @@ class AulaWidgetsClient:
 
     def __init__(self, api_client: _WidgetRequestClient) -> None:
         self._api_client = api_client
+        # child user ID -> the (loginId, child header) pair EasyIQ accepted.
+        self._easyiq_identifiers: dict[str, list[tuple[str, str]]] = {}
 
     async def _get_bearer_token(self, widget_id: str) -> str:
         resp = await self._api_client._request_with_version_retry(
@@ -140,14 +194,108 @@ class AulaWidgetsClient:
         resp.raise_for_status()
         return [MUWeeklyPerson.from_dict(p) for p in resp.json().get("personer", [])]
 
+    async def get_easyiq_calendar_events(
+        self,
+        *,
+        week: str,
+        institution_filter: list[str],
+        child_profile_id: str,
+        child_user_id: str,
+        guardian_login: str,
+        widget_id: str = WIDGET_EASYIQ_WEEKPLAN,
+    ) -> list[EasyIQCalendarEvent]:
+        """Fetch a child's whole EasyIQ week from the school portal.
+
+        One request returns lessons, calendar entries and homework together;
+        callers split them on ``item_type``.
+
+        EasyIQ accepts different Aula identifiers for ``loginId`` and the child
+        headers depending on the institution, and answers 200-with-nothing for
+        the combinations it does not recognise. Rather than guess, this tries
+        the known combinations in turn and keeps the one that returns rows,
+        remembering it so later weeks cost a single request. A remembered
+        combination that stops working just costs one wasted request before
+        the rest are tried again.
+        """
+        token = await self._get_bearer_token(widget_id)
+        base_headers = {
+            "Authorization": token,
+            "Accept": "application/json",
+            "x-institutionfilter": ",".join(institution_filter),
+            "x-userprofile": "guardian",
+            "x-login": guardian_login,
+            "x-requested-with": "XMLHttpRequest",
+            # EasyIQ only serves the calendar to callers that look like the
+            # embedded widget.
+            "Referer": f"{EASYIQ_PORTAL}/UgeplanWidget",
+        }
+        params = {
+            "date": _monday_of_week(week),
+            "activityFilter": "-1",
+            "courseFilter": "-1",
+            "textFilter": "",
+            "ownWeekPlan": "false",
+        }
+
+        variants = _ordered_unique(
+            self._easyiq_identifiers.get(child_user_id, [])
+            + [
+                (child_profile_id, child_user_id),
+                (child_user_id, child_user_id),
+                (child_profile_id, child_profile_id),
+                (guardian_login, child_user_id),
+            ]
+        )
+
+        first_empty: list[EasyIQCalendarEvent] | None = None
+        last_error: Exception | None = None
+
+        for login_id, child_header in variants:
+            headers = {**base_headers, "x-child": child_header, "x-childfilter": child_header}
+            try:
+                resp = await self._api_client._request_with_version_retry(
+                    "get",
+                    f"{EASYIQ_PORTAL}/Calendar/CalendarGetWeekplanEvents",
+                    params={**params, "loginId": login_id},
+                    headers=headers,
+                )
+                resp.raise_for_status()
+            except Exception as e:
+                last_error = e
+                _LOGGER.debug("EasyIQ calendar rejected loginId=%s: %s", login_id, e)
+                continue
+
+            events = [EasyIQCalendarEvent.from_dict(e) for e in _extract_events(resp.json())]
+            if events:
+                self._easyiq_identifiers[child_user_id] = [(login_id, child_header)]
+                return events
+            if first_empty is None:
+                first_empty = events
+
+        if first_empty is not None:
+            return first_empty
+        if last_error is not None:
+            raise last_error
+        return []
+
     async def get_easyiq_weekplan(
         self,
         week: str,
         session_uuid: str,
         institution_filter: list[str],
         child_id: str,
-        widget_id: str = WIDGET_EASYIQ,
+        widget_id: str = WIDGET_EASYIQ_WEEKPLAN,
+        *,
+        child_profile_id: str | None = None,
     ) -> list[Appointment]:
+        """Fetch a child's EasyIQ weekly plan.
+
+        Tries the ``weekplaninfo`` API first and falls back to the school
+        portal's calendar, which is the only source that still serves some
+        institutions. The fallback needs ``child_profile_id`` (the child's
+        institution profile ID) to identify the child, so it is skipped when
+        the caller cannot supply one.
+        """
         token = await self._get_bearer_token(widget_id)
         headers = {
             "Authorization": token,
@@ -160,34 +308,75 @@ class AulaWidgetsClient:
             "institutionFilter": institution_filter,
             "childFilter": [child_id],
         }
-        resp = await self._api_client._request_with_version_retry(
-            "post", f"{EASYIQ_API}/weekplaninfo", json=payload, headers=headers
+        appointments: list[dict[str, Any]] = []
+        try:
+            resp = await self._api_client._request_with_version_retry(
+                "post", f"{EASYIQ_API}/weekplaninfo", json=payload, headers=headers
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            envelope = data.get("data") if isinstance(data, dict) else None
+            if isinstance(envelope, dict):
+                appointments = _as_list(envelope.get("appointments", []), "EasyIQ weekplan")
+        except Exception as e:
+            if child_profile_id is None:
+                raise
+            _LOGGER.info("EasyIQ weekplaninfo failed (%s), falling back to the portal", e)
+
+        if appointments:
+            return [Appointment.from_dict(a) for a in appointments]
+        if child_profile_id is None:
+            return []
+
+        events = await self.get_easyiq_calendar_events(
+            week=week,
+            institution_filter=institution_filter,
+            child_profile_id=child_profile_id,
+            child_user_id=child_id,
+            guardian_login=session_uuid,
+            widget_id=widget_id,
         )
-        resp.raise_for_status()
-        appointments = resp.json().get("data", {}).get("appointments", [])
-        return [Appointment.from_dict(a) for a in appointments]
+        return [
+            Appointment(
+                _raw=event._raw,
+                appointment_id=event.start,
+                title=event.title,
+                start=event.start,
+                end=event.end,
+                description=event.description,
+                item_type=event.item_type,
+            )
+            for event in events
+            if event.item_type in WEEKPLAN_ITEM_TYPES
+        ]
 
     async def get_easyiq_homework(
-        self, week: str, session_uuid: str, institution_filter: list[str], child_id: str
+        self,
+        week: str,
+        session_uuid: str,
+        institution_filter: list[str],
+        child_id: str,
+        *,
+        child_profile_id: str,
     ) -> list[EasyIQHomework]:
-        token = await self._get_bearer_token(WIDGET_EASYIQ_HOMEWORK)
-        headers = {
-            "Authorization": token,
-            "x-aula-institutionfilter": ",".join(institution_filter),
-        }
-        payload = {
-            "sessionId": session_uuid,
-            "currentWeekNr": week,
-            "userProfile": "guardian",
-            "institutionFilter": institution_filter,
-            "childFilter": [child_id],
-        }
-        resp = await self._api_client._request_with_version_retry(
-            "post", f"{EASYIQ_API}/homeworkinfo", json=payload, headers=headers
+        """Fetch a child's EasyIQ homework for a week.
+
+        ``child_id`` is the child's Aula user ID and ``child_profile_id`` their
+        institution profile ID; EasyIQ wants both.
+        """
+        events = await self.get_easyiq_calendar_events(
+            week=week,
+            institution_filter=institution_filter,
+            child_profile_id=child_profile_id,
+            child_user_id=child_id,
+            guardian_login=session_uuid,
+            widget_id=WIDGET_EASYIQ_HOMEWORK,
         )
-        resp.raise_for_status()
-        items = resp.json().get("data", {}).get("homework", [])
-        return [EasyIQHomework.from_dict(h) for h in items]
+        return [
+            EasyIQHomework.from_calendar_event(event)
+            for event in events
+            if event.item_type in HOMEWORK_ITEM_TYPES
+        ]
 
     async def get_meebook_weekplan(
         self,

--- a/tests/models/test_easyiq_calendar_event.py
+++ b/tests/models/test_easyiq_calendar_event.py
@@ -1,0 +1,68 @@
+"""Tests for aula.models.easyiq_calendar_event."""
+
+from aula.models.easyiq_calendar_event import (
+    HOMEWORK_ITEM_TYPES,
+    WEEKPLAN_ITEM_TYPES,
+    EasyIQCalendarEvent,
+)
+
+
+def test_from_dict_reads_the_primary_shape():
+    data = {
+        "itemType": 9,
+        "start": "2026-02-24T08:00:00",
+        "end": "2026-02-24T09:00:00",
+        "courses": "Matematik",
+        "activities": "Algebra",
+        "description": "<p>Kapitel 3</p>",
+    }
+    event = EasyIQCalendarEvent.from_dict(data)
+    assert event.item_type == 9
+    assert event.start == "2026-02-24T08:00:00"
+    assert event.end == "2026-02-24T09:00:00"
+    assert event.courses == "Matematik"
+    assert event.activities == "Algebra"
+    assert event.description == "<p>Kapitel 3</p>"
+    assert event._raw is data
+
+
+def test_from_dict_defaults():
+    event = EasyIQCalendarEvent.from_dict({})
+    assert event.item_type is None
+    assert event.start == ""
+    assert event.title == "(untitled)"
+
+
+def test_item_type_accepts_a_string():
+    """EasyIQ has returned the type as a number and as a string."""
+    assert EasyIQCalendarEvent.from_dict({"itemType": "4"}).item_type == 4
+    assert EasyIQCalendarEvent.from_dict({"itemType": "not-a-number"}).item_type is None
+
+
+def test_alternate_keys_are_read():
+    event = EasyIQCalendarEvent.from_dict(
+        {"type": 8, "startDateTime": "2026-02-24T08:00:00", "subject": "Idræt", "note": "Husk tøj"}
+    )
+    assert event.item_type == 8
+    assert event.start == "2026-02-24T08:00:00"
+    assert event.courses == "Idræt"
+    assert event.description == "Husk tøj"
+
+
+def test_list_values_are_joined():
+    event = EasyIQCalendarEvent.from_dict({"activities": ["Læsning", "Skrivning"]})
+    assert event.activities == "Læsning, Skrivning"
+
+
+def test_title_falls_back_to_the_activity():
+    assert EasyIQCalendarEvent.from_dict({"activities": "Læsebånd"}).title == "Læsebånd"
+
+
+def test_item_types_do_not_overlap():
+    assert not set(WEEKPLAN_ITEM_TYPES) & set(HOMEWORK_ITEM_TYPES)
+
+
+def test_dict_conversion_drops_raw():
+    result = dict(EasyIQCalendarEvent.from_dict({"itemType": 4, "courses": "Dansk"}))
+    assert result["courses"] == "Dansk"
+    assert "_raw" not in result

--- a/tests/models/test_easyiq_calendar_event.py
+++ b/tests/models/test_easyiq_calendar_event.py
@@ -39,6 +39,26 @@ def test_item_type_accepts_a_string():
     assert EasyIQCalendarEvent.from_dict({"itemType": "not-a-number"}).item_type is None
 
 
+def test_pascal_case_keys_are_read():
+    """EasyIQ's homework controller answers in PascalCase, the calendar one does not."""
+    event = EasyIQCalendarEvent.from_dict(
+        {
+            "ItemType": 4,
+            "Start": "2026-02-28T00:00:00",
+            "End": "2026-02-28T09:00:00",
+            "Courses": "Dansk",
+            "Activities": "Læselektie",
+            "Description": "<p>Side 40</p>",
+        }
+    )
+    assert event.item_type == 4
+    assert event.start == "2026-02-28T00:00:00"
+    assert event.end == "2026-02-28T09:00:00"
+    assert event.courses == "Dansk"
+    assert event.activities == "Læselektie"
+    assert event.description == "<p>Side 40</p>"
+
+
 def test_alternate_keys_are_read():
     event = EasyIQCalendarEvent.from_dict(
         {"type": 8, "startDateTime": "2026-02-24T08:00:00", "subject": "Idræt", "note": "Husk tøj"}

--- a/tests/models/test_easyiq_calendar_event.py
+++ b/tests/models/test_easyiq_calendar_event.py
@@ -30,7 +30,8 @@ def test_from_dict_defaults():
     event = EasyIQCalendarEvent.from_dict({})
     assert event.item_type is None
     assert event.start == ""
-    assert event.title == "(untitled)"
+    # Empty rather than a placeholder: rendering decides how to show it.
+    assert event.title == ""
 
 
 def test_item_type_accepts_a_string():
@@ -78,8 +79,39 @@ def test_title_falls_back_to_the_activity():
     assert EasyIQCalendarEvent.from_dict({"activities": "Læsebånd"}).title == "Læsebånd"
 
 
-def test_item_types_do_not_overlap():
-    assert not set(WEEKPLAN_ITEM_TYPES) & set(HOMEWORK_ITEM_TYPES)
+def test_item_types_match_the_widget_source():
+    """The homework widget filters on 1, 2, 3, 4 and 8 (CalendarItem.js)."""
+    assert set(HOMEWORK_ITEM_TYPES) == {1, 2, 3, 4, 8}
+    assert set(WEEKPLAN_ITEM_TYPES) == {8, 9}
+    # 8 is VigtigInformation, which both views show.
+    assert set(WEEKPLAN_ITEM_TYPES) & set(HOMEWORK_ITEM_TYPES) == {8}
+
+
+def test_html_entities_are_unescaped():
+    """The portal sends entities in its text, unlike other Aula sources."""
+    event = EasyIQCalendarEvent.from_dict(
+        {"Description": "skal v&aelig;re l&aelig;st", "CoursesDisplay": "Dansk &amp; Historie"}
+    )
+    assert event.description == "skal være læst"
+    assert event.courses == "Dansk & Historie"
+
+
+def test_whitespace_only_title_falls_through():
+    """The portal pads unused titles with a single space."""
+    event = EasyIQCalendarEvent.from_dict({"Title": " ", "Activities": "Læsebånd"})
+    assert event.courses == ""
+    assert event.title == "Læsebånd"
+
+
+def test_iso_timestamp_is_preferred_over_the_display_string():
+    event = EasyIQCalendarEvent.from_dict(
+        {"StartTimeISO": "2026-08-18T08:00:00", "Start": "2026/08/18 08:00"}
+    )
+    assert event.start == "2026-08-18T08:00:00"
+
+
+def test_event_id_is_read():
+    assert EasyIQCalendarEvent.from_dict({"Id": 17363414}).event_id == "17363414"
 
 
 def test_dict_conversion_drops_raw():

--- a/tests/models/test_easyiq_calendar_event.py
+++ b/tests/models/test_easyiq_calendar_event.py
@@ -110,6 +110,30 @@ def test_iso_timestamp_is_preferred_over_the_display_string():
     assert event.start == "2026-08-18T08:00:00"
 
 
+def test_start_and_end_share_a_format_when_only_one_has_an_iso_field():
+    """EndTimeISO is null on rows where StartTimeISO is set."""
+    event = EasyIQCalendarEvent.from_dict(
+        {
+            "StartTimeISO": "2026-08-13T12:55:00.0000000",
+            "EndTimeISO": None,
+            "Start": "2026/08/13 12:55",
+            "End": "2026/08/13 14:25",
+        }
+    )
+    assert event.start == "2026-08-13T12:55:00"
+    assert event.end == "2026-08-13T14:25:00"
+
+
+def test_seconds_in_the_display_format_are_kept():
+    event = EasyIQCalendarEvent.from_dict({"Start": "2026/08/13 12:55:30"})
+    assert event.start == "2026-08-13T12:55:30"
+
+
+def test_an_unparseable_timestamp_is_passed_through():
+    event = EasyIQCalendarEvent.from_dict({"Start": "next tuesday"})
+    assert event.start == "next tuesday"
+
+
 def test_event_id_is_read():
     assert EasyIQCalendarEvent.from_dict({"Id": 17363414}).event_id == "17363414"
 

--- a/tests/models/test_easyiq_homework.py
+++ b/tests/models/test_easyiq_homework.py
@@ -1,5 +1,6 @@
 """Tests for aula.models.easyiq_homework."""
 
+from aula.models.easyiq_calendar_event import EasyIQCalendarEvent
 from aula.models.easyiq_homework import EasyIQHomework
 
 
@@ -37,6 +38,30 @@ def test_easyiq_homework_from_dict_completed():
     data = {"id": "hw-2", "title": "Essay", "isCompleted": True}
     hw = EasyIQHomework.from_dict(data)
     assert hw.is_completed is True
+
+
+def test_easyiq_homework_from_calendar_event():
+    raw = {
+        "itemType": 4,
+        "id": "evt-9",
+        "start": "2026-02-28T00:00:00",
+        "courses": "Dansk",
+        "description": "<p>Pages 40-55</p>",
+    }
+    hw = EasyIQHomework.from_calendar_event(EasyIQCalendarEvent.from_dict(raw))
+    assert hw.id == "evt-9"
+    assert hw.title == "Dansk"
+    assert hw.subject == "Dansk"
+    assert hw.description == "<p>Pages 40-55</p>"
+    assert hw.due_date == "2026-02-28T00:00:00"
+    assert hw.is_completed is False
+    assert hw._raw is raw
+
+
+def test_easyiq_homework_from_calendar_event_without_an_id():
+    """Portal rows carry no assignment id, so the start timestamp stands in."""
+    event = EasyIQCalendarEvent.from_dict({"itemType": 4, "start": "2026-02-28T00:00:00"})
+    assert EasyIQHomework.from_calendar_event(event).id == "2026-02-28T00:00:00"
 
 
 def test_easyiq_homework_dict_conversion():

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -11,6 +11,7 @@ from aula.const import API_URL, API_VERSION, CSRF_TOKEN_HEADER
 from aula.http import (
     AulaAuthenticationError,
     AulaServerError,
+    HttpRequestError,
     HttpResponse,
 )
 
@@ -1805,6 +1806,53 @@ class TestGetPresenceRegistrations:
         )
         result = await client.get_presence_registrations([201], date(2026, 3, 8), date(2026, 3, 8))
         assert result == []
+
+    @pytest.mark.asyncio
+    async def test_batch_400_retries_each_profile_and_keeps_what_works(self, client):
+        """One profile without presence must not blank out the others."""
+        ok = HttpResponse(
+            status_code=200,
+            data={"data": [{"id": 1, "institutionProfileId": 201, "status": 3}]},
+        )
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[
+                HttpResponse(status_code=400, data=None),  # both profiles at once
+                ok,  # 201 alone
+                HttpResponse(status_code=400, data=None),  # 202 alone
+            ]
+        )
+
+        result = await client.get_presence_registrations(
+            [201, 202], date(2026, 3, 8), date(2026, 3, 8)
+        )
+
+        assert [r.institution_profile_id for r in result] == [201]
+        retried = client._request_with_version_retry.await_args_list
+        assert [c.kwargs["params"]["institutionProfileIds[]"] for c in retried] == [
+            [201, 202],
+            [201],
+            [202],
+        ]
+
+    @pytest.mark.asyncio
+    async def test_batch_400_raises_when_no_profile_can_be_read(self, client):
+        client._request_with_version_retry = AsyncMock(
+            return_value=HttpResponse(status_code=400, data=None)
+        )
+
+        with pytest.raises(HttpRequestError):
+            await client.get_presence_registrations([201, 202], date(2026, 3, 8), date(2026, 3, 8))
+
+    @pytest.mark.asyncio
+    async def test_single_profile_failure_is_not_retried(self, client):
+        client._request_with_version_retry = AsyncMock(
+            return_value=HttpResponse(status_code=400, data=None)
+        )
+
+        with pytest.raises(HttpRequestError):
+            await client.get_presence_registrations([201], date(2026, 3, 8), date(2026, 3, 8))
+
+        assert client._request_with_version_retry.await_count == 1
 
 
 class TestGetPresenceRegistrationDetail:

--- a/tests/test_widgets_client.py
+++ b/tests/test_widgets_client.py
@@ -8,6 +8,8 @@ from aula.api_client import AulaApiClient
 from aula.const import (
     CICERO_API,
     EASYIQ_API,
+    EASYIQ_CALENDAR_PATH,
+    EASYIQ_HOMEWORK_PATH,
     EASYIQ_PORTAL,
     MEEBOOK_API,
     MIN_UDDANNELSE_API,
@@ -19,7 +21,8 @@ from aula.const import (
 )
 from aula.http import AulaNotFoundError
 
-EASYIQ_CALENDAR_URL = f"{EASYIQ_PORTAL}/Calendar/CalendarGetWeekplanEvents"
+EASYIQ_CALENDAR_URL = f"{EASYIQ_PORTAL}{EASYIQ_CALENDAR_PATH}"
+EASYIQ_HOMEWORK_URL = f"{EASYIQ_PORTAL}{EASYIQ_HOMEWORK_PATH}"
 
 
 def _token_response(token: str) -> Mock:
@@ -29,10 +32,10 @@ def _token_response(token: str) -> Mock:
     return resp
 
 
-def _calendar_response(events: list[dict]) -> Mock:
+def _calendar_response(payload: object) -> Mock:
     resp = Mock()
     resp.raise_for_status = Mock()
-    resp.json = Mock(return_value=events)
+    resp.json = Mock(return_value=payload)
     return resp
 
 
@@ -205,26 +208,21 @@ class TestWidgetsClient:
         assert easyiq_response.method_calls == [call.raise_for_status(), call.json()]
 
     @pytest.mark.asyncio
-    async def test_get_easyiq_homework_reads_the_portal_calendar(self, client):
-        """Homework comes from the portal calendar; ``/homeworkinfo`` 404s."""
-        calendar = _calendar_response(
+    async def test_get_easyiq_homework_reads_the_homework_controller(self, client):
+        """The calendar controller never returns homework; this one does."""
+        homework_rows = _calendar_response(
             [
                 {
-                    "itemType": 4,
-                    "start": "2026-02-28T00:00:00",
-                    "courses": "Dansk",
-                    "activities": "Læselektie",
-                    "description": "<p>Pages 40-55</p>",
-                },
-                {
-                    "itemType": 9,
-                    "start": "2026-02-24T08:00:00",
-                    "courses": "Matematik",
-                },
+                    "ItemType": 4,
+                    "Start": "2026-02-28T00:00:00",
+                    "Courses": "Dansk",
+                    "Activities": "Læselektie",
+                    "Description": "<p>Pages 40-55</p>",
+                }
             ]
         )
         client._request_with_version_retry = AsyncMock(
-            side_effect=[_token_response("token-easy-hw"), calendar]
+            side_effect=[_token_response("token-easy-hw"), homework_rows]
         )
 
         homework = await client.widgets.get_easyiq_homework(
@@ -235,7 +233,7 @@ class TestWidgetsClient:
             child_profile_id="4242",
         )
 
-        # The weekplan row of the same response is not homework.
+        # PascalCase keys: this controller does not answer in camelCase.
         assert len(homework) == 1
         assert homework[0].title == "Dansk"
         assert homework[0].subject == "Dansk"
@@ -248,13 +246,10 @@ class TestWidgetsClient:
             "get",
             f"{client.api_url}?method=aulaToken.getAulaToken&widgetId={WIDGET_EASYIQ_HOMEWORK}",
         )
-        assert calls[1].args == ("get", EASYIQ_CALENDAR_URL)
+        assert calls[1].args == ("get", EASYIQ_HOMEWORK_URL)
         assert calls[1].kwargs["params"] == {
             "date": "2026-02-23T00:00:00Z",
-            "activityFilter": "-1",
-            "courseFilter": "-1",
-            "textFilter": "",
-            "ownWeekPlan": "false",
+            "activityFilter": "",
             "loginId": "4242",
         }
         assert calls[1].kwargs["headers"] == {
@@ -268,6 +263,44 @@ class TestWidgetsClient:
             "x-child": "child-user-1",
             "x-childfilter": "child-user-1",
         }
+
+    @pytest.mark.asyncio
+    async def test_get_easyiq_homework_keeps_rows_of_an_unfamiliar_item_type(self, client):
+        """The controller only serves homework, so never report nothing instead."""
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[
+                _token_response("token-easy-hw"),
+                _calendar_response([{"ItemType": 11, "Courses": "Dansk"}]),
+            ]
+        )
+
+        homework = await client.widgets.get_easyiq_homework(
+            week="2026-W09",
+            session_uuid="guardian-1",
+            institution_filter=["inst-1"],
+            child_id="child-user-1",
+            child_profile_id="4242",
+        )
+
+        assert [hw.subject for hw in homework] == ["Dansk"]
+
+    @pytest.mark.asyncio
+    async def test_get_easyiq_weekplan_does_not_use_the_homework_controller(self, client):
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[
+                _token_response("token-easy"),
+                _calendar_response({"data": {"appointments": []}}),
+                _token_response("token-easy"),
+                _calendar_response([{"itemType": 9, "courses": "Matematik"}]),
+            ]
+        )
+
+        await client.widgets.get_easyiq_weekplan(
+            "2026-W09", "guardian-1", ["inst-1"], "child-user-1", child_profile_id="4242"
+        )
+
+        calls = client._request_with_version_retry.await_args_list
+        assert calls[3].args == ("get", EASYIQ_CALENDAR_URL)
 
     @pytest.mark.asyncio
     async def test_easyiq_calendar_falls_through_to_the_accepted_identifiers(self, client):

--- a/tests/test_widgets_client.py
+++ b/tests/test_widgets_client.py
@@ -8,13 +8,32 @@ from aula.api_client import AulaApiClient
 from aula.const import (
     CICERO_API,
     EASYIQ_API,
+    EASYIQ_PORTAL,
     MEEBOOK_API,
     MIN_UDDANNELSE_API,
     SYSTEMATIC_API,
+    WIDGET_EASYIQ_HOMEWORK,
     WIDGET_HUSKELISTEN,
     WIDGET_MIN_UDDANNELSE_TASKS,
     WIDGET_MIN_UDDANNELSE_UGEPLAN,
 )
+from aula.http import AulaNotFoundError
+
+EASYIQ_CALENDAR_URL = f"{EASYIQ_PORTAL}/Calendar/CalendarGetWeekplanEvents"
+
+
+def _token_response(token: str) -> Mock:
+    resp = Mock()
+    resp.raise_for_status = Mock()
+    resp.json = Mock(return_value={"data": token})
+    return resp
+
+
+def _calendar_response(events: list[dict]) -> Mock:
+    resp = Mock()
+    resp.raise_for_status = Mock()
+    resp.json = Mock(return_value=events)
+    return resp
 
 
 class TestWidgetsClient:
@@ -186,63 +205,207 @@ class TestWidgetsClient:
         assert easyiq_response.method_calls == [call.raise_for_status(), call.json()]
 
     @pytest.mark.asyncio
-    async def test_get_easyiq_homework_uses_token_and_expected_request_shape(self, client):
-        token_response = Mock()
-        token_response.raise_for_status = Mock()
-        token_response.json = Mock(return_value={"data": "token-easy-hw"})
-
-        homework_response = Mock()
-        homework_response.raise_for_status = Mock()
-        homework_response.json = Mock(
-            return_value={
-                "data": {
-                    "homework": [
-                        {
-                            "id": "hw-1",
-                            "title": "Read chapter 5",
-                            "description": "<p>Pages 40-55</p>",
-                            "dueDate": "2026-02-28",
-                            "subject": "Danish",
-                            "isCompleted": False,
-                        }
-                    ]
-                }
-            }
+    async def test_get_easyiq_homework_reads_the_portal_calendar(self, client):
+        """Homework comes from the portal calendar; ``/homeworkinfo`` 404s."""
+        calendar = _calendar_response(
+            [
+                {
+                    "itemType": 4,
+                    "start": "2026-02-28T00:00:00",
+                    "courses": "Dansk",
+                    "activities": "Læselektie",
+                    "description": "<p>Pages 40-55</p>",
+                },
+                {
+                    "itemType": 9,
+                    "start": "2026-02-24T08:00:00",
+                    "courses": "Matematik",
+                },
+            ]
         )
-
         client._request_with_version_retry = AsyncMock(
-            side_effect=[token_response, homework_response]
+            side_effect=[_token_response("token-easy-hw"), calendar]
         )
 
         homework = await client.widgets.get_easyiq_homework(
             week="2026-W09",
-            session_uuid="session-1",
+            session_uuid="guardian-1",
             institution_filter=["inst-1", "inst-2"],
-            child_id="child-1",
+            child_id="child-user-1",
+            child_profile_id="4242",
         )
 
+        # The weekplan row of the same response is not homework.
         assert len(homework) == 1
-        assert homework[0].id == "hw-1"
-        assert homework[0].title == "Read chapter 5"
+        assert homework[0].title == "Dansk"
+        assert homework[0].subject == "Dansk"
         assert homework[0].description == "<p>Pages 40-55</p>"
-        assert homework[0].due_date == "2026-02-28"
-        assert homework[0].subject == "Danish"
+        assert homework[0].due_date == "2026-02-28T00:00:00"
         assert homework[0].is_completed is False
 
         calls = client._request_with_version_retry.await_args_list
-        assert calls[1].args == ("post", f"{EASYIQ_API}/homeworkinfo")
+        assert calls[0].args == (
+            "get",
+            f"{client.api_url}?method=aulaToken.getAulaToken&widgetId={WIDGET_EASYIQ_HOMEWORK}",
+        )
+        assert calls[1].args == ("get", EASYIQ_CALENDAR_URL)
+        assert calls[1].kwargs["params"] == {
+            "date": "2026-02-23T00:00:00Z",
+            "activityFilter": "-1",
+            "courseFilter": "-1",
+            "textFilter": "",
+            "ownWeekPlan": "false",
+            "loginId": "4242",
+        }
         assert calls[1].kwargs["headers"] == {
             "Authorization": "Bearer token-easy-hw",
-            "x-aula-institutionfilter": "inst-1,inst-2",
+            "Accept": "application/json",
+            "x-institutionfilter": "inst-1,inst-2",
+            "x-userprofile": "guardian",
+            "x-login": "guardian-1",
+            "x-requested-with": "XMLHttpRequest",
+            "Referer": f"{EASYIQ_PORTAL}/UgeplanWidget",
+            "x-child": "child-user-1",
+            "x-childfilter": "child-user-1",
         }
-        assert calls[1].kwargs["json"] == {
-            "sessionId": "session-1",
-            "currentWeekNr": "2026-W09",
-            "userProfile": "guardian",
-            "institutionFilter": ["inst-1", "inst-2"],
-            "childFilter": ["child-1"],
+
+    @pytest.mark.asyncio
+    async def test_easyiq_calendar_falls_through_to_the_accepted_identifiers(self, client):
+        """EasyIQ answers 200-with-nothing for identifiers it does not know."""
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[
+                _token_response("token-easy"),
+                _calendar_response([]),  # profile login / user child
+                _calendar_response([{"itemType": 4, "courses": "Dansk"}]),  # user login
+            ]
+        )
+
+        homework = await client.widgets.get_easyiq_homework(
+            week="2026-W09",
+            session_uuid="guardian-1",
+            institution_filter=["inst-1"],
+            child_id="child-user-1",
+            child_profile_id="4242",
+        )
+
+        assert [hw.subject for hw in homework] == ["Dansk"]
+        calls = client._request_with_version_retry.await_args_list
+        assert [c.kwargs["params"]["loginId"] for c in calls[1:]] == ["4242", "child-user-1"]
+
+    @pytest.mark.asyncio
+    async def test_easyiq_calendar_reuses_the_identifiers_that_worked(self, client):
+        """A second week must not re-probe every identifier combination."""
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[
+                _token_response("token-easy"),
+                _calendar_response([]),
+                _calendar_response([{"itemType": 4, "courses": "Dansk"}]),
+                _token_response("token-easy"),
+                _calendar_response([{"itemType": 4, "courses": "Matematik"}]),
+            ]
+        )
+        kwargs = {
+            "session_uuid": "guardian-1",
+            "institution_filter": ["inst-1"],
+            "child_id": "child-user-1",
+            "child_profile_id": "4242",
         }
-        assert homework_response.method_calls == [call.raise_for_status(), call.json()]
+
+        await client.widgets.get_easyiq_homework(week="2026-W09", **kwargs)
+        homework = await client.widgets.get_easyiq_homework(week="2026-W10", **kwargs)
+
+        assert [hw.subject for hw in homework] == ["Matematik"]
+        calls = client._request_with_version_retry.await_args_list
+        assert len(calls) == 5
+        assert calls[4].kwargs["params"]["loginId"] == "child-user-1"
+
+    @pytest.mark.asyncio
+    async def test_easyiq_calendar_raises_when_every_identifier_is_rejected(self, client):
+        rejected = Mock()
+        rejected.raise_for_status = Mock(side_effect=AulaNotFoundError("HTTP 404", 404))
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[_token_response("token-easy"), rejected, rejected, rejected, rejected]
+        )
+
+        with pytest.raises(AulaNotFoundError):
+            await client.widgets.get_easyiq_homework(
+                week="2026-W09",
+                session_uuid="guardian-1",
+                institution_filter=["inst-1"],
+                child_id="child-user-1",
+                child_profile_id="4242",
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_easyiq_weekplan_falls_back_to_the_portal_when_the_api_fails(self, client):
+        failing = Mock()
+        failing.raise_for_status = Mock(side_effect=AulaNotFoundError("HTTP 404", 404))
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[
+                _token_response("token-easy"),
+                failing,
+                _token_response("token-easy"),
+                _calendar_response(
+                    [
+                        {"itemType": 9, "courses": "Matematik", "start": "2026-02-24T08:00:00"},
+                        {"itemType": 4, "courses": "Dansk"},
+                    ]
+                ),
+            ]
+        )
+
+        appointments = await client.widgets.get_easyiq_weekplan(
+            "2026-W09",
+            "guardian-1",
+            ["inst-1"],
+            "child-user-1",
+            child_profile_id="4242",
+        )
+
+        # Homework rows in the same response stay out of the weekly plan.
+        assert [a.title for a in appointments] == ["Matematik"]
+        assert appointments[0].start == "2026-02-24T08:00:00"
+        calls = client._request_with_version_retry.await_args_list
+        assert calls[1].args == ("post", f"{EASYIQ_API}/weekplaninfo")
+        assert calls[3].args == ("get", EASYIQ_CALENDAR_URL)
+
+    @pytest.mark.asyncio
+    async def test_get_easyiq_weekplan_falls_back_when_the_api_returns_nothing(self, client):
+        """A 200 with an empty appointment list is the shape issue #45 reported."""
+        empty = Mock()
+        empty.raise_for_status = Mock()
+        empty.json = Mock(return_value={"data": {"appointments": []}})
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[
+                _token_response("token-easy"),
+                empty,
+                _token_response("token-easy"),
+                _calendar_response([{"itemType": 8, "courses": "Idræt"}]),
+            ]
+        )
+
+        appointments = await client.widgets.get_easyiq_weekplan(
+            "2026-W09",
+            "guardian-1",
+            ["inst-1"],
+            "child-user-1",
+            child_profile_id="4242",
+        )
+
+        assert [a.title for a in appointments] == ["Idræt"]
+
+    @pytest.mark.asyncio
+    async def test_get_easyiq_weekplan_raises_when_no_profile_id_to_fall_back_with(self, client):
+        failing = Mock()
+        failing.raise_for_status = Mock(side_effect=AulaNotFoundError("HTTP 404", 404))
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[_token_response("token-easy"), failing]
+        )
+
+        with pytest.raises(AulaNotFoundError):
+            await client.widgets.get_easyiq_weekplan(
+                "2026-W09", "guardian-1", ["inst-1"], "child-user-1"
+            )
 
     @pytest.mark.asyncio
     async def test_get_meebook_weekplan_uses_token_and_expected_request_shape(self, client):

--- a/tests/test_widgets_client.py
+++ b/tests/test_widgets_client.py
@@ -8,7 +8,9 @@ from aula.api_client import AulaApiClient
 from aula.const import (
     CICERO_API,
     EASYIQ_API,
+    EASYIQ_AUTHENTICATE_PATH,
     EASYIQ_CALENDAR_PATH,
+    EASYIQ_CHILDREN_PATH,
     EASYIQ_HOMEWORK_PATH,
     EASYIQ_PORTAL,
     MEEBOOK_API,
@@ -42,6 +44,14 @@ def _calendar_response(payload: object) -> Mock:
 class TestWidgetsClient:
     @pytest.fixture
     def client(self):
+        client = AulaApiClient(http_client=AsyncMock(), access_token="token")
+        # The EasyIQ portal session has its own tests below; marking it done
+        # keeps the request-shape tests free of bootstrap plumbing.
+        client.widgets._easyiq_session_ready = True
+        return client
+
+    @pytest.fixture
+    def unbootstrapped_client(self):
         return AulaApiClient(http_client=AsyncMock(), access_token="token")
 
     @pytest.mark.asyncio
@@ -263,6 +273,96 @@ class TestWidgetsClient:
             "x-child": "child-user-1",
             "x-childfilter": "child-user-1",
         }
+
+    @pytest.mark.asyncio
+    async def test_portal_session_is_established_before_any_controller(self, unbootstrapped_client):
+        """Without AuthenticateAulaUser the portal's controllers all 500."""
+        client = unbootstrapped_client
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[
+                _token_response("token-boot"),  # token for the bootstrap
+                _calendar_response(None),  # AuthenticateAulaUser
+                _calendar_response({"Children": [{"Id": "9001", "Login": "ASTR8360"}]}),
+                _token_response("token-easy-hw"),  # token for the fetch
+                _calendar_response([{"ItemType": 4, "CoursesDisplay": "Dansk"}]),
+            ]
+        )
+
+        homework = await client.widgets.get_easyiq_homework(
+            "2026-W09",
+            "guardian-1",
+            ["inst-1"],
+            "astr8360",
+            child_profile_id="4242",
+            all_child_user_ids=["astr8360", "kris37r9"],
+        )
+
+        assert [hw.subject for hw in homework] == ["Dansk"]
+        calls = client._request_with_version_retry.await_args_list
+        assert calls[1].args == ("post", f"{EASYIQ_PORTAL}{EASYIQ_AUTHENTICATE_PATH}")
+        assert calls[2].args == ("get", f"{EASYIQ_PORTAL}{EASYIQ_CHILDREN_PATH}")
+        # EasyIQ's own ID is used as loginId, matched on Login not Name, and
+        # x-childfilter carries every child while x-child carries this one.
+        assert calls[4].kwargs["params"]["loginId"] == "9001"
+        assert calls[4].kwargs["headers"]["x-child"] == "astr8360"
+        assert calls[4].kwargs["headers"]["x-childfilter"] == "astr8360,kris37r9"
+
+    @pytest.mark.asyncio
+    async def test_portal_session_runs_once_across_calls(self, unbootstrapped_client):
+        client = unbootstrapped_client
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[
+                _token_response("token-boot"),
+                _calendar_response(None),
+                _calendar_response({"Children": [{"Id": "9001", "Login": "astr8360"}]}),
+                _token_response("token-easy-hw"),
+                _calendar_response([{"ItemType": 4, "CoursesDisplay": "Dansk"}]),
+                _token_response("token-easy-hw"),
+                _calendar_response([{"ItemType": 4, "CoursesDisplay": "Matematik"}]),
+            ]
+        )
+        kwargs = {
+            "child_profile_id": "4242",
+            "all_child_user_ids": ["astr8360"],
+        }
+
+        await client.widgets.get_easyiq_homework(
+            "2026-W09", "guardian-1", ["inst-1"], "astr8360", **kwargs
+        )
+        homework = await client.widgets.get_easyiq_homework(
+            "2026-W10", "guardian-1", ["inst-1"], "astr8360", **kwargs
+        )
+
+        assert [hw.subject for hw in homework] == ["Matematik"]
+        assert client._request_with_version_retry.await_count == 7
+
+    @pytest.mark.asyncio
+    async def test_a_failed_bootstrap_leaves_the_guessing_fallback(self, unbootstrapped_client):
+        """Institutions this flow does not suit must still get the old path."""
+        client = unbootstrapped_client
+        failing = Mock()
+        failing.raise_for_status = Mock(side_effect=AulaNotFoundError("HTTP 404", 404))
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[
+                _token_response("token-boot"),
+                failing,  # AuthenticateAulaUser
+                _token_response("token-easy-hw"),
+                _calendar_response([{"ItemType": 4, "CoursesDisplay": "Dansk"}]),
+            ]
+        )
+
+        homework = await client.widgets.get_easyiq_homework(
+            "2026-W09",
+            "guardian-1",
+            ["inst-1"],
+            "astr8360",
+            child_profile_id="4242",
+            all_child_user_ids=["astr8360"],
+        )
+
+        assert [hw.subject for hw in homework] == ["Dansk"]
+        calls = client._request_with_version_retry.await_args_list
+        assert calls[3].kwargs["params"]["loginId"] == "4242"
 
     @pytest.mark.asyncio
     async def test_get_easyiq_homework_keeps_rows_of_an_unfamiliar_item_type(self, client):

--- a/tests/utils/test_easyiq_probe.py
+++ b/tests/utils/test_easyiq_probe.py
@@ -159,6 +159,9 @@ class TestProbeEasyIQ:
         client.widgets._get_bearer_token = AsyncMock(return_value="Bearer t")
         client.widgets.easyiq_headers = Mock(return_value={"Authorization": "Bearer t"})
         client.widgets.easyiq_identifier_variants = Mock(return_value=[("4242", "astr8360")])
+        client.widgets.resolve_easyiq_child_id = Mock(return_value=None)
+        # The real client owns the session; the probe only has to ask for it.
+        client.widgets.ensure_easyiq_session = AsyncMock()
         client._request_with_version_retry = AsyncMock(side_effect=responses)
         return client
 
@@ -187,6 +190,26 @@ class TestProbeEasyIQ:
         assert probe.attempts[EASYIQ_CALENDAR_PATH][0].item_types == {"9": 1}
         assert probe.attempts[EASYIQ_HOMEWORK_PATH][0].item_types == {"4": 1}
         assert probe.attempts[EASYIQ_HOMEWORK_PATH][0].keys == ["ItemType"]
+
+    @pytest.mark.asyncio
+    async def test_establishes_the_session_before_probing(self, child):
+        """A probe without the session would report nothing but 500s."""
+        client = self._client(
+            [self._resp(200, {"Children": []}), self._resp(200, []), self._resp(200, [])]
+        )
+
+        await probe_easyiq(
+            client,
+            [child],
+            "nick536a",
+            "2026-08-10T00:00:00Z",
+            ["inst-1"],
+            ["astr8360", "kris37r9"],
+        )
+
+        client.widgets.ensure_easyiq_session.assert_awaited_once_with(
+            ["inst-1"], "nick536a", ["astr8360", "kris37r9"]
+        )
 
     @pytest.mark.asyncio
     async def test_a_failing_controller_is_recorded_not_raised(self, child):

--- a/tests/utils/test_easyiq_probe.py
+++ b/tests/utils/test_easyiq_probe.py
@@ -1,0 +1,221 @@
+"""Tests for aula.utils.easyiq_probe."""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from aula.const import EASYIQ_CALENDAR_PATH, EASYIQ_HOMEWORK_PATH
+from aula.utils.easyiq_probe import (
+    Attempt,
+    ChildProbe,
+    ProbeReport,
+    _describe_rows,
+    _match_easyiq_entry,
+    probe_easyiq,
+    render_report,
+)
+
+
+class TestDescribeRows:
+    def test_bare_list(self):
+        rows, histogram, keys = _describe_rows([{"itemType": 4}, {"itemType": 9}, {"itemType": 4}])
+        assert rows == 3
+        assert histogram == {"4": 2, "9": 1}
+        assert keys == ["itemType"]
+
+    def test_wrapped_list(self):
+        rows, histogram, _ = _describe_rows({"events": [{"ItemType": 4}]})
+        assert rows == 1
+        assert histogram == {"4": 1}
+
+    def test_item_type_casing_does_not_split_the_histogram(self):
+        _, histogram, _ = _describe_rows([{"ItemType": 4}, {"itemType": 4}])
+        assert histogram == {"4": 2}
+
+    def test_keys_keep_their_original_casing(self):
+        """The casing is the finding, so it must survive into the report."""
+        _, _, keys = _describe_rows([{"ItemType": 4, "Courses": "x"}])
+        assert keys == ["ItemType", "Courses"]
+
+    def test_missing_item_type(self):
+        _, histogram, _ = _describe_rows([{"courses": "x"}])
+        assert histogram == {"missing": 1}
+
+    def test_non_list_payload(self):
+        assert _describe_rows(None) == (None, {}, [])
+
+
+class TestMatchEasyIQEntry:
+    AULA = {"institution_profile_id": "4242", "profile_id": "77", "user_id": "astr8360"}
+
+    def test_matches_by_login_and_reports_the_equal_id(self):
+        found, matches = _match_easyiq_entry(
+            [{"Id": "4242", "Login": "astr8360", "Name": "A"}], self.AULA
+        )
+        assert found is True
+        assert matches == ["institution_profile_id"]
+
+    def test_entry_with_an_id_of_its_own(self):
+        """This is the case that would break the loginId assumption."""
+        found, matches = _match_easyiq_entry(
+            [{"Id": "99999", "Login": "astr8360", "Name": "A"}], self.AULA
+        )
+        assert found is True
+        assert matches == []
+
+    def test_child_absent_from_easyiq(self):
+        found, matches = _match_easyiq_entry([{"Id": "1", "Login": "other"}], self.AULA)
+        assert found is False
+        assert matches == []
+
+    def test_no_entries(self):
+        assert _match_easyiq_entry([], self.AULA) == (False, [])
+
+
+class TestRenderReport:
+    def _report(self) -> ProbeReport:
+        return ProbeReport(
+            widgets=[("0142", "EasyIQ Lektier", "iframe")],
+            tokens={"0128": "ok", "0142": "ok"},
+            children_status=200,
+            children_count=1,
+            children_fields=["Id", "Login", "Name"],
+            children=[
+                ChildProbe(
+                    label="Child 1 of 2",
+                    easyiq_entry_found=True,
+                    easyiq_id_matches=["institution_profile_id"],
+                    attempts={
+                        EASYIQ_HOMEWORK_PATH: [
+                            Attempt(
+                                login_id_source="institution_profile_id",
+                                child_header_source="user_id",
+                                status=200,
+                                rows=3,
+                                item_types={"4": 3},
+                                keys=["ItemType", "Courses"],
+                                body=[{"Courses": "Dansk"}],
+                            )
+                        ]
+                    },
+                )
+            ],
+        )
+
+    def test_reports_the_findings(self):
+        text = "\n".join(render_report(self._report()))
+        assert "EasyIQ Lektier" in text
+        assert "EasyIQ Id equals the Aula institution_profile_id" in text
+        assert "loginId=institution_profile_id child=user_id  200  3 rows" in text
+        assert "keys: ItemType, Courses" in text
+
+    def test_leaks_no_values_by_default(self):
+        text = "\n".join(render_report(self._report()))
+        assert "Dansk" not in text
+        assert "4242" not in text
+        assert "astr8360" not in text
+        assert "No names, subjects or IDs are included" in text
+
+    def test_include_values_prints_bodies_and_warns(self):
+        text = "\n".join(render_report(self._report(), include_values=True))
+        assert "Dansk" in text
+        assert "Do not paste this publicly" in text
+
+    def test_child_not_on_easyiq(self):
+        report = self._report()
+        report.children[0].easyiq_entry_found = False
+        assert "likely not an EasyIQ institution" in "\n".join(render_report(report))
+
+    def test_error_is_shown(self):
+        report = self._report()
+        report.children[0].attempts[EASYIQ_HOMEWORK_PATH][0].error = "AulaServerError: HTTP 500"
+        assert "AulaServerError: HTTP 500" in "\n".join(render_report(report))
+
+
+class TestProbeEasyIQ:
+    @pytest.fixture
+    def child(self):
+        child = Mock()
+        child.id = 4242
+        child.profile_id = 77
+        child._raw = {"userId": "astr8360"}
+        return child
+
+    def _widget(self, widget_id, name, widget_type, supplier):
+        # ``name`` is reserved by Mock's constructor, so it has to be set after.
+        widget = Mock(widget_id=widget_id, widget_type=widget_type, widget_supplier=supplier)
+        widget.name = name
+        return widget
+
+    def _client(self, responses):
+        client = Mock()
+        client.get_widgets = AsyncMock(
+            return_value=[
+                self._widget("0142", "EasyIQ Lektier", "iframe", "EasyIQ"),
+                self._widget("0019", "Biblioteket", "secure", "Systematic"),
+            ]
+        )
+        client.widgets = Mock()
+        client.widgets._get_bearer_token = AsyncMock(return_value="Bearer t")
+        client.widgets.easyiq_headers = Mock(return_value={"Authorization": "Bearer t"})
+        client.widgets.easyiq_identifier_variants = Mock(return_value=[("4242", "astr8360")])
+        client._request_with_version_retry = AsyncMock(side_effect=responses)
+        return client
+
+    def _resp(self, status, payload):
+        resp = Mock()
+        resp.status_code = status
+        resp.json = Mock(return_value=payload)
+        return resp
+
+    @pytest.mark.asyncio
+    async def test_probes_both_controllers_and_keeps_only_easyiq_widgets(self, child):
+        client = self._client(
+            [
+                self._resp(200, {"Children": [{"Id": "4242", "Login": "astr8360"}]}),
+                self._resp(200, [{"itemType": 9}]),
+                self._resp(200, [{"ItemType": 4}]),
+            ]
+        )
+
+        report = await probe_easyiq(client, [child], "nick536a", "2026-08-10T00:00:00Z")
+
+        assert report.widgets == [("0142", "EasyIQ Lektier", "iframe")]
+        assert report.children_count == 1
+        probe = report.children[0]
+        assert probe.easyiq_id_matches == ["institution_profile_id"]
+        assert probe.attempts[EASYIQ_CALENDAR_PATH][0].item_types == {"9": 1}
+        assert probe.attempts[EASYIQ_HOMEWORK_PATH][0].item_types == {"4": 1}
+        assert probe.attempts[EASYIQ_HOMEWORK_PATH][0].keys == ["ItemType"]
+
+    @pytest.mark.asyncio
+    async def test_a_failing_controller_is_recorded_not_raised(self, child):
+        client = self._client(
+            [
+                self._resp(200, {"Children": []}),
+                Exception("boom"),
+                self._resp(200, []),
+            ]
+        )
+
+        report = await probe_easyiq(client, [child], "nick536a", "2026-08-10T00:00:00Z")
+
+        assert "boom" in report.children[0].attempts[EASYIQ_CALENDAR_PATH][0].error
+        assert report.children[0].attempts[EASYIQ_HOMEWORK_PATH][0].status == 200
+
+    @pytest.mark.asyncio
+    async def test_bodies_are_only_captured_when_asked_for(self, child):
+        responses = [
+            self._resp(200, {"Children": []}),
+            self._resp(200, [{"a": 1}]),
+            self._resp(200, []),
+        ]
+        client = self._client(list(responses))
+        report = await probe_easyiq(client, [child], "nick536a", "2026-08-10T00:00:00Z")
+        assert report.children[0].attempts[EASYIQ_CALENDAR_PATH][0].body is None
+
+        client = self._client(list(responses))
+        report = await probe_easyiq(
+            client, [child], "nick536a", "2026-08-10T00:00:00Z", include_values=True
+        )
+        assert report.children[0].attempts[EASYIQ_CALENDAR_PATH][0].body == [{"a": 1}]


### PR DESCRIPTION
Fixes #45.

## What was wrong

`easyiq:homework` returned an empty array because EasyIQ removed the endpoint it called. I checked the routes directly:

| Endpoint | Status |
| --- | --- |
| `POST api.easyiqcloud.dk/api/aula/homeworkinfo` | 404, the route is gone |
| `POST api.easyiqcloud.dk/api/aula/weekplaninfo` | 500, the route still exists |
| `GET skoleportal.easyiqcloud.dk/Calendar/CalendarGetWeekplanEvents` | 403, exists behind auth |

So the reporter was right about homework. Ugeplan was a separate problem: `get_easyiq_weekplan` asked for a token for widget `0001`, but the EasyIQ weekplan widget is `0128`. That ID was already in `const.py` and never used.

On top of both, the `--output json` paths for these two commands did `except Exception: continue`, so a 404 came back as `[]` with no message at all.

## What this changes

**Homework now reads the portal calendar.** New `get_easyiq_calendar_events` fetches a child's whole week in one request from `CalendarGetWeekplanEvents`. Rows are split by `itemType`: 4 is homework, 8 and 9 are the weekly plan.

EasyIQ accepts different Aula identifiers for `loginId` and the child headers depending on the institution, and it answers 200 with an empty body for the ones it does not recognise. The client tries the four known combinations in order, keeps the first that returns rows, and caches it per child so later weeks cost one request. A cached pair that stops working costs one wasted request before the others are tried again.

**Weekplan uses widget 0128.** It still calls `weekplaninfo` first, because that route works for some accounts. If the call fails or comes back empty, it falls back to the portal calendar. The fallback needs the child's institution profile ID, so it is skipped when a caller cannot pass one. The deprecated `AulaApiClient.get_easyiq_weekplan` wrapper keeps its old behaviour.

**Errors are visible again.** The two silent `continue` blocks now report the failure. `print_error` gained an `err=True` option so the message goes to stderr and does not end up inside the JSON document.

**Presence 400 (also reported in the issue).** `get_presence_registrations` sent every child in one request, and Aula rejects the whole batch if any one profile cannot be queried. It now retries per profile after a failure, returns what it can, and warns about the profiles it skipped. It only raises when no profile is readable. A single-profile request is not retried. This helps whether or not my reading of the cause (daycare children have presence, school children do not) is correct, because it isolates the failing profile either way.

## Testing

523 tests pass. ruff and ty are clean. New tests cover the portal request shape, the identifier fall-through and its cache, the all-rejected error path, both weekplan fallback triggers, the presence retry and when it raises, and the new `EasyIQCalendarEvent` model.

### Verified against a live Aula session

I ran both commands against a real logged in account:

- `CalendarGetWeekplanEvents` returned HTTP 200 and a valid JSON array on the first identifier combination (`loginId` = institution profile ID, `x-child` = Aula user ID). The other three returned 500. So the request shape, headers, and widget token are right, and the combination tried first is the one EasyIQ accepts.
- Aula issued a valid `0142` widget token even though that account does not have the EasyIQ widget, so the token step is not a blocker.
- The weekplan fallback fired as intended: `weekplaninfo` answered 200 with nothing, and the code fell through to the portal.
- The presence retry ran: the batch 400ed, both children were retried one at a time, both 400ed, so it raised. Both children are at the same school with no presence module, so there was nothing to salvage.

The array came back empty because that account is on MinUddannelse, not EasyIQ. Whether a real EasyIQ school returns rows is the one thing still unchecked. @dinf60 offered to test, so that is the check this needs before merge.
