### PR TITLE
fix: treat null nested objects as absent

### DIFF
--- a/src/aula/api_client.py
+++ b/src/aula/api_client.py
@@ -343,7 +343,7 @@ class AulaApiClient:
             "get", f"{self.api_url}?method=profiles.getProfilesByLogin"
         )
         resp.raise_for_status()
-        raw_data_list = resp.json().get("data", {}).get("profiles", [])
+        raw_data_list = (resp.json().get("data") or {}).get("profiles", [])
 
         if not raw_data_list:
             raise ValueError("No profile data found in API response")
@@ -412,9 +412,9 @@ class AulaApiClient:
         )
         resp.raise_for_status()
         data = resp.json()
-        widget_configs = (
-            data.get("data", {}).get("pageConfiguration", {}).get("widgetConfigurations", [])
-        )
+        widget_configs = ((data.get("data") or {}).get("pageConfiguration") or {}).get(
+            "widgetConfigurations"
+        ) or []
         widgets = []
         for item in widget_configs:
             try:
@@ -837,7 +837,7 @@ class AulaApiClient:
             url += f"&filterOn={filter_on}"
         resp = await self._request_with_version_retry("get", url)
         resp.raise_for_status()
-        threads_data = resp.json().get("data", {}).get("threads", [])
+        threads_data = (resp.json().get("data") or {}).get("threads", [])
 
         threads = []
         for t_dict in threads_data:
@@ -865,12 +865,12 @@ class AulaApiClient:
         resp.raise_for_status()
         data = resp.json()
         messages = []
-        raw_messages = data.get("data", {}).get("messages", [])
+        raw_messages = (data.get("data") or {}).get("messages", [])
 
         for msg_dict in raw_messages:
             if msg_dict.get("messageType") in ("Message", "MessageEdited"):
                 try:
-                    text = msg_dict.get("text", {}).get("html") or msg_dict.get("text", "")
+                    text = (msg_dict.get("text") or {}).get("html") or msg_dict.get("text", "")
                     messages.append(
                         Message(_raw=msg_dict, id=msg_dict.get("id"), content_html=text)
                     )
@@ -917,7 +917,7 @@ class AulaApiClient:
                 substitute = self._find_participant_by_role(lesson, "substituteTeacher")
 
                 has_substitute = lesson.get("lessonStatus", "").lower() == "substitute"
-                location = lesson.get("primaryResource", {}).get("name")
+                location = (lesson.get("primaryResource") or {}).get("name")
 
                 events.append(
                     CalendarEvent(
@@ -1234,7 +1234,7 @@ class AulaApiClient:
 
         resp.raise_for_status()
 
-        posts_data = resp.json().get("data", {}).get("posts", [])
+        posts_data = (resp.json().get("data") or {}).get("posts", [])
         posts = []
 
         for post_data in posts_data:
@@ -1597,7 +1597,7 @@ class AulaApiClient:
                 f"{self.api_url}?method=messaging.getThreads&sortOn=date&orderDirection=desc&page={page}",
             )
             resp.raise_for_status()
-            threads = resp.json().get("data", {}).get("threads", [])
+            threads = (resp.json().get("data") or {}).get("threads", [])
             if not threads:
                 break
 
@@ -1631,7 +1631,7 @@ class AulaApiClient:
                 f"{self.api_url}?method=messaging.getMessagesForThread&threadId={thread_id}&page={page}",
             )
             resp.raise_for_status()
-            messages = resp.json().get("data", {}).get("messages", [])
+            messages = (resp.json().get("data") or {}).get("messages", [])
             if not messages:
                 break
 
@@ -1755,7 +1755,7 @@ class AulaApiClient:
             params["PortalRoles"] = portal_roles
         resp = await self._request_with_version_retry("get", self.api_url, params=params)
         resp.raise_for_status()
-        data = resp.json().get("data", {}).get("results", [])
+        data = (resp.json().get("data") or {}).get("results", [])
         if not isinstance(data, list):
             return []
         return data

