### PR TITLE
refactor: read nested API values with get_in

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,14 @@ repos:
 
   - repo: local
     hooks:
+      # Aula sends an explicit null for objects it leaves empty, so `.get(k, {})`
+      # returns None and the next `.get` raises. See src/aula/utils/mapping.py.
+      - id: no-get-empty-dict-default
+        name: use get_in() instead of .get(key, {})
+        language: pygrep
+        entry: '\.get\([^)]*, ?\{\}\)'
+        files: '^src/.+\.py$'
+
       - id: pytest
         name: pytest
         language: system

--- a/src/aula/api_client.py
+++ b/src/aula/api_client.py
@@ -60,6 +60,7 @@ from .models import (
     VacationRegistration,
     WidgetConfiguration,
 )
+from .utils.mapping import get_in
 from .widgets import AulaWidgetsClient
 
 # Logger
@@ -343,7 +344,7 @@ class AulaApiClient:
             "get", f"{self.api_url}?method=profiles.getProfilesByLogin"
         )
         resp.raise_for_status()
-        raw_data_list = (resp.json().get("data") or {}).get("profiles", [])
+        raw_data_list = get_in(resp.json(), "data.profiles", default=[])
 
         if not raw_data_list:
             raise ValueError("No profile data found in API response")
@@ -412,9 +413,7 @@ class AulaApiClient:
         )
         resp.raise_for_status()
         data = resp.json()
-        widget_configs = ((data.get("data") or {}).get("pageConfiguration") or {}).get(
-            "widgetConfigurations"
-        ) or []
+        widget_configs = get_in(data, "data.pageConfiguration.widgetConfigurations", default=[])
         widgets = []
         for item in widget_configs:
             try:
@@ -837,7 +836,7 @@ class AulaApiClient:
             url += f"&filterOn={filter_on}"
         resp = await self._request_with_version_retry("get", url)
         resp.raise_for_status()
-        threads_data = (resp.json().get("data") or {}).get("threads", [])
+        threads_data = get_in(resp.json(), "data.threads", default=[])
 
         threads = []
         for t_dict in threads_data:
@@ -865,12 +864,14 @@ class AulaApiClient:
         resp.raise_for_status()
         data = resp.json()
         messages = []
-        raw_messages = (data.get("data") or {}).get("messages", [])
+        raw_messages = get_in(data, "data.messages", default=[])
 
         for msg_dict in raw_messages:
             if msg_dict.get("messageType") in ("Message", "MessageEdited"):
                 try:
-                    text = (msg_dict.get("text") or {}).get("html") or msg_dict.get("text", "")
+                    text = get_in(msg_dict, "text.html", default="") or get_in(
+                        msg_dict, "text", default=""
+                    )
                     messages.append(
                         Message(_raw=msg_dict, id=msg_dict.get("id"), content_html=text)
                     )
@@ -911,13 +912,13 @@ class AulaApiClient:
 
         for event in raw_events:
             try:
-                lesson = event.get("lesson", {}) or {}
+                lesson = event.get("lesson") or {}
 
                 teacher = self._find_participant_by_role(lesson, "primaryTeacher")
                 substitute = self._find_participant_by_role(lesson, "substituteTeacher")
 
                 has_substitute = lesson.get("lessonStatus", "").lower() == "substitute"
-                location = (lesson.get("primaryResource") or {}).get("name")
+                location = get_in(lesson, "primaryResource.name")
 
                 events.append(
                     CalendarEvent(
@@ -957,7 +958,7 @@ class AulaApiClient:
         resp = await self._request_with_version_retry("get", self.api_url, params=params)
         resp.raise_for_status()
 
-        data = resp.json().get("data", {})
+        data = resp.json().get("data") or {}
         if not data or not isinstance(data, dict):
             return None
         return data
@@ -1174,7 +1175,7 @@ class AulaApiClient:
         resp = await self._request_with_version_retry("get", self.api_url, params=params)
         resp.raise_for_status()
 
-        data = resp.json().get("data", {})
+        data = resp.json().get("data") or {}
         if not data or not isinstance(data, dict):
             return None
         return Group.from_dict(data)
@@ -1234,7 +1235,7 @@ class AulaApiClient:
 
         resp.raise_for_status()
 
-        posts_data = (resp.json().get("data") or {}).get("posts", [])
+        posts_data = get_in(resp.json(), "data.posts", default=[])
         posts = []
 
         for post_data in posts_data:
@@ -1275,7 +1276,7 @@ class AulaApiClient:
         resp = await self._request_with_version_retry("get", self.api_url, params=params)
         resp.raise_for_status()
 
-        data = resp.json().get("data", {})
+        data = resp.json().get("data") or {}
         if not data:
             return None
 
@@ -1561,7 +1562,7 @@ class AulaApiClient:
                 json=payload,
             )
             resp.raise_for_status()
-            data = resp.json().get("data", {})
+            data = resp.json().get("data") or {}
             results = data.get("results", [])
             if not results:
                 break
@@ -1597,7 +1598,7 @@ class AulaApiClient:
                 f"{self.api_url}?method=messaging.getThreads&sortOn=date&orderDirection=desc&page={page}",
             )
             resp.raise_for_status()
-            threads = (resp.json().get("data") or {}).get("threads", [])
+            threads = get_in(resp.json(), "data.threads", default=[])
             if not threads:
                 break
 
@@ -1631,7 +1632,7 @@ class AulaApiClient:
                 f"{self.api_url}?method=messaging.getMessagesForThread&threadId={thread_id}&page={page}",
             )
             resp.raise_for_status()
-            messages = (resp.json().get("data") or {}).get("messages", [])
+            messages = get_in(resp.json(), "data.messages", default=[])
             if not messages:
                 break
 
@@ -1730,7 +1731,7 @@ class AulaApiClient:
         }
         resp = await self._request_with_version_retry("get", self.api_url, params=params)
         resp.raise_for_status()
-        data = resp.json().get("data", {})
+        data = resp.json().get("data") or {}
         if not data or not isinstance(data, dict):
             return None
         return data
@@ -1755,7 +1756,7 @@ class AulaApiClient:
             params["PortalRoles"] = portal_roles
         resp = await self._request_with_version_retry("get", self.api_url, params=params)
         resp.raise_for_status()
-        data = (resp.json().get("data") or {}).get("results", [])
+        data = get_in(resp.json(), "data.results", default=[])
         if not isinstance(data, list):
             return []
         return data
@@ -1770,7 +1771,7 @@ class AulaApiClient:
         }
         resp = await self._request_with_version_retry("get", self.api_url, params=params)
         resp.raise_for_status()
-        return resp.json().get("data", {})
+        return resp.json().get("data") or {}
 
     async def search(
         self, text: str, doc_type: str | None = None, limit: int = 20, offset: int = 0
@@ -1787,7 +1788,7 @@ class AulaApiClient:
             params["DocType"] = doc_type
         resp = await self._request_with_version_retry("get", self.api_url, params=params)
         resp.raise_for_status()
-        return resp.json().get("data", {})
+        return resp.json().get("data") or {}
 
     async def get_contact_list(
         self,
@@ -1859,7 +1860,7 @@ class AulaApiClient:
         }
         resp = await self._request_with_version_retry("get", self.api_url, params=params)
         resp.raise_for_status()
-        data = resp.json().get("data", {})
+        data = resp.json().get("data") or {}
         if not data or not isinstance(data, dict):
             return None
         return data
@@ -1959,7 +1960,7 @@ class AulaApiClient:
         }
         resp = await self._request_with_version_retry("get", self.api_url, params=params)
         resp.raise_for_status()
-        data = resp.json().get("data", {})
+        data = resp.json().get("data") or {}
         results = data.get("results", []) if isinstance(data, dict) else []
         if not isinstance(results, list):
             return []

--- a/src/aula/auth_flow.py
+++ b/src/aula/auth_flow.py
@@ -95,12 +95,12 @@ async def create_client(
         ValueError: If ``token_data`` has no ``access_token`` (compatibility
             requirement for stored credential schema).
     """
-    tokens = token_data.get("tokens", {})
+    tokens = token_data.get("tokens") or {}
     access_token = tokens.get("access_token")
     if not access_token:
         raise ValueError("No access_token found in token_data")
 
-    cookies = token_data.get("cookies", {})
+    cookies = token_data.get("cookies") or {}
     # Csrfp-Token is expected from the restored cookie jar when available.
     csrf_token = cookies.get(CSRF_TOKEN_COOKIE)
 
@@ -195,13 +195,13 @@ async def authenticate(
             _LOGGER.info("Force login requested; skipping cached token reuse")
 
         if token_data is not None:
-            tokens = token_data.get("tokens", {})
+            tokens = token_data.get("tokens") or {}
             expires_at = tokens.get("expires_at")
             if tokens.get("access_token") and (
                 expires_at is None or time.time() + _TOKEN_EXPIRY_BUFFER_SECS < expires_at
             ):
                 auth_client.tokens = tokens
-                cookies = token_data.get("cookies", {})
+                cookies = token_data.get("cookies") or {}
                 result_data = token_data
                 tokens_valid = True
                 _LOGGER.info("Loaded cached authentication tokens")
@@ -209,7 +209,7 @@ async def authenticate(
                 _LOGGER.info("Cached tokens expired, attempting refresh")
                 try:
                     new_tokens = await auth_client.refresh_access_token(tokens["refresh_token"])
-                    cookies = token_data.get("cookies", {})
+                    cookies = token_data.get("cookies") or {}
                     result_data = _build_token_data(mitid_username, new_tokens, cookies)
                     if token_storage:
                         await token_storage.save(result_data)

--- a/src/aula/cli.py
+++ b/src/aula/cli.py
@@ -27,6 +27,7 @@ from .const import (
 from .models import Child, DailyOverview, Group, Message, MessageThread, Notification, Profile
 from .token_storage import FileTokenStorage
 from .utils.json import to_json
+from .utils.mapping import get_in
 from .utils.output import (
     build_contact_table,
     clip,
@@ -412,7 +413,7 @@ async def _get_widget_context(
     institution_filter: list[str] = []
     for child in prof.children:
         if child._raw:
-            inst_code = (child._raw.get("institutionProfile") or {}).get("institutionCode", "")
+            inst_code = get_in(child._raw, "institutionProfile.institutionCode", default="")
             if inst_code and str(inst_code) not in institution_filter:
                 institution_filter.append(str(inst_code))
 
@@ -448,7 +449,7 @@ def _easyiq_child_user_ids(profile_context: dict) -> list[str]:
     out of the filter.
     """
     data = profile_context.get("data") or {}
-    relations = (data.get("institutionProfile") or {}).get("relations") or []
+    relations = get_in(data, "institutionProfile.relations") or []
     institution_children = [
         child
         for institution in data.get("institutions") or []
@@ -731,7 +732,7 @@ async def messages(ctx, limit, unread, search, folders):
             institution_codes: list[str] = []
             for child in prof.children:
                 if child._raw:
-                    code = (child._raw.get("institutionProfile") or {}).get("institutionCode", "")
+                    code = get_in(child._raw, "institutionProfile.institutionCode", default="")
                     if code and str(code) not in institution_codes:
                         institution_codes.append(str(code))
 
@@ -757,7 +758,7 @@ async def messages(ctx, limit, unread, search, folders):
 
             for i, msg in enumerate(results):
                 msg_raw = msg._raw or {}
-                sender = (msg_raw.get("sender") or {}).get("fullName", "Unknown")
+                sender = get_in(msg_raw, "sender.fullName", default="Unknown")
                 send_date = msg_raw.get("sendDateTime", "")
                 subject = msg_raw.get("threadSubject", "")
 
@@ -822,7 +823,7 @@ async def messages(ctx, limit, unread, search, folders):
                 else:
                     for msg in messages_list:
                         msg_raw = msg._raw or {}
-                        sender = (msg_raw.get("sender") or {}).get("fullName", "Unknown")
+                        sender = get_in(msg_raw, "sender.fullName", default="Unknown")
                         send_date = msg_raw.get("sendDateTime", "")
                         message_title = msg_raw.get("threadSubject", "")
                         for line in format_message_lines(
@@ -860,9 +861,8 @@ async def notifications(ctx, offset, limit, module):
                 children_ids.append(child.id)
                 if not child._raw:
                     continue
-                institution = child._raw.get("institutionProfile", {})
-                code = institution.get("institutionCode")
-                name = institution.get("institutionName")
+                code = get_in(child._raw, "institutionProfile.institutionCode")
+                name = get_in(child._raw, "institutionProfile.institutionName")
                 if code and name and str(code) not in institution_names:
                     institution_names[str(code)] = str(name)
                 if code and str(code) not in institution_codes:
@@ -1090,7 +1090,7 @@ async def birthdays(ctx, group_id, start_date, end_date):
             institution_codes: list[str] = []
             for child in prof.children:
                 if child._raw:
-                    code = (child._raw.get("institutionProfile") or {}).get("institutionCode", "")
+                    code = get_in(child._raw, "institutionProfile.institutionCode", default="")
                     if code and str(code) not in institution_codes:
                         institution_codes.append(str(code))
 
@@ -1636,7 +1636,7 @@ async def debug_easyiq(ctx, week, include_values):
         institution_filter: list[str] = []
         for child in prof.children:
             if child._raw:
-                inst_code = (child._raw.get("institutionProfile") or {}).get("institutionCode", "")
+                inst_code = get_in(child._raw, "institutionProfile.institutionCode", default="")
                 if inst_code and str(inst_code) not in institution_filter:
                     institution_filter.append(str(inst_code))
 
@@ -1872,7 +1872,7 @@ async def easyiq_ugeplan(ctx, week):
         institution_filter: list[str] = []
         for child in prof.children:
             if child._raw:
-                inst_code = (child._raw.get("institutionProfile") or {}).get("institutionCode", "")
+                inst_code = get_in(child._raw, "institutionProfile.institutionCode", default="")
                 if inst_code and str(inst_code) not in institution_filter:
                     institution_filter.append(str(inst_code))
 
@@ -1981,7 +1981,7 @@ async def easyiq_homework(ctx, week):
         institution_filter: list[str] = []
         for child in prof.children:
             if child._raw:
-                inst_code = (child._raw.get("institutionProfile") or {}).get("institutionCode", "")
+                inst_code = get_in(child._raw, "institutionProfile.institutionCode", default="")
                 if inst_code and str(inst_code) not in institution_filter:
                     institution_filter.append(str(inst_code))
 
@@ -2099,7 +2099,7 @@ async def meebook_ugeplan(ctx, week):
         institution_filter: list[str] = []
         for child in prof.children:
             if child._raw:
-                inst_code = (child._raw.get("institutionProfile") or {}).get("institutionCode", "")
+                inst_code = get_in(child._raw, "institutionProfile.institutionCode", default="")
                 if inst_code and str(inst_code) not in institution_filter:
                     institution_filter.append(str(inst_code))
 
@@ -2184,7 +2184,7 @@ async def momo_course(ctx):
         institutions: list[str] = []
         for child in prof.children:
             if child._raw:
-                inst_code = (child._raw.get("institutionProfile") or {}).get("institutionCode", "")
+                inst_code = get_in(child._raw, "institutionProfile.institutionCode", default="")
                 if inst_code and str(inst_code) not in institutions:
                     institutions.append(str(inst_code))
 
@@ -2259,7 +2259,7 @@ async def momo_reminders(ctx):
         institutions: list[str] = []
         for child in prof.children:
             if child._raw:
-                inst_code = (child._raw.get("institutionProfile") or {}).get("institutionCode", "")
+                inst_code = get_in(child._raw, "institutionProfile.institutionCode", default="")
                 if inst_code and str(inst_code) not in institutions:
                     institutions.append(str(inst_code))
 
@@ -2399,7 +2399,7 @@ async def download_images(ctx, output, since, source, tags):
         institution_codes: list[str] = []
         for child in prof.children:
             if child._raw:
-                code = (child._raw.get("institutionProfile") or {}).get("institutionCode", "")
+                code = get_in(child._raw, "institutionProfile.institutionCode", default="")
                 if code and code not in institution_codes:
                     institution_codes.append(code)
 
@@ -2592,7 +2592,7 @@ async def weekly_summary(ctx, child, week, providers):
             else {WeeklySummaryProvider(p) for p in providers}
         )
     else:
-        cfg = load_config().get("weekly_summary", {})
+        cfg = load_config().get("weekly_summary") or {}
         enabled = set()
         for key, active in cfg.items():
             try:
@@ -2745,7 +2745,7 @@ async def weekly_summary(ctx, child, week, providers):
                     msgs = await client.get_messages_for_thread(thread.thread_id)
                     for msg in msgs:
                         msg_raw = msg._raw or {}
-                        sender = (msg_raw.get("sender") or {}).get("fullName", "Unknown")
+                        sender = get_in(msg_raw, "sender.fullName", default="Unknown")
                         send_date = msg_raw.get("sendDateTime", "")
                         click.echo(f"Author: {sender}")
                         if send_date:
@@ -2903,7 +2903,7 @@ async def weekly_summary(ctx, child, week, providers):
                     continue
                 c_user_id = str(c._raw["userId"])
                 c_institutions: list[str] = []
-                inst_code = (c._raw.get("institutionProfile") or {}).get("institutionCode", "")
+                inst_code = get_in(c._raw, "institutionProfile.institutionCode", default="")
                 if inst_code:
                     c_institutions.append(str(inst_code))
 
@@ -2957,7 +2957,7 @@ async def weekly_summary(ctx, child, week, providers):
                     continue
                 c_user_id = str(c._raw["userId"])
                 c_institutions: list[str] = []
-                inst_code = (c._raw.get("institutionProfile") or {}).get("institutionCode", "")
+                inst_code = get_in(c._raw, "institutionProfile.institutionCode", default="")
                 if inst_code:
                     c_institutions.append(str(inst_code))
 
@@ -4027,7 +4027,7 @@ async def daily_summary(ctx, child, target_date):
                     msgs = await client.get_messages_for_thread(thread.thread_id)
                     for msg in msgs:
                         msg_raw = msg._raw or {}
-                        sender = (msg_raw.get("sender") or {}).get("fullName", "Unknown")
+                        sender = get_in(msg_raw, "sender.fullName", default="Unknown")
                         send_date = msg_raw.get("sendDateTime", "")
                         click.echo(f"Author: {sender}")
                         if send_date:

--- a/src/aula/models/child.py
+++ b/src/aula/models/child.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Any
 
+from ..utils.mapping import get_in
 from .base import AulaDataClass
 
 
@@ -29,6 +30,6 @@ class Child(AulaDataClass):
             id=data["id"],
             profile_id=data["profileId"],
             name=data["name"],
-            institution_name=(data.get("institutionProfile") or {}).get("institutionName", ""),
-            profile_picture=(data.get("profilePicture") or {}).get("url", ""),
+            institution_name=get_in(data, "institutionProfile.institutionName", default=""),
+            profile_picture=get_in(data, "profilePicture.url", default=""),
         )

--- a/src/aula/models/comment.py
+++ b/src/aula/models/comment.py
@@ -21,7 +21,7 @@ class Comment(AulaDataClass):
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Comment:
-        owner = data.get("owner", {}) or {}
+        owner = data.get("owner") or {}
         return cls(
             _raw=data,
             id=data["id"],

--- a/src/aula/models/institution_profile.py
+++ b/src/aula/models/institution_profile.py
@@ -30,7 +30,7 @@ class InstitutionProfile(AulaDataClass):
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> InstitutionProfile:
-        pic_data = data.get("profilePicture", {})
+        pic_data = data.get("profilePicture") or {}
         return cls(
             profile_id=data.get("profileId"),
             id=data.get("id"),

--- a/src/aula/models/post.py
+++ b/src/aula/models/post.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from ..utils.html import html_to_markdown, html_to_plain
+from ..utils.mapping import get_in
 from .base import AulaDataClass
 from .profile_reference import ProfileReference
 
@@ -57,12 +58,12 @@ class Post(AulaDataClass):
             except ValueError, TypeError:
                 return None
 
-        owner = ProfileReference.from_dict(data.get("ownerProfile", {}))
+        owner = ProfileReference.from_dict(data.get("ownerProfile") or {})
 
         return cls(
             id=data["id"],
             title=data.get("title", ""),
-            content_html=(data.get("content") or {}).get("html", ""),
+            content_html=get_in(data, "content.html", default=""),
             timestamp=parse_datetime(data.get("timestamp")),
             owner=owner,
             allow_comments=data.get("allowComments", False),

--- a/src/aula/models/presence_registration.py
+++ b/src/aula/models/presence_registration.py
@@ -109,7 +109,7 @@ class ChildPresenceState(AulaDataClass):
                 _LOGGER.warning("Unknown presence status value: %s", status_value)
 
         # Profile ID and name are nested inside uniStudent
-        uni_student = data.get("uniStudent", {}) or {}
+        uni_student = data.get("uniStudent") or {}
         institution_profile_id = uni_student.get("id") or data.get("institutionProfileId")
         name = uni_student.get("name")
 
@@ -136,8 +136,8 @@ class PresenceConfiguration(AulaDataClass):
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> PresenceConfiguration:
         # Real API nests config under "presenceConfiguration"
-        config = data.get("presenceConfiguration", {}) or {}
-        institution = config.get("institution", {}) or {}
+        config = data.get("presenceConfiguration") or {}
+        institution = config.get("institution") or {}
 
         return cls(
             _raw=data,

--- a/src/aula/models/profile_reference.py
+++ b/src/aula/models/profile_reference.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Any
 
+from ..utils.mapping import get_in
 from .base import AulaDataClass
 
 
@@ -29,7 +30,7 @@ class ProfileReference(AulaDataClass):
             full_name=data.get("fullName", ""),
             short_name=data.get("shortName", ""),
             role=data.get("role", ""),
-            institution_name=(data.get("institution") or {}).get("institutionName", ""),
+            institution_name=get_in(data, "institution.institutionName", default=""),
             profile_picture=data.get("profilePicture"),
             _raw=data,
         )

--- a/src/aula/models/widget.py
+++ b/src/aula/models/widget.py
@@ -17,7 +17,7 @@ class WidgetConfiguration(AulaDataClass):
 
     @classmethod
     def from_dict(cls, data: dict) -> WidgetConfiguration:
-        widget = data.get("widget", {})
+        widget = data.get("widget") or {}
         return cls(
             widget_id=widget.get("widgetId", ""),
             name=widget.get("name", ""),

--- a/src/aula/utils/download.py
+++ b/src/aula/utils/download.py
@@ -7,6 +7,7 @@ from datetime import date, datetime
 from pathlib import Path
 
 from ..api_client import AulaApiClient
+from .mapping import get_in
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -225,12 +226,11 @@ async def download_message_images(
     threads: dict[str, dict] = {}
     for result in search_results:
         raw = result._raw or {}
-        thread_info = raw.get("thread", {})
-        thread_id = str(thread_info.get("id", ""))
+        thread_id = str(get_in(raw, "thread.id", default=""))
         if thread_id and thread_id not in threads:
-            send_dt = (raw.get("searchMessage") or {}).get("sendDateTime", "")
+            send_dt = get_in(raw, "searchMessage.sendDateTime", default="")
             threads[thread_id] = {
-                "subject": thread_info.get("subject", "No Subject"),
+                "subject": get_in(raw, "thread.subject", default="No Subject"),
                 "date": _parse_date_str(send_dt),
             }
 

--- a/src/aula/utils/mapping.py
+++ b/src/aula/utils/mapping.py
@@ -1,0 +1,23 @@
+"""Helpers for reading nested values out of API responses."""
+
+from typing import Any
+
+
+def get_in(data: Any, path: str, default: Any = None) -> Any:
+    """Read a dotted key path out of *data*.
+
+    Aula sends an explicit ``null`` for objects it leaves empty, so a missing
+    key and a present-but-null one mean the same thing here. Both give
+    *default*, as does a value with an unexpected shape.
+
+    >>> get_in({"profilePicture": {"url": "http://x"}}, "profilePicture.url")
+    'http://x'
+    >>> get_in({"profilePicture": None}, "profilePicture.url", default="")
+    ''
+    """
+    for key in path.split("."):
+        try:
+            data = data[key]
+        except KeyError, IndexError, TypeError:
+            return default
+    return default if data is None else data

--- a/tests/utils/test_mapping.py
+++ b/tests/utils/test_mapping.py
@@ -1,0 +1,50 @@
+"""Tests for aula.utils.mapping."""
+
+from aula.utils.mapping import get_in
+
+
+def test_reads_a_nested_value():
+    assert get_in({"profilePicture": {"url": "http://x"}}, "profilePicture.url") == "http://x"
+
+
+def test_reads_a_single_key():
+    assert get_in({"title": "Heading"}, "title") == "Heading"
+
+
+def test_null_intermediate_gives_default():
+    """Aula sends null, not a missing key, for a child without a picture."""
+    assert get_in({"profilePicture": None}, "profilePicture.url", default="") == ""
+
+
+def test_null_leaf_gives_default():
+    """A default means the caller wants a value, not None."""
+    assert get_in({"profilePicture": {"url": None}}, "profilePicture.url", default="") == ""
+
+
+def test_missing_key_gives_default():
+    assert get_in({}, "profilePicture.url", default="") == ""
+
+
+def test_wrong_shape_gives_default():
+    assert get_in({"profilePicture": "not-a-dict"}, "profilePicture.url", default="") == ""
+
+
+def test_none_input_gives_default():
+    """Lets callers drop the `if child._raw:` guard around a lookup."""
+    assert get_in(None, "institutionProfile.institutionCode", default="") == ""
+
+
+def test_default_defaults_to_none():
+    assert get_in({}, "primaryResource.name") is None
+
+
+def test_deep_path():
+    data = {"data": {"pageConfiguration": {"widgetConfigurations": [1, 2]}}}
+    assert get_in(data, "data.pageConfiguration.widgetConfigurations", default=[]) == [1, 2]
+
+
+def test_falsy_values_are_returned_as_is():
+    """Only None is treated as absent, so 0 and "" survive."""
+    assert get_in({"a": {"b": 0}}, "a.b", default=99) == 0
+    assert get_in({"a": {"b": ""}}, "a.b", default="x") == ""
+    assert get_in({"a": {"b": []}}, "a.b", default=[1]) == []


### PR DESCRIPTION
Closes #53.

## The problem

Aula sends an explicit null for objects it leaves empty, so `.get(k, {})` returns `None` and the next `.get` raises. #52 fixed the chained form by hand at 32 sites, which left the pattern itself in place for the next field anyone adds.

## The helper

`src/aula/utils/mapping.py`:

```python
def get_in(data: Any, path: str, default: Any = None) -> Any:
    for key in path.split("."):
        try:
            data = data[key]
        except (KeyError, IndexError, TypeError):
            return default
    return default if data is None else data
```

Indexing `None` raises `TypeError`, so null intermediates fall out of the `try` for free, with no type inspection.

| Input | Result with `default=""` |
| --- | --- |
| `{"profilePicture": {"url": "http://x"}}` | `"http://x"` |
| `{"profilePicture": None}` | `""` |
| `{"profilePicture": {"url": None}}` | `""` |
| `{}` | `""` |
| `{"profilePicture": "not-a-dict"}` | `""` |
| `None` | `""` |

The last line, `default if data is None else data`, is a deliberate difference from `toolz.get_in` and `pydash.get`. Both return `None` for a null leaf even when handed a default. Treating null and missing alike at every level means a field annotated `str` cannot come back `None`.

Callsites:

```python
(data.get("profilePicture") or {}).get("url", "")
get_in(data, "profilePicture.url", default="")

(((data.get("data") or {}).get("pageConfiguration")) or {}).get("widgetConfigurations") or []
get_in(data, "data.pageConfiguration.widgetConfigurations", default=[])
```

The `None` row also retires the `if child._raw:` guard at several `cli.py` sites.

## Wider than #53 described

#53 said 9 two-step sites. There are 19. The survey regex behind that number required a simple left-hand side, so it missed every `data = resp.json().get("data", {})`, which is the same shape and the same risk. All converted.

One live gap nobody had flagged: `models/post.py` passed `data.get("ownerProfile", {})` into `ProfileReference.from_dict()`, which raises `AttributeError` on a null owner. Now guarded.

## Where the helper is not used

`models/widget.py` (6 reads), `models/institution_profile.py` and 5 `auth_flow.py` token sites bind an intermediate and read it many times, so they keep `or {}`. Six `get_in` calls sharing one prefix reads worse than one binding.

## Keeping it out

A `pygrep` hook fails the build on `.get(key, {})` in `src/`. Verified both ways: passes on this tree, and on a planted `x.get("a", {}).get("b")` it fails with the file and line. Zero occurrences remain.

## Verification

592 passed, 2 skipped. `ruff check`, `ruff format --check` and all prek hooks clean. `main` collects 584 tests and this branch collects 594, so the difference is exactly the 10 new helper tests and nothing was dropped.