### PR TITLE
fix: read vacation registrations from the by-children endpoint

### DIFF
--- a/src/aula/api_client.py
+++ b/src/aula/api_client.py
@@ -2017,13 +2017,20 @@ class AulaApiClient:
                 _LOGGER.warning("Skipping common file due to parsing error: %s", e)
         return result
 
-    async def get_vacation_registrations(
-        self, institution_profile_ids: list[int]
-    ) -> list[VacationRegistration]:
-        """Fetch vacation registrations for the given institution profile IDs."""
+    async def get_vacation_registrations(self, child_ids: list[int]) -> list[VacationRegistration]:
+        """Fetch vacation registrations for the given children.
+
+        Args:
+            child_ids: Institution profile IDs of the children (`Child.id`). Passing
+                a guardian's own institution profile ID, or a child's user profile
+                ID, makes Aula reject the request.
+
+        Aula groups the response by child; the rows are flattened into a single
+        list with the child carried on each registration.
+        """
         params: dict[str, Any] = {
-            "method": "presence.getVacationRegistrations",
-            "institutionProfileIds[]": institution_profile_ids,
+            "method": "presence.getVacationRegistrationsByChildren",
+            "childIds[]": child_ids,
         }
         resp = await self._request_with_version_retry("get", self.api_url, params=params)
         resp.raise_for_status()
@@ -2031,13 +2038,21 @@ class AulaApiClient:
         if not isinstance(data, list):
             return []
         result: list[VacationRegistration] = []
-        for item in data:
-            if not isinstance(item, dict):
+        for group in data:
+            if not isinstance(group, dict):
                 continue
-            try:
-                result.append(VacationRegistration.from_dict(item))
-            except (TypeError, ValueError, KeyError) as e:
-                _LOGGER.warning("Skipping vacation registration due to parsing error: %s", e)
+            child = group.get("child")
+            child = child if isinstance(child, dict) else {}
+            registrations = group.get("vacationRegistrations")
+            if not isinstance(registrations, list):
+                continue
+            for item in registrations:
+                if not isinstance(item, dict):
+                    continue
+                try:
+                    result.append(VacationRegistration.from_dict(item, child))
+                except (TypeError, ValueError, KeyError) as e:
+                    _LOGGER.warning("Skipping vacation registration due to parsing error: %s", e)
         return result
 
     async def get_notification_settings(self) -> list[NotificationSetting]:

--- a/src/aula/cli.py
+++ b/src/aula/cli.py
@@ -1462,8 +1462,13 @@ async def vacations(ctx):
             print_error(f"fetching profile: {e}")
             return
 
+        child_ids = [c.id for c in prof.children]
+        if not child_ids:
+            print_error("no children on this profile to look up vacation registrations for")
+            return
+
         try:
-            result = await client.get_vacation_registrations(prof.institution_profile_ids)
+            result = await client.get_vacation_registrations(child_ids)
         except Exception as e:
             print_error(f"fetching vacations: {e}")
             return
@@ -1478,11 +1483,11 @@ async def vacations(ctx):
         print_heading("Vacation Registrations")
         for v in result:
             parts = []
-            if v.vacation_type:
-                parts.append(v.vacation_type)
-            if v.status:
-                parts.append(f"[{v.status}]")
-            click.echo(format_row(v.child_name or f"Profile {v.institution_profile_id}", *parts))
+            if v.title:
+                parts.append(v.title)
+            if v.is_missing_answer:
+                parts.append("[missing answer]")
+            click.echo(format_row(v.child_name or f"Child {v.child_id}", *parts))
             dates = []
             if v.start_date:
                 dates.append(f"From: {v.start_date}")
@@ -1490,6 +1495,10 @@ async def vacations(ctx):
                 dates.append(f"To: {v.end_date}")
             if dates:
                 click.echo(f"  {' | '.join(dates)}")
+            if v.response_deadline:
+                click.echo(f"  Answer by: {v.response_deadline}")
+            if v.note_to_guardian:
+                click.echo(f"  Note: {v.note_to_guardian}")
 
 
 @cli.command("notification-settings")

