### PR TITLE
fix: follow the redirect to /loginoption during MitID completion

### DIFF
--- a/src/aula/auth/mitid_client.py
+++ b/src/aula/auth/mitid_client.py
@@ -421,7 +421,13 @@ class MitIDAuthClient:
                 "SessionStorageActiveChallenge": challenge,
             }
 
-            response = await self._client.post(f"{MITID_BASE_URL}/login/mitid", data=params)
+            # The shared client runs with follow_redirects=False, but users with more
+            # than one MitID identity are answered with 302 -> /loginoption here.
+            # Without following it, response.url stays on /login/mitid, the check
+            # below never fires, and we parse SAML out of an empty redirect body.
+            response = await self._client.post(
+                f"{MITID_BASE_URL}/login/mitid", data=params, follow_redirects=True
+            )
 
             if str(response.url).endswith("/loginoption"):
                 _LOGGER.info("Multiple identities detected, handling identity selection")
@@ -495,7 +501,8 @@ class MitIDAuthClient:
             form_data["SessionStorageActiveChallenge"] = challenge
 
         login_option_url = str(response.url)
-        result = await self._client.post(login_option_url, data=form_data)
+        # Submitting the choice redirects on to the page carrying the SAML form.
+        result = await self._client.post(login_option_url, data=form_data, follow_redirects=True)
         return BeautifulSoup(result.text, features="html.parser")
 
     async def _step5_saml_broker_flow(self, saml_data: dict[str, str]) -> dict[str, str]:

--- a/tests/auth/test_mitid_client_loginoption.py
+++ b/tests/auth/test_mitid_client_loginoption.py
@@ -94,6 +94,28 @@ class TestStep4CompleteMitIDFlow:
         assert "GET /loginoption" in backend.paths
 
     @pytest.mark.asyncio
+    async def test_identity_choice_redirect_is_followed(self):
+        """Submitting the choice can answer 302, with the SAML form on the target."""
+
+        class RedirectAfterChoice(FakeNemLogIn):
+            async def __call__(self, request: httpx.Request) -> httpx.Response:
+                if request.method == "POST" and request.url.path == "/loginoption":
+                    self.paths.append(f"{request.method} {request.url.path}")
+                    return httpx.Response(302, headers={"Location": f"{MITID}/login/saml"})
+                if request.url.path == "/login/saml":
+                    self.paths.append(f"{request.method} {request.url.path}")
+                    return httpx.Response(200, text=SAML_FORM)
+                return await super().__call__(request)
+
+        backend = RedirectAfterChoice(identities=2)
+        client = _client(backend)
+
+        result = await client._step4_complete_mitid_flow("verify-token", "auth-code")
+
+        assert result == {"relay_state": "relay-123", "saml_response": "saml-abc"}
+        assert "GET /login/saml" in backend.paths
+
+    @pytest.mark.asyncio
     async def test_reports_missing_saml_data(self):
         class NoSaml(FakeNemLogIn):
             async def __call__(self, request: httpx.Request) -> httpx.Response:

--- a/tests/auth/test_mitid_client_loginoption.py
+++ b/tests/auth/test_mitid_client_loginoption.py
@@ -1,0 +1,105 @@
+"""Tests for aula.auth.mitid_client step 4 — the identity selection detour.
+
+A user with a single MitID identity gets the SAML form straight back from
+POST /login/mitid. A user with more than one is redirected to /loginoption
+first, and has to pick one before the SAML form is produced.
+"""
+
+import httpx
+import pytest
+
+from aula.auth.exceptions import SAMLError
+from aula.auth.mitid_client import MitIDAuthClient
+
+MITID = "https://nemlog-in.mitid.dk"
+
+SAML_FORM = """
+<html><body><form>
+  <input type="hidden" name="RelayState" value="relay-123"/>
+  <input type="hidden" name="SAMLResponse" value="saml-abc"/>
+</form></body></html>
+"""
+
+LOGIN_OPTION_PAGE = """
+<html><body>
+  <input type="hidden" name="__RequestVerificationToken" value="tok-1"/>
+  <a class="list-link" data-loginoptions='{"id":"priv"}'>
+    <div class="list-link-text">Asser Smidt</div>
+    <div class="link-list-detail">Privat</div>
+  </a>
+  <a class="list-link" data-loginoptions='{"id":"biz"}'>
+    <div class="list-link-text">Asser Smidt</div>
+    <div class="link-list-detail">Firma ApS</div>
+  </a>
+</body></html>
+"""
+
+
+class FakeNemLogIn:
+    """POST /login/mitid answers per `identities`; /loginoption returns the SAML form."""
+
+    def __init__(self, identities: int = 1):
+        self.identities = identities
+        self.paths: list[str] = []
+
+    async def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.paths.append(f"{request.method} {request.url.path}")
+
+        if request.url.path == "/login/mitid":
+            if self.identities > 1:
+                # What the real backend does: bounce to the identity picker.
+                return httpx.Response(302, headers={"Location": f"{MITID}/loginoption"})
+            return httpx.Response(200, text=SAML_FORM)
+
+        if request.url.path == "/loginoption":
+            if request.method == "GET":
+                return httpx.Response(200, text=LOGIN_OPTION_PAGE)
+            return httpx.Response(200, text=SAML_FORM)
+
+        return httpx.Response(404)
+
+
+def _client(backend: FakeNemLogIn, **kwargs) -> MitIDAuthClient:
+    transport = httpx.MockTransport(backend)
+    return MitIDAuthClient(
+        mitid_username="tester",
+        httpx_client=httpx.AsyncClient(transport=transport, follow_redirects=False),
+        **kwargs,
+    )
+
+
+class TestStep4CompleteMitIDFlow:
+    @pytest.mark.asyncio
+    async def test_single_identity_returns_saml_data(self):
+        client = _client(FakeNemLogIn(identities=1))
+
+        result = await client._step4_complete_mitid_flow("verify-token", "auth-code")
+
+        assert result == {"relay_state": "relay-123", "saml_response": "saml-abc"}
+
+    @pytest.mark.asyncio
+    async def test_multiple_identities_follows_redirect_to_loginoption(self):
+        """The 302 to /loginoption has an empty body — not following it loses the SAML form."""
+
+        async def pick_first(identities: list[str]) -> int:
+            assert identities == ["Asser Smidt (Privat)", "Asser Smidt (Firma ApS)"]
+            return 0
+
+        backend = FakeNemLogIn(identities=2)
+        client = _client(backend, on_identity_selected=pick_first)
+
+        result = await client._step4_complete_mitid_flow("verify-token", "auth-code")
+
+        assert result == {"relay_state": "relay-123", "saml_response": "saml-abc"}
+        assert "GET /loginoption" in backend.paths
+
+    @pytest.mark.asyncio
+    async def test_reports_missing_saml_data(self):
+        class NoSaml(FakeNemLogIn):
+            async def __call__(self, request: httpx.Request) -> httpx.Response:
+                return httpx.Response(200, text="<html><body>nothing here</body></html>")
+
+        client = _client(NoSaml())
+
+        with pytest.raises(SAMLError, match="Could not find SAML data"):
+            await client._step4_complete_mitid_flow("verify-token", "auth-code")


### PR DESCRIPTION
## The problem

Users with more than one MitID identity (e.g. a personal one and a
business one) cannot log in. Authentication fails at step 4/7:

```
Step 3/7: Authenticating with MitID app
MitID app authentication successful
Step 4/7: Completing MitID flow
SAMLError: Could not find SAML data in MitID completion response
```

MitID approval succeeds — it is the step right after that fails.

## Cause

`POST /login/mitid` does not return the SAML form for these users. It
answers `302 -> /loginoption`, the identity picker, and the SAML form is
only produced after an identity is chosen.

The client is built with `follow_redirects=False`, so that redirect is
never followed:

```python
self._client = httpx.AsyncClient(follow_redirects=False, timeout=timeout)
...
response = await self._client.post(f"{MITID_BASE_URL}/login/mitid", data=params)

if str(response.url).endswith("/loginoption"):   # never true
```

`response.url` stays on `/login/mitid`, so `_handle_login_option_page()`
is never reached and the empty redirect body is parsed for SAML data
instead.

The `endswith("/loginoption")` check already assumes the redirect has
been followed — `response.url` only reflects a redirect target once
httpx has followed it. So the intent was there; the request just needed
to opt in.

## The change

Pass `follow_redirects=True` on that request, and on the identity
submission inside `_handle_login_option_page()` which lands on a
redirect for the same reason. The shared client default is untouched, so
the manually-driven redirect chain in step 2 is unaffected.

## Verification

Observed against the live backend from a captured chain:

```
[021] 302 POST https://nemlog-in.mitid.dk/login/mitid  ->  /loginoption
```

With the fix the chain continues to completion:

```
[023] 200 POST /loginoption                    SAMLResponse + RelayState
[024] 302 POST broker.unilogin.dk/.../endpoint
[029] 302 GET  .../authorize.php               -> app-private.aula.dk?code=...
[030] 200 POST .../token.php                   access_token + refresh_token
```

`tests/auth/test_mitid_client_loginoption.py` covers step 4 for both the
single-identity and multi-identity paths. The multi-identity test fails
on `main` with the exact error above and passes with the change.

Full suite: 579 passed, 2 skipped. `ruff check` and `ruff format` clean.

## Note

This may be the same root cause as the second half of #43 — that report
also ends with an unexpected page where SAML data was expected, though
its chain breaks earlier at `security-check.stil.dk`, which this does
not address.