### PR TITLE
fix: make the EasyIQ portal session once under concurrency

### DIFF
--- a/src/aula/widgets/client.py
+++ b/src/aula/widgets/client.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Any, Protocol
 
@@ -117,6 +118,8 @@ class AulaWidgetsClient:
         self._easyiq_identifiers: dict[str, list[tuple[str, str]]] = {}
         # Whether POST /Aula/AuthenticateAulaUser has run for this client.
         self._easyiq_session_ready = False
+        # Serialises the bootstrap so concurrent week reads make it once.
+        self._easyiq_session_lock = asyncio.Lock()
         # child UniLogin (casefolded) -> EasyIQ's own ID, from GetChildren.
         self._easyiq_child_ids: dict[str, str] = {}
 
@@ -235,10 +238,27 @@ class AulaWidgetsClient:
         Best-effort: a failure is logged rather than raised, leaving the
         identifier guessing in :meth:`easyiq_identifier_variants` as a
         fallback for institutions this flow does not suit.
+
+        Safe to await concurrently: callers reading several weeks or children
+        at once share the one bootstrap rather than each making their own.
         """
         if self._easyiq_session_ready or not child_user_ids:
             return
 
+        async with self._easyiq_session_lock:
+            # Another caller may have finished the bootstrap while this one
+            # waited for the lock. Re-check rather than repeat it.
+            if self._easyiq_session_ready:
+                return
+            await self._bootstrap_easyiq_session(institution_filter, guardian_login, child_user_ids)
+
+    async def _bootstrap_easyiq_session(
+        self,
+        institution_filter: list[str],
+        guardian_login: str,
+        child_user_ids: list[str],
+    ) -> None:
+        """Make the portal session and read its child IDs. Holds the lock."""
         token = await self._get_bearer_token(WIDGET_EASYIQ_HOMEWORK)
         headers = self.easyiq_headers(token, institution_filter, guardian_login, child_user_ids)
         try:

--- a/tests/test_widgets_client.py
+++ b/tests/test_widgets_client.py
@@ -1,5 +1,6 @@
 """Tests for widget token and provider endpoints."""
 
+import asyncio
 from unittest.mock import AsyncMock, Mock, call
 
 import pytest
@@ -335,6 +336,45 @@ class TestWidgetsClient:
 
         assert [hw.subject for hw in homework] == ["Matematik"]
         assert client._request_with_version_retry.await_count == 7
+
+    @pytest.mark.asyncio
+    async def test_portal_session_runs_once_under_concurrency(self, unbootstrapped_client):
+        """Callers reading several children at once share the one bootstrap.
+
+        The ready flag alone does not settle this: every caller sees it unset
+        while the first is still awaiting the POST, so each would sign in
+        again and the portal would be asked to open a session per child.
+        """
+        client = unbootstrapped_client
+        authenticate_calls = 0
+
+        async def _dispatch(method, url, **kwargs):
+            nonlocal authenticate_calls
+            # Yield, so the callers really do interleave inside the bootstrap
+            # rather than each running start to finish.
+            await asyncio.sleep(0)
+            if "getAulaToken" in url:
+                return _token_response("token-boot")
+            if url.endswith(EASYIQ_AUTHENTICATE_PATH):
+                authenticate_calls += 1
+                return _calendar_response(None)
+            if url.endswith(EASYIQ_CHILDREN_PATH):
+                return _calendar_response({"Children": [{"Id": "9001", "Login": "astr8360"}]})
+            raise AssertionError(f"unexpected request: {url}")
+
+        client._request_with_version_retry = _dispatch
+
+        await asyncio.gather(
+            *(
+                client.widgets.ensure_easyiq_session(
+                    ["inst-1"], "guardian-1", ["astr8360", "kris37r9"]
+                )
+                for _ in range(4)
+            )
+        )
+
+        assert authenticate_calls == 1
+        assert client.widgets.resolve_easyiq_child_id("astr8360") == "9001"
 
     @pytest.mark.asyncio
     async def test_a_failed_bootstrap_leaves_the_guessing_fallback(self, unbootstrapped_client):


### PR DESCRIPTION
## Problem

`ensure_easyiq_session` was guarded by a plain `_easyiq_session_ready` flag:

```python
if self._easyiq_session_ready or not child_user_ids:
    return
```

That settles nothing when callers arrive together. Every one of them sees the flag unset while the first is still awaiting `AuthenticateAulaUser`, so they all sign in and the portal is asked to open a session per caller.

The Home Assistant integration hits this on its first refresh, where it reads the weekly plan and homework for every child through `asyncio.gather` — so a two-child account makes four bootstrap POSTs instead of one.

## Fix

An `asyncio.Lock` with a re-check inside, so the losers of the race return once the winner is done rather than repeating its work.

The body moves to `_bootstrap_easyiq_session` so its early returns still mean "give up on the bootstrap" rather than "release the lock early".

A failed bootstrap still leaves the flag unset, so a later call retries rather than being stuck with the guessing fallback for the client's lifetime. Concurrent callers now retry serially rather than in parallel — same total request count, and it preserves the retry.

## Testing

New `test_portal_session_runs_once_under_concurrency` drives four concurrent `ensure_easyiq_session` calls through a dispatcher that yields inside the bootstrap, so the callers really interleave.

Verified it catches the regression — reverting the lock gives `assert 4 == 1`.

Full suite: 593 passed, 2 skipped.