--- a/src/aula/models/vacation_registration.py
+++ b/src/aula/models/vacation_registration.py
@@ -6,24 +6,44 @@ from .base import AulaDataClass
 
 @dataclass
 class VacationRegistration(AulaDataClass):
+    """A vacation registration the institution asks a guardian to answer.
+
+    Aula returns these grouped by child from
+    `presence.getVacationRegistrationsByChildren`. Each row is flattened here so
+    the child it belongs to travels with the registration.
+    """
+
     id: int
+    child_id: int = 0
     child_name: str = ""
-    institution_profile_id: int = 0
+    title: str = ""
     start_date: str | None = None
     end_date: str | None = None
-    status: str = ""
-    vacation_type: str = ""
+    response_id: int = 0
+    response_deadline: str | None = None
+    note_to_guardian: str = ""
+    is_editable: bool = False
+    is_missing_answer: bool = False
+    is_presence_times_required: bool = False
     _raw: dict | None = field(default=None, repr=False)
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> VacationRegistration:
+    def from_dict(
+        cls, data: dict[str, Any], child: dict[str, Any] | None = None
+    ) -> VacationRegistration:
+        child = child or {}
         return cls(
             _raw=data,
-            id=data.get("id", 0),
-            child_name=data.get("childName", "") or data.get("name", ""),
-            institution_profile_id=data.get("institutionProfileId", 0),
-            start_date=data.get("startDate") or data.get("fromDate"),
-            end_date=data.get("endDate") or data.get("toDate"),
-            status=data.get("status", ""),
-            vacation_type=data.get("vacationType", "") or data.get("type", ""),
+            id=data.get("vacationRegistrationId", 0),
+            child_id=child.get("id", 0),
+            child_name=child.get("name", ""),
+            title=data.get("title", ""),
+            start_date=data.get("startDate"),
+            end_date=data.get("endDate"),
+            response_id=data.get("responseId", 0),
+            response_deadline=data.get("responseDeadline"),
+            note_to_guardian=data.get("noteToGuardian", "") or "",
+            is_editable=data.get("isEditable", False),
+            is_missing_answer=data.get("isMissingAnswer", False),
+            is_presence_times_required=data.get("isPresenceTimesRequired", False),
         )

--- a/tests/models/test_vacation_registration.py
+++ b/tests/models/test_vacation_registration.py
@@ -1,0 +1,59 @@
+"""Tests for aula.models.vacation_registration."""
+
+from aula.models.vacation_registration import VacationRegistration
+
+
+class TestVacationRegistration:
+    def test_from_dict_full(self):
+        data = {
+            "vacationRegistrationId": 9911,
+            "title": "Sommerferie",
+            "startDate": "2026-07-01",
+            "endDate": "2026-07-14",
+            "responseId": 4455,
+            "responseDeadline": "2026-06-01",
+            "noteToGuardian": "Husk at svare",
+            "isEditable": True,
+            "isMissingAnswer": True,
+            "isPresenceTimesRequired": True,
+        }
+        child = {"id": 4727534, "name": "Anna", "institutionCode": "G19736", "metadata": "0.A"}
+
+        reg = VacationRegistration.from_dict(data, child)
+
+        assert reg.id == 9911
+        assert reg.child_id == 4727534
+        assert reg.child_name == "Anna"
+        assert reg.title == "Sommerferie"
+        assert reg.start_date == "2026-07-01"
+        assert reg.end_date == "2026-07-14"
+        assert reg.response_id == 4455
+        assert reg.response_deadline == "2026-06-01"
+        assert reg.note_to_guardian == "Husk at svare"
+        assert reg.is_editable is True
+        assert reg.is_missing_answer is True
+        assert reg.is_presence_times_required is True
+        assert reg._raw is data
+
+    def test_from_dict_minimal(self):
+        reg = VacationRegistration.from_dict({})
+
+        assert reg.id == 0
+        assert reg.child_id == 0
+        assert reg.child_name == ""
+        assert reg.start_date is None
+        assert reg.end_date is None
+        assert reg.response_deadline is None
+        assert reg.is_missing_answer is False
+
+    def test_from_dict_without_child(self):
+        reg = VacationRegistration.from_dict({"vacationRegistrationId": 7})
+
+        assert reg.id == 7
+        assert reg.child_id == 0
+        assert reg.child_name == ""
+
+    def test_from_dict_null_note_becomes_empty_string(self):
+        reg = VacationRegistration.from_dict({"noteToGuardian": None})
+
+        assert reg.note_to_guardian == ""

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1951,6 +1951,114 @@ class TestGetPresenceConfiguration:
         assert result == []
 
 
