### PR TITLE
fix: parse daily overview location as an object

### DIFF
--- a/src/aula/cli.py
+++ b/src/aula/cli.py
@@ -675,8 +675,8 @@ async def overview(ctx, child_id):
                     details.append(("Exit", data.exit_time))
                 if data.exit_with:
                     details.append(("Exit with", data.exit_with))
-                if data.location:
-                    details.append(("Location", data.location))
+                if data.location and data.location.name:
+                    details.append(("Location", data.location.name))
                 if data.comment:
                     details.append(("Comment", data.comment))
 
@@ -3225,7 +3225,7 @@ async def update_presence(
             )
             cur_who = tmpl.exit_with if tmpl else (ov.exit_with if ov else None)
             cur_comment = tmpl.comment if tmpl else (ov.comment if ov else None)
-            location = ov.location if ov and ov.location else None
+            location = ov.location.name if ov and ov.location else None
 
             click.echo(f"  {c.name}")
             click.echo(f"    Status:      {status_str}")
@@ -3868,8 +3868,8 @@ async def daily_summary(ctx, child, target_date):
                     click.echo(f"- Check-in: {ov.check_in_time}")
                 if ov.check_out_time:
                     click.echo(f"- Check-out: {ov.check_out_time}")
-                if ov.location:
-                    click.echo(f"- Location: {ov.location}")
+                if ov.location and ov.location.name:
+                    click.echo(f"- Location: {ov.location.name}")
                 if ov.main_group:
                     click.echo(f"- Group: {ov.main_group.name}")
 

--- a/src/aula/models/__init__.py
+++ b/src/aula/models/__init__.py
@@ -29,6 +29,7 @@ from .pickup_responsible import PickupPerson as PickupPerson
 from .post import Post as Post
 from .presence import ActivityType as ActivityType
 from .presence import PresenceState as PresenceState
+from .presence_location import PresenceLocation as PresenceLocation
 from .presence_registration import ChildPresenceState as ChildPresenceState
 from .presence_registration import PresenceActivity as PresenceActivity
 from .presence_registration import PresenceConfiguration as PresenceConfiguration

--- a/src/aula/models/daily_overview.py
+++ b/src/aula/models/daily_overview.py
@@ -7,6 +7,7 @@ from .base import AulaDataClass
 from .institution_profile import InstitutionProfile
 from .main_group import MainGroup
 from .presence import PresenceState
+from .presence_location import PresenceLocation
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,7 +22,7 @@ class DailyOverview(AulaDataClass):
     institution_profile: InstitutionProfile | None = None
     main_group: MainGroup | None = None
     status: PresenceState | None = None
-    location: str | None = None
+    location: PresenceLocation | None = None
     sleep_intervals: list[SleepInterval] = dataclasses.field(default_factory=list)
     check_in_time: str | None = None
     check_out_time: str | None = None
@@ -48,7 +49,7 @@ class DailyOverview(AulaDataClass):
             _raw=raw_data,
             id=raw_data.get("id"),
             status=presence_status,
-            location=raw_data.get("location"),
+            location=PresenceLocation.parse(raw_data.get("location")),
             sleep_intervals=raw_data.get("sleepIntervals", []),
             check_in_time=raw_data.get("checkInTime"),
             check_out_time=raw_data.get("checkOutTime"),

--- a/src/aula/models/presence_location.py
+++ b/src/aula/models/presence_location.py
@@ -1,0 +1,59 @@
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from .base import AulaDataClass
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class PresenceLocation(AulaDataClass):
+    """Where a child physically is, as reported by the presence endpoints.
+
+    Aula sends this as an object, not a string: the Android app models it as
+    ``PresenceLocationDto {long Id, string Name, string Description, string
+    Symbol}``. The live payload carries more keys than that (time and date
+    intervals, weekday masks), so the four the official client reads are named
+    here and the rest stay in ``_raw``.
+    """
+
+    id: int | None = None
+    name: str = ""
+    description: str = ""
+    symbol: str = ""
+    _raw: dict | None = field(default=None, repr=False)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PresenceLocation:
+        location_id = data.get("id")
+        try:
+            location_id = int(location_id) if location_id is not None else None
+        except TypeError, ValueError:
+            _LOGGER.warning("Non-numeric location id received: %s", location_id)
+            location_id = None
+
+        return cls(
+            _raw=data,
+            id=location_id,
+            name=data.get("name") or "",
+            description=data.get("description") or "",
+            symbol=data.get("symbol") or "",
+        )
+
+    @classmethod
+    def parse(cls, value: Any) -> PresenceLocation | None:
+        """Build a location from whatever the API sent, or None if it sent nothing.
+
+        A bare string is accepted as the name. No response is known to use that
+        shape, but it costs nothing to keep older or unseen payloads working.
+        """
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            return cls.from_dict(value)
+        if isinstance(value, str):
+            return cls(name=value) if value else None
+
+        _LOGGER.warning("Unexpected location value received: %r", value)
+        return None

--- a/tests/models/test_daily_overview.py
+++ b/tests/models/test_daily_overview.py
@@ -2,13 +2,25 @@
 
 from aula.models.daily_overview import DailyOverview
 from aula.models.presence import PresenceState
+from aula.models.presence_location import PresenceLocation
+
+# The shape Aula actually sends, matching PresenceLocationDto in the Android app.
+LOCATION_PAYLOAD = {
+    "id": 4321,
+    "name": "Ude",
+    "description": "",
+    "symbol": "icon-Aula_sfo_slide",
+    "startTime": None,
+    "endTime": None,
+    "isDeactivated": False,
+}
 
 
 def test_daily_overview_from_dict_full():
     data = {
         "id": 1,
         "status": 3,
-        "location": "Room A",
+        "location": LOCATION_PAYLOAD,
         "sleepIntervals": [{"start": "10:00", "end": "11:00"}],
         "checkInTime": "08:00",
         "checkOutTime": "16:00",
@@ -26,7 +38,11 @@ def test_daily_overview_from_dict_full():
     overview = DailyOverview.from_dict(data)
     assert overview.id == 1
     assert overview.status == PresenceState.PRESENT
-    assert overview.location == "Room A"
+    assert overview.location is not None
+    assert overview.location.id == 4321
+    assert overview.location.name == "Ude"
+    assert overview.location.symbol == "icon-Aula_sfo_slide"
+    assert overview.location._raw is LOCATION_PAYLOAD
     assert overview.sleep_intervals == [{"start": "10:00", "end": "11:00"}]
     assert overview.check_in_time == "08:00"
     assert overview.check_out_time == "16:00"
@@ -58,8 +74,26 @@ def test_daily_overview_unknown_status():
 
 
 def test_daily_overview_dict_conversion():
-    overview = DailyOverview(id=1, location="Room B")
+    overview = DailyOverview(id=1, location=PresenceLocation(id=7, name="Hal"))
     result = dict(overview)
     assert result["id"] == 1
-    assert result["location"] == "Room B"
+    assert result["location"] == {
+        "id": 7,
+        "name": "Hal",
+        "description": "",
+        "symbol": "",
+    }
     assert "_raw" not in result
+
+
+def test_daily_overview_location_absent():
+    overview = DailyOverview.from_dict({"status": 3})
+    assert overview.location is None
+
+
+def test_daily_overview_location_string_fallback():
+    """No response is known to send a bare string, but it must not break parsing."""
+    overview = DailyOverview.from_dict({"location": "Room A"})
+    assert overview.location is not None
+    assert overview.location.name == "Room A"
+    assert overview.location.id is None

--- a/tests/models/test_presence_location.py
+++ b/tests/models/test_presence_location.py
@@ -1,0 +1,78 @@
+"""Tests for aula.models.presence_location."""
+
+from aula.models.presence_location import PresenceLocation
+
+
+def test_from_dict_full():
+    data = {
+        "id": 1234,
+        "name": "Hal",
+        "description": "Gymnastiksalen",
+        "symbol": "icon-Aula_sfo_gymnastic_hall",
+        "weekDayMask": None,
+    }
+    location = PresenceLocation.from_dict(data)
+    assert location.id == 1234
+    assert location.name == "Hal"
+    assert location.description == "Gymnastiksalen"
+    assert location.symbol == "icon-Aula_sfo_gymnastic_hall"
+    assert location._raw is data
+
+
+def test_from_dict_missing_optional():
+    location = PresenceLocation.from_dict({"name": "Ude"})
+    assert location.id is None
+    assert location.name == "Ude"
+    assert location.description == ""
+    assert location.symbol == ""
+
+
+def test_from_dict_null_fields():
+    """Aula sends explicit nulls rather than omitting keys."""
+    location = PresenceLocation.from_dict({"id": None, "name": "Ude", "description": None})
+    assert location.id is None
+    assert location.description == ""
+
+
+def test_from_dict_string_id_is_coerced():
+    assert PresenceLocation.from_dict({"id": "99"}).id == 99
+
+
+def test_from_dict_non_numeric_id_is_dropped(caplog):
+    location = PresenceLocation.from_dict({"id": "abc", "name": "Ude"})
+    assert location.id is None
+    assert location.name == "Ude"
+    assert "Non-numeric location id" in caplog.text
+
+
+def test_parse_dict():
+    location = PresenceLocation.parse({"id": 1, "name": "Ude"})
+    assert location is not None
+    assert location.name == "Ude"
+
+
+def test_parse_none():
+    assert PresenceLocation.parse(None) is None
+
+
+def test_parse_string():
+    location = PresenceLocation.parse("Room A")
+    assert location is not None
+    assert location.name == "Room A"
+    assert location._raw is None
+
+
+def test_parse_empty_string():
+    assert PresenceLocation.parse("") is None
+
+
+def test_parse_unexpected_type(caplog):
+    assert PresenceLocation.parse(42) is None
+    assert "Unexpected location value" in caplog.text
+
+
+def test_dict_conversion_excludes_raw():
+    location = PresenceLocation.from_dict({"id": 1, "name": "Ude"})
+    result = dict(location)
+    assert result == {"id": 1, "name": "Ude", "description": "", "symbol": ""}
+    assert "_raw" not in result


### PR DESCRIPTION
Closes #56.

`presence.getDailyOverview` returns `location` as an object, but our model declared it `str | None` and stored the raw dict unparsed. Whenever a child had presence status 7 (physical placement), the CLI printed the whole dict instead of a name.

The shape is confirmed against the decompiled Android app (v2.15.2.1), which models it as `PresenceLocationDto {long Id, string Name, string Description, string Symbol}` and reuses the same DTO on the employee side. The live payload carries more keys than that, so the four the official client reads are named and the rest stay in `_raw`.

## Changes

- New `PresenceLocation` model in `src/aula/models/presence_location.py`, exported from `models/__init__.py`. `id` is coerced to `int`, with a warning and `None` when it is not numeric.
- `DailyOverview.location` is now `PresenceLocation | None`, parsed through `PresenceLocation.parse()`.
- `parse()` accepts the object, a bare string as the name, `None`, and anything else (warns, returns `None`). No response is known to send a string, but it costs nothing to keep older or unseen payloads working.
- The three CLI sites that showed the location now print `location.name`, each guarded against an empty name.

## Tests

New `tests/models/test_presence_location.py` covers the full object, missing and null fields, string id coercion, a non-numeric id, all four `parse` inputs, and `_raw` exclusion from `dict()`. The daily overview fixture is rewritten to the real payload shape, with the string form kept as an explicit fallback case.

`606 passed, 2 skipped`

## Note for consumers

`dict(overview)["location"]` now yields the trimmed four key dict instead of the raw API dict, so `--json` output for daily overview changes shape. hass-aula pins `aula==1.6.0` and is unaffected until that pin moves, at which point its sensor attribute wants `location.name`.