--- a/src/aula/cli.py
+++ b/src/aula/cli.py
@@ -412,7 +412,7 @@ async def _get_widget_context(
     institution_filter: list[str] = []
     for child in prof.children:
         if child._raw:
-            inst_code = child._raw.get("institutionProfile", {}).get("institutionCode", "")
+            inst_code = (child._raw.get("institutionProfile") or {}).get("institutionCode", "")
             if inst_code and str(inst_code) not in institution_filter:
                 institution_filter.append(str(inst_code))
 
@@ -731,7 +731,7 @@ async def messages(ctx, limit, unread, search, folders):
             institution_codes: list[str] = []
             for child in prof.children:
                 if child._raw:
-                    code = child._raw.get("institutionProfile", {}).get("institutionCode", "")
+                    code = (child._raw.get("institutionProfile") or {}).get("institutionCode", "")
                     if code and str(code) not in institution_codes:
                         institution_codes.append(str(code))
 
@@ -757,7 +757,7 @@ async def messages(ctx, limit, unread, search, folders):
 
             for i, msg in enumerate(results):
                 msg_raw = msg._raw or {}
-                sender = msg_raw.get("sender", {}).get("fullName", "Unknown")
+                sender = (msg_raw.get("sender") or {}).get("fullName", "Unknown")
                 send_date = msg_raw.get("sendDateTime", "")
                 subject = msg_raw.get("threadSubject", "")
 
@@ -822,7 +822,7 @@ async def messages(ctx, limit, unread, search, folders):
                 else:
                     for msg in messages_list:
                         msg_raw = msg._raw or {}
-                        sender = msg_raw.get("sender", {}).get("fullName", "Unknown")
+                        sender = (msg_raw.get("sender") or {}).get("fullName", "Unknown")
                         send_date = msg_raw.get("sendDateTime", "")
                         message_title = msg_raw.get("threadSubject", "")
                         for line in format_message_lines(
@@ -1090,7 +1090,7 @@ async def birthdays(ctx, group_id, start_date, end_date):
             institution_codes: list[str] = []
             for child in prof.children:
                 if child._raw:
-                    code = child._raw.get("institutionProfile", {}).get("institutionCode", "")
+                    code = (child._raw.get("institutionProfile") or {}).get("institutionCode", "")
                     if code and str(code) not in institution_codes:
                         institution_codes.append(str(code))
 
@@ -1636,7 +1636,7 @@ async def debug_easyiq(ctx, week, include_values):
         institution_filter: list[str] = []
         for child in prof.children:
             if child._raw:
-                inst_code = child._raw.get("institutionProfile", {}).get("institutionCode", "")
+                inst_code = (child._raw.get("institutionProfile") or {}).get("institutionCode", "")
                 if inst_code and str(inst_code) not in institution_filter:
                     institution_filter.append(str(inst_code))
 
@@ -1872,7 +1872,7 @@ async def easyiq_ugeplan(ctx, week):
         institution_filter: list[str] = []
         for child in prof.children:
             if child._raw:
-                inst_code = child._raw.get("institutionProfile", {}).get("institutionCode", "")
+                inst_code = (child._raw.get("institutionProfile") or {}).get("institutionCode", "")
                 if inst_code and str(inst_code) not in institution_filter:
                     institution_filter.append(str(inst_code))
 
@@ -1981,7 +1981,7 @@ async def easyiq_homework(ctx, week):
         institution_filter: list[str] = []
         for child in prof.children:
             if child._raw:
-                inst_code = child._raw.get("institutionProfile", {}).get("institutionCode", "")
+                inst_code = (child._raw.get("institutionProfile") or {}).get("institutionCode", "")
                 if inst_code and str(inst_code) not in institution_filter:
                     institution_filter.append(str(inst_code))
 
@@ -2099,7 +2099,7 @@ async def meebook_ugeplan(ctx, week):
         institution_filter: list[str] = []
         for child in prof.children:
             if child._raw:
-                inst_code = child._raw.get("institutionProfile", {}).get("institutionCode", "")
+                inst_code = (child._raw.get("institutionProfile") or {}).get("institutionCode", "")
                 if inst_code and str(inst_code) not in institution_filter:
                     institution_filter.append(str(inst_code))
 
@@ -2184,7 +2184,7 @@ async def momo_course(ctx):
         institutions: list[str] = []
         for child in prof.children:
             if child._raw:
-                inst_code = child._raw.get("institutionProfile", {}).get("institutionCode", "")
+                inst_code = (child._raw.get("institutionProfile") or {}).get("institutionCode", "")
                 if inst_code and str(inst_code) not in institutions:
                     institutions.append(str(inst_code))
 
@@ -2259,7 +2259,7 @@ async def momo_reminders(ctx):
         institutions: list[str] = []
         for child in prof.children:
             if child._raw:
-                inst_code = child._raw.get("institutionProfile", {}).get("institutionCode", "")
+                inst_code = (child._raw.get("institutionProfile") or {}).get("institutionCode", "")
                 if inst_code and str(inst_code) not in institutions:
                     institutions.append(str(inst_code))
 
@@ -2399,7 +2399,7 @@ async def download_images(ctx, output, since, source, tags):
         institution_codes: list[str] = []
         for child in prof.children:
             if child._raw:
-                code = child._raw.get("institutionProfile", {}).get("institutionCode", "")
+                code = (child._raw.get("institutionProfile") or {}).get("institutionCode", "")
                 if code and code not in institution_codes:
                     institution_codes.append(code)
 
@@ -2745,7 +2745,7 @@ async def weekly_summary(ctx, child, week, providers):
                     msgs = await client.get_messages_for_thread(thread.thread_id)
                     for msg in msgs:
                         msg_raw = msg._raw or {}
-                        sender = msg_raw.get("sender", {}).get("fullName", "Unknown")
+                        sender = (msg_raw.get("sender") or {}).get("fullName", "Unknown")
                         send_date = msg_raw.get("sendDateTime", "")
                         click.echo(f"Author: {sender}")
                         if send_date:
@@ -2903,7 +2903,7 @@ async def weekly_summary(ctx, child, week, providers):
                     continue
                 c_user_id = str(c._raw["userId"])
                 c_institutions: list[str] = []
-                inst_code = c._raw.get("institutionProfile", {}).get("institutionCode", "")
+                inst_code = (c._raw.get("institutionProfile") or {}).get("institutionCode", "")
                 if inst_code:
                     c_institutions.append(str(inst_code))
 
@@ -2957,7 +2957,7 @@ async def weekly_summary(ctx, child, week, providers):
                     continue
                 c_user_id = str(c._raw["userId"])
                 c_institutions: list[str] = []
-                inst_code = c._raw.get("institutionProfile", {}).get("institutionCode", "")
+                inst_code = (c._raw.get("institutionProfile") or {}).get("institutionCode", "")
                 if inst_code:
                     c_institutions.append(str(inst_code))
 
@@ -4027,7 +4027,7 @@ async def daily_summary(ctx, child, target_date):
                     msgs = await client.get_messages_for_thread(thread.thread_id)
                     for msg in msgs:
                         msg_raw = msg._raw or {}
-                        sender = msg_raw.get("sender", {}).get("fullName", "Unknown")
+                        sender = (msg_raw.get("sender") or {}).get("fullName", "Unknown")
                         send_date = msg_raw.get("sendDateTime", "")
                         click.echo(f"Author: {sender}")
                         if send_date:

--- a/src/aula/models/child.py
+++ b/src/aula/models/child.py
@@ -29,6 +29,6 @@ class Child(AulaDataClass):
             id=data["id"],
             profile_id=data["profileId"],
             name=data["name"],
-            institution_name=data.get("institutionProfile", {}).get("institutionName", ""),
-            profile_picture=data.get("profilePicture", {}).get("url", ""),
+            institution_name=(data.get("institutionProfile") or {}).get("institutionName", ""),
+            profile_picture=(data.get("profilePicture") or {}).get("url", ""),
         )

--- a/src/aula/models/post.py
+++ b/src/aula/models/post.py
@@ -62,7 +62,7 @@ class Post(AulaDataClass):
         return cls(
             id=data["id"],
             title=data.get("title", ""),
-            content_html=data.get("content", {}).get("html", ""),
+            content_html=(data.get("content") or {}).get("html", ""),
             timestamp=parse_datetime(data.get("timestamp")),
             owner=owner,
             allow_comments=data.get("allowComments", False),

--- a/src/aula/models/profile_reference.py
+++ b/src/aula/models/profile_reference.py
@@ -29,7 +29,7 @@ class ProfileReference(AulaDataClass):
             full_name=data.get("fullName", ""),
             short_name=data.get("shortName", ""),
             role=data.get("role", ""),
-            institution_name=data.get("institution", {}).get("institutionName", ""),
+            institution_name=(data.get("institution") or {}).get("institutionName", ""),
             profile_picture=data.get("profilePicture"),
             _raw=data,
         )

--- a/src/aula/utils/download.py
+++ b/src/aula/utils/download.py
@@ -228,7 +228,7 @@ async def download_message_images(
         thread_info = raw.get("thread", {})
         thread_id = str(thread_info.get("id", ""))
         if thread_id and thread_id not in threads:
-            send_dt = raw.get("searchMessage", {}).get("sendDateTime", "")
+            send_dt = (raw.get("searchMessage") or {}).get("sendDateTime", "")
             threads[thread_id] = {
                 "subject": thread_info.get("subject", "No Subject"),
                 "date": _parse_date_str(send_dt),

--- a/tests/models/test_child.py
+++ b/tests/models/test_child.py
@@ -47,3 +47,17 @@ def test_child_dict_conversion():
     assert result["id"] == 1
     assert result["profile_id"] == 100
     assert "_raw" not in result
+
+
+def test_child_from_dict_null_nested():
+    """Aula sends null — not a missing key — for a child without a profile picture."""
+    data = {
+        "id": 4,
+        "profileId": 400,
+        "name": "Diana",
+        "institutionProfile": None,
+        "profilePicture": None,
+    }
+    child = Child.from_dict(data)
+    assert child.institution_name == ""
+    assert child.profile_picture == ""

--- a/tests/models/test_post.py
+++ b/tests/models/test_post.py
@@ -112,3 +112,15 @@ def test_post_dict_conversion():
     result = dict(post)
     assert result["title"] == "Test"
     assert "_raw" not in result
+
+
+def test_post_from_dict_null_content():
+    """A post with no body arrives as "content": null, not as a missing key."""
+    data = {
+        "id": 7,
+        "title": "Heading only",
+        "content": None,
+        "ownerProfile": {"id": 1, "profileId": 1},
+    }
+    post = Post.from_dict(data)
+    assert post.content_html == ""


### PR DESCRIPTION
## The problem

`get_profile()` raises for any guardian whose child has no profile
picture:

```
File "aula/api_client.py", line 360, in get_profile
    children.append(Child.from_dict(child_dict))
File "aula/models/child.py", line 33, in from_dict
    profile_picture=data.get("profilePicture", {}).get("url", ""),
AttributeError: 'NoneType' object has no attribute 'get'
```

Through the CLI it surfaces as `Error: unexpected failure: 'NoneType'
object has no attribute 'get'`, which is hard to trace back to a missing
photo. One of my two children has no picture, and that was enough to
make every `profile` call fail — and with it every command that resolves
children first.

## Cause

`dict.get(key, {})` only falls back to `{}` when the key is **missing**.
Aula sends the key with an explicit null:

```json
{"id": 2030280, "name": "...", "profilePicture": null}
```

so `.get("profilePicture", {})` returns `None`, and the chained `.get()`
runs on it.

`tests/models/test_child.py` already covers the neighbouring cases — a
missing key (`test_child_from_dict_missing_optional`) and an empty dict
(`test_child_from_dict_empty_nested`) — but not an explicit null, which
is what the API actually sends.

## The change

`data.get(k, {}).get(...)` becomes `(data.get(k) or {}).get(...)`.
Identical when the value is a dict; absorbs null.

Applied across the 31 occurrences of the pattern rather than only the
one that crashed, since the same failure is reachable wherever Aula may
send null for an object it leaves empty — post content, owner profiles,
institution profiles, message senders. They are the same one-line
change, and the diff is mechanical.

## Verification

Two tests added alongside the existing ones, for the null case in
`Child` and `Post`. Both fail on `main`:

```
FAILED tests/models/test_child.py::test_child_from_dict_null_nested - AttributeError
FAILED tests/models/test_post.py::test_post_from_dict_null_content - AttributeError
```

and pass with the change. Full suite: 578 passed, 2 skipped.
`ruff check` and `ruff format` clean.

Verified against a live account: `profile`, `messages`, `calendar`,
`meebook:ugeplan`, `daily-summary` and `weekly-summary` all return data
where `profile` previously crashed.