+class TestGetVacationRegistrations:
+    """Tests for AulaApiClient.get_vacation_registrations method."""
+
+    @pytest.fixture
+    def client(self):
+        http_client = AsyncMock()
+        return AulaApiClient(http_client=http_client, access_token="test_token")
+
+    @pytest.mark.asyncio
+    async def test_happy_path_flattens_groups(self, client):
+        response_data = {
+            "data": [
+                {
+                    "child": {"id": 201, "name": "Anna"},
+                    "vacationRegistrations": [
+                        {
+                            "vacationRegistrationId": 1,
+                            "title": "Sommerferie",
+                            "startDate": "2026-07-01",
+                            "endDate": "2026-07-14",
+                        },
+                        {"vacationRegistrationId": 2, "title": "Efterårsferie"},
+                    ],
+                },
+                {
+                    "child": {"id": 202, "name": "Bo"},
+                    "vacationRegistrations": [{"vacationRegistrationId": 3, "title": "Juleferie"}],
+                },
+            ]
+        }
+        client._request_with_version_retry = AsyncMock(
+            return_value=HttpResponse(status_code=200, data=response_data)
+        )
+
+        result = await client.get_vacation_registrations([201, 202])
+
+        assert [r.id for r in result] == [1, 2, 3]
+        assert [r.child_id for r in result] == [201, 201, 202]
+        assert [r.child_name for r in result] == ["Anna", "Anna", "Bo"]
+        assert result[0].start_date == "2026-07-01"
+
+    @pytest.mark.asyncio
+    async def test_sends_child_ids_to_by_children_method(self, client):
+        client._request_with_version_retry = AsyncMock(
+            return_value=HttpResponse(status_code=200, data={"data": []})
+        )
+
+        await client.get_vacation_registrations([201, 202])
+
+        _, kwargs = client._request_with_version_retry.call_args
+        assert kwargs["params"] == {
+            "method": "presence.getVacationRegistrationsByChildren",
+            "childIds[]": [201, 202],
+        }
+
+    @pytest.mark.asyncio
+    async def test_empty_data(self, client):
+        client._request_with_version_retry = AsyncMock(
+            return_value=HttpResponse(status_code=200, data={"data": []})
+        )
+
+        assert await client.get_vacation_registrations([201]) == []
+
+    @pytest.mark.asyncio
+    async def test_skips_groups_without_registrations(self, client):
+        response_data = {
+            "data": [
+                {"child": {"id": 201, "name": "Anna"}},
+                {"child": {"id": 202, "name": "Bo"}, "vacationRegistrations": None},
+                "not-a-group",
+                {
+                    "child": {"id": 203, "name": "Cille"},
+                    "vacationRegistrations": [{"vacationRegistrationId": 5}, "not-a-row"],
+                },
+            ]
+        }
+        client._request_with_version_retry = AsyncMock(
+            return_value=HttpResponse(status_code=200, data=response_data)
+        )
+
+        result = await client.get_vacation_registrations([201, 202, 203])
+
+        assert [r.id for r in result] == [5]
+        assert result[0].child_name == "Cille"
+
+    @pytest.mark.asyncio
+    async def test_group_without_child_still_parses(self, client):
+        response_data = {
+            "data": [{"vacationRegistrations": [{"vacationRegistrationId": 9, "title": "Ferie"}]}]
+        }
+        client._request_with_version_retry = AsyncMock(
+            return_value=HttpResponse(status_code=200, data=response_data)
+        )
+
+        result = await client.get_vacation_registrations([201])
+
+        assert result[0].id == 9
+        assert result[0].child_id == 0
+
+    @pytest.mark.asyncio
+    async def test_non_list_data(self, client):
+        client._request_with_version_retry = AsyncMock(
+            return_value=HttpResponse(status_code=200, data={"data": None})
+        )
+
+        assert await client.get_vacation_registrations([201]) == []
+
+
 class TestGetActivityOverview:
     """Tests for AulaApiClient.get_activity_overview method."""
 


### PR DESCRIPTION
Fixes #47.

## What was wrong

`presence.getVacationRegistrations` is not the guardian endpoint. It is the **employee** vacation overview, and the decompiled app spells out its parameters:

```csharp
public class ComeGoGetVacationRegistrationOverviewRequestDto
{
    public long DepartmentId { get; set; }
    public List<long> FilterGroups { get; set; }
    public string[] StatusFilters { get; set; }
    public int Offset { get; set; }
    public int Limit { get; set; }
}
```

We sent `institutionProfileIds[]`, which is none of those. That is why every ID combination in the issue came back 400 with `status.code` 40. The method existed, so it did not 404, but no required parameter was ever present.

## The guardian endpoint

Three independent sources agree, so this was not guesswork:

| Source | Evidence |
| --- | --- |
| Aula web bundle, `src/store/modules/presence.js` | `get('?method=presence.getVacationRegistrationsByChildren', { params })` |
| Aula web bundle, `src/components/presence/VacationRegistrations.vue` | `loadVacationRegistrations({ childIds: this.activeChildren })` |
| Decompiled app, `ComeGoService.cs` | `GetVacationRegistrationsByChildren(long[] childIds)` |

`childIds` are the children's **institution profile IDs**. The app calls them `UniStudentId`, and it maps that straight onto an institution profile ID (`ChildStatus.cs:21`, `CreatePickupResponsibleFormPageViewModel.cs:23`). That is our `Child.id`, not `Child.profile_id`.

## Response shape

Aula groups the rows by child rather than returning a flat list. `VacationRegistrationsByChildrenDto` and the frontend's `vacationRegistration.ts` give the same field set:

```
[{ child: { id, name, institutionCode, metadata },
   vacationRegistrations: [{ vacationRegistrationId, startDate, endDate, title,
                             noteToGuardian, responseId, responseDeadline,
                             isEditable, isMissingAnswer, isPresenceTimesRequired }] }]
```

The old `VacationRegistration` model was built for a shape Aula never sent. It looked for `id`, `status`, `vacationType` and `childName`, none of which exist here.

## What this changes

- `get_vacation_registrations` calls `presence.getVacationRegistrationsByChildren` with `childIds[]` and takes child IDs rather than a mixed list of institution profile IDs.
- The grouped response is flattened into one list, with the child carried on each registration, so the CLI keeps printing a row per registration.
- `VacationRegistration` now matches the real fields. `title`, `response_deadline` and `note_to_guardian` are printed, and a registration awaiting an answer is marked.
- The CLI passes `[c.id for c in prof.children]` instead of `prof.institution_profile_ids`, which had the guardian's own profile in it, and reports it when the profile has no children.

## Testing

565 tests pass. ruff and ty are clean. New tests cover the request shape, the group flattening, groups with no registrations, a group with no child, and the model fields.

### Verified against a live Aula session

| Request | Result |
| --- | --- |
| `getVacationRegistrationsByChildren`, `childIds[]` = children's institution profile IDs | **HTTP 200, `status.code` 0** |
| `getVacationRegistrationsByChildren`, `childIds[]` = children's user profile IDs | HTTP 403 |
| `getVacationRegistrations`, `institutionProfileIds[]` | HTTP 400, code 40 (the bug) |

The 403 on profile IDs is the useful half of that: Aula validated the IDs and rejected the wrong kind, which confirms `childIds` means institution profile IDs.

`aula vacations` now exits cleanly instead of `Error: fetching vacations: HTTP 400`.

## What is still unverified

My account has no vacation registrations, so the array came back empty and I could not see a parsed row. The field names come from the C# DTO, the TypeScript model and the Vue template independently, so I am reasonably confident, but an account with a pending vacation request would confirm the rendering.

## Follow-up, not in this PR

`presence.getVacationAnnouncementsByChildren` takes the same `childIds` and also answered 200 on my account. It is the sibling tab in Aula's UI and would be worth a command of its own.