### PR TITLE
fix: say which child an EasyIQ row belongs to, and keep its class

### DIFF
--- a/src/aula/cli.py
+++ b/src/aula/cli.py
@@ -24,7 +24,7 @@ from .const import (
     WIDGET_MIN_UDDANNELSE_TASKS,
     WIDGET_MIN_UDDANNELSE_UGEPLAN,
 )
-from .models import DailyOverview, Group, Message, MessageThread, Notification, Profile
+from .models import Child, DailyOverview, Group, Message, MessageThread, Notification, Profile
 from .token_storage import FileTokenStorage
 from .utils.json import to_json
 from .utils.output import (
@@ -424,6 +424,17 @@ async def _get_widget_context(
         return None
 
     return child_filter, institution_filter, session_uuid
+
+
+def _with_child(row: dict, child: Child) -> dict:
+    """Tag a provider row with the child it was fetched for.
+
+    Providers that answer per child return bare rows, so a combined JSON
+    listing would otherwise give no way to tell whose row is whose. The text
+    output already prints the child, so this keeps the two output modes
+    saying the same thing.
+    """
+    return {**row, "child_id": child.id, "child_name": child.name}
 
 
 def _easyiq_child_user_ids(profile_context: dict) -> list[str]:
@@ -1890,7 +1901,7 @@ async def easyiq_ugeplan(ctx, week):
                         child_profile_id=str(child.id),
                         all_child_user_ids=all_child_user_ids,
                     )
-                    all_appointments.extend(dict(a) for a in appointments)
+                    all_appointments.extend(_with_child(dict(a), child) for a in appointments)
                 except Exception as e:
                     print_error(f"fetching EasyIQ weekplan for {child.name}: {e}", err=True)
                     continue
@@ -1924,6 +1935,7 @@ async def easyiq_ugeplan(ctx, week):
                     title=appt.title,
                     properties=[
                         ("Child", child.name),
+                        ("Class", appt.activities),
                         ("Start", appt.start),
                         ("End", appt.end),
                     ],
@@ -1998,7 +2010,7 @@ async def easyiq_homework(ctx, week):
                         child_profile_id=str(child.id),
                         all_child_user_ids=all_child_user_ids,
                     )
-                    all_homework.extend(dict(hw) for hw in homework)
+                    all_homework.extend(_with_child(dict(hw), child) for hw in homework)
                 except Exception as e:
                     print_error(f"fetching EasyIQ homework for {child.name}: {e}", err=True)
                     continue
@@ -2033,6 +2045,7 @@ async def easyiq_homework(ctx, week):
                     title=hw.title,
                     properties=[
                         ("Child", child.name),
+                        ("Class", hw.activities),
                         ("Status", status),
                         ("Subject", hw.subject),
                         ("Due", hw.due_date),
@@ -2910,7 +2923,7 @@ async def weekly_summary(ctx, child, week, providers):
                 if not appointments:
                     continue
 
-                easyiq_appointments.extend(dict(a) for a in appointments)
+                easyiq_appointments.extend(_with_child(dict(a), c) for a in appointments)
 
                 if not is_json:
                     if not easyiq_any:
@@ -2964,7 +2977,7 @@ async def weekly_summary(ctx, child, week, providers):
                 if not homework:
                     continue
 
-                easyiq_hw_items.extend(dict(hw) for hw in homework)
+                easyiq_hw_items.extend(_with_child(dict(hw), c) for hw in homework)
 
                 if not is_json:
                     if not easyiq_hw_any:

--- a/src/aula/models/appointment.py
+++ b/src/aula/models/appointment.py
@@ -11,6 +11,9 @@ class Appointment(AulaDataClass):
     start: str = ""
     end: str = ""
     description: str = ""
+    #: EasyIQ's ``ActivitiesDisplay``: the class or team the lesson belongs
+    #: to, e.g. "6A". Empty for sources that do not carry one.
+    activities: str = ""
     item_type: int | None = None
     _raw: dict | None = field(default=None, repr=False)
 

--- a/src/aula/models/easyiq_homework.py
+++ b/src/aula/models/easyiq_homework.py
@@ -12,6 +12,9 @@ class EasyIQHomework(AulaDataClass):
     description: str = ""
     due_date: str = ""
     subject: str = ""
+    #: EasyIQ's ``ActivitiesDisplay``, which on homework rows holds the class
+    #: or team the assignment was set for, e.g. "6A" or "7-9F".
+    activities: str = ""
     is_completed: bool = False
     _raw: dict | None = field(default=None, repr=False)
 
@@ -42,5 +45,6 @@ class EasyIQHomework(AulaDataClass):
             description=event.description,
             due_date=event.start,
             subject=event.courses,
+            activities=event.activities,
             is_completed=False,
         )

--- a/src/aula/widgets/client.py
+++ b/src/aula/widgets/client.py
@@ -502,6 +502,7 @@ class AulaWidgetsClient:
                 start=event.start,
                 end=event.end,
                 description=event.description,
+                activities=event.activities,
                 item_type=event.item_type,
             )
             for event in events

--- a/tests/models/test_easyiq_homework.py
+++ b/tests/models/test_easyiq_homework.py
@@ -58,6 +58,16 @@ def test_easyiq_homework_from_calendar_event():
     assert hw._raw is raw
 
 
+def test_easyiq_homework_keeps_the_class():
+    """ActivitiesDisplay says which class the homework was set for."""
+    event = EasyIQCalendarEvent.from_dict(
+        {"ItemType": 4, "CoursesDisplay": "Dansk", "ActivitiesDisplay": "7-9F"}
+    )
+    hw = EasyIQHomework.from_calendar_event(event)
+    assert hw.activities == "7-9F"
+    assert dict(hw)["activities"] == "7-9F"
+
+
 def test_easyiq_homework_from_calendar_event_without_an_id():
     """Portal rows carry no assignment id, so the start timestamp stands in."""
     event = EasyIQCalendarEvent.from_dict({"itemType": 4, "start": "2026-02-28T00:00:00"})

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,9 @@ from aula.cli import (
     _print_otp_code,
     _require_widget,
     _token_digits_provider,
+    _with_child,
 )
+from aula.models import Child, EasyIQHomework
 
 
 def _pager(total: int):
@@ -95,6 +97,37 @@ class TestWidgetAvailability:
     async def test_require_widget_is_quiet_when_present(self, capsys):
         assert await _require_widget(self._client(["0019"]), "0019", "Biblioteket") is True
         assert capsys.readouterr().out == ""
+
+
+class TestWithChild:
+    """Providers that answer per child return rows with no child on them."""
+
+    def _child(self):
+        return Child(
+            id=4727534,
+            profile_id=2044021,
+            name="Astrid",
+            institution_name="Skole",
+            profile_picture="",
+        )
+
+    def test_tags_a_row_with_the_child_it_was_fetched_for(self):
+        row = dict(EasyIQHomework(id="hw-1", title="Dansk", subject="Dansk"))
+        tagged = _with_child(row, self._child())
+        assert tagged["child_id"] == 4727534
+        assert tagged["child_name"] == "Astrid"
+
+    def test_keeps_the_row_intact(self):
+        row = dict(EasyIQHomework(id="hw-1", title="Dansk", subject="Dansk", activities="7-9F"))
+        tagged = _with_child(row, self._child())
+        assert tagged["id"] == "hw-1"
+        assert tagged["subject"] == "Dansk"
+        assert tagged["activities"] == "7-9F"
+
+    def test_does_not_mutate_the_row(self):
+        row = dict(EasyIQHomework(id="hw-1", title="Dansk"))
+        _with_child(row, self._child())
+        assert "child_id" not in row
 
 
 class TestFetchContactPages:

--- a/tests/test_widgets_client.py
+++ b/tests/test_widgets_client.py
@@ -480,7 +480,12 @@ class TestWidgetsClient:
                 _token_response("token-easy"),
                 _calendar_response(
                     [
-                        {"itemType": 9, "courses": "Matematik", "start": "2026-02-24T08:00:00"},
+                        {
+                            "itemType": 9,
+                            "courses": "Matematik",
+                            "activitiesDisplay": "6A",
+                            "start": "2026-02-24T08:00:00",
+                        },
                         {"itemType": 4, "courses": "Dansk"},
                     ]
                 ),
@@ -498,6 +503,8 @@ class TestWidgetsClient:
         # Homework rows in the same response stay out of the weekly plan.
         assert [a.title for a in appointments] == ["Matematik"]
         assert appointments[0].start == "2026-02-24T08:00:00"
+        # The class survives the mapping to Appointment.
+        assert appointments[0].activities == "6A"
         calls = client._request_with_version_retry.await_args_list
         assert calls[1].args == ("post", f"{EASYIQ_API}/weekplaninfo")
         assert calls[3].args == ("get", EASYIQ_CALENDAR_URL)


### PR DESCRIPTION
Follow-up to #46, from https://github.com/nickknissen/aula/pull/46#issuecomment-5264098198.

## The child was missing from JSON only

`easyiq:homework` and `easyiq:ugeplan` call the portal once per child, so the client knows whose rows it has. The JSON path threw that away and returned a flat list of bare rows:

```json
[{"id": "17363414", "subject": "Engelsk", "due_date": "2026-08-18T08:00:00", ...}]
```

With two school children there was no way to tell which child a row belonged to. The text output was already printing `Child:` for both commands, so the same command answered the question in one output mode and not the other.

Each row now carries `child_id` and `child_name`. The rows stay a flat array rather than being grouped under a child object, so this is additive and does not break anything already reading the output.

## The class was dropped at the mapping boundary

`ActivitiesDisplay` holds the class the row belongs to, for example `6A` or `7-9F`. It was already being parsed into `EasyIQCalendarEvent.activities`, but neither `EasyIQHomework` nor `Appointment` had a field for it, so it was lost when the calendar event was mapped to either one.

Both models now keep it as `activities`, matching EasyIQ's own naming rather than inventing `class_name`, since the same field carries lesson and team names in other contexts. The text output shows it as `Class`.

`weekly-summary` gets the same treatment for its EasyIQ sections.

## Testing

569 tests pass, ruff and ty clean. New tests cover the child tagging, that it leaves the row otherwise intact and unmutated, that homework keeps the class, and that the class survives the mapping to `Appointment`.

I have no EasyIQ data on my account, so the shape of the output is covered by tests rather than observed. @dinf60 can confirm the rows now split by child.