### PR TITLE
fix: select the MitID combination the account was offered

### DIFF
--- a/src/aula/auth/browser_client.py
+++ b/src/aula/auth/browser_client.py
@@ -106,6 +106,8 @@ class BrowserClient:
         self._authenticator_eafe_hash: str | None = None
         self._authenticator_session_id: str | None = None
         self._finalization_session_id: str | None = None
+        # Authenticator name -> the combination id this account was offered.
+        self._combination_ids: dict[str, str] = {}
 
         # Session context (populated after initialize)
         self._broker_security_context: str | None = None
@@ -210,6 +212,8 @@ class BrowserClient:
                 "Ignoring MitID authenticator combinations with no client support: %s",
                 ", ".join(unsupported),
             )
+
+        self._record_combination_ids(combinations)
 
         return {
             _COMBINATION_ID_TO_NAME[combo["id"]]: combo["combinationItems"][0]["name"]
@@ -597,14 +601,52 @@ class BrowserClient:
 
         return hmac.new(proof_key, payload, hashlib.sha256).hexdigest()
 
+    def _record_combination_ids(self, combinations: list[dict]) -> None:
+        """Remember which combination id this account carries per authenticator.
+
+        MitID serves the same authenticator under different ids depending on the
+        account: the app is S3, S4 (app plus chip) or L2. When more than one id
+        maps to the same name, the one in ``_NAME_TO_COMBINATION_ID`` wins so a
+        plain app account keeps selecting S3 over the chip variant.
+        """
+        offered: dict[str, list[str]] = {}
+        for combo in combinations:
+            name = _COMBINATION_ID_TO_NAME.get(combo["id"])
+            if name:
+                offered.setdefault(name, []).append(combo["id"])
+
+        self._combination_ids = {}
+        for name, ids in offered.items():
+            preferred = _NAME_TO_COMBINATION_ID.get(name)
+            self._combination_ids[name] = preferred if preferred in ids else ids[0]
+
+    def _combination_id_for(self, authenticator_type: str) -> str:
+        """Return the combination id to post when selecting this authenticator.
+
+        The id the server listed during identify wins. The static table is only
+        a fallback for a caller that selects without identifying first.
+        """
+        if authenticator_type not in _NAME_TO_COMBINATION_ID:
+            raise MitIDError(f"No such authenticator name ({authenticator_type})")
+
+        if not self._combination_ids:
+            return _NAME_TO_COMBINATION_ID[authenticator_type]
+
+        combination_id = self._combination_ids.get(authenticator_type)
+        if combination_id is None:
+            offered = ", ".join(sorted(self._combination_ids)) or "none"
+            raise MitIDError(
+                f"{authenticator_type} authentication is not available for this MitID user "
+                f"(available: {offered})"
+            )
+        return combination_id
+
     async def _select_authenticator(self, authenticator_type: str) -> None:
         """Select a specific authenticator type."""
         if self._authenticator_type == authenticator_type:
             return
 
-        combination_id = _NAME_TO_COMBINATION_ID.get(authenticator_type)
-        if not combination_id:
-            raise MitIDError(f"No such authenticator name ({authenticator_type})")
+        combination_id = self._combination_id_for(authenticator_type)
 
         r = await self._client.post(
             self._base_url(version=2) + "/next",

--- a/tests/auth/test_browser_client.py
+++ b/tests/auth/test_browser_client.py
@@ -7,7 +7,7 @@ import logging
 import httpx
 import pytest
 
-from aula.auth.browser_client import BrowserClient
+from aula.auth.browser_client import _COMBINATION_ID_TO_NAME, BrowserClient
 from aula.auth.exceptions import MitIDError, PasswordInvalidError, TokenInvalidError
 
 SESSION_ID = "auth-session-1"
@@ -49,12 +49,21 @@ class FakeMitID:
         password_invalid: bool = False,
         authenticator_after_token: str = "PASSWORD",
         extra_combinations: list[dict] | None = None,
+        combinations: list[dict] | None = None,
+        default_authenticator: str = "APP",
     ):
         self.latency = latency
         self.totp_invalid = totp_invalid
         self.password_invalid = password_invalid
         self.authenticator_after_token = authenticator_after_token
         self.extra_combinations = extra_combinations or []
+        self.combinations = combinations or [
+            {"id": "S3", "combinationItems": [{"name": "MitID app"}]},
+            {"id": "S1", "combinationItems": [{"name": "MitID kodeviser"}]},
+        ]
+        self.default_authenticator = default_authenticator
+        # Combination ids the client asked for, in order.
+        self.selected: list[str] = []
 
         self.paths: list[str] = []
         self.bodies: dict[str, dict] = {}
@@ -109,11 +118,17 @@ class FakeMitID:
     def _handle_next(self, request: httpx.Request) -> httpx.Response:
         combination_id = _json_body(request)["combinationId"]
 
-        # Selecting the kodeviser explicitly.
-        if combination_id == "S1":
+        # Selecting an authenticator explicitly. MitID answers with whatever the
+        # requested combination maps to, so unoffered ids never get this far.
+        if combination_id:
+            self.selected.append(combination_id)
+            if combination_id not in [combo["id"] for combo in self._all_combinations()]:
+                return httpx.Response(400, json={"errorCode": "control.no_such_combination"})
+            name = _COMBINATION_ID_TO_NAME[combination_id]
+            session_id = TOKEN_SESSION_ID if name == "TOKEN" else "app-session-2"
             return httpx.Response(
                 200,
-                json={"errors": [], "nextAuthenticator": _authenticator("TOKEN", TOKEN_SESSION_ID)},
+                json={"errors": [], "nextAuthenticator": _authenticator(name, session_id)},
             )
 
         # Advancing after the password proof: hand back the finalization session.
@@ -143,19 +158,18 @@ class FakeMitID:
                 },
             )
 
-        # The identify step: MitID defaults to the app authenticator.
+        # The identify step: MitID hands back a default authenticator.
         return httpx.Response(
             200,
             json={
                 "errors": [],
-                "nextAuthenticator": _authenticator("APP", "app-session-1"),
-                "combinations": [
-                    {"id": "S3", "combinationItems": [{"name": "MitID app"}]},
-                    {"id": "S1", "combinationItems": [{"name": "MitID kodeviser"}]},
-                    *self.extra_combinations,
-                ],
+                "nextAuthenticator": _authenticator(self.default_authenticator, "app-session-1"),
+                "combinations": self._all_combinations(),
             },
         )
+
+    def _all_combinations(self) -> list[dict]:
+        return [*self.combinations, *self.extra_combinations]
 
 
 def _json_body(request: httpx.Request) -> dict:
@@ -257,6 +271,101 @@ class TestKodeviserFlow:
 
         assert "S9" not in authenticators
         assert "S9" in caplog.text
+
+
+APP = {"id": "S3", "combinationItems": [{"name": "MitID app"}]}
+APP_CHIP = {"id": "S4", "combinationItems": [{"name": "MitID app + chip"}]}
+APP_LOW = {"id": "L2", "combinationItems": [{"name": "MitID app"}]}
+KODEVISER = {"id": "S1", "combinationItems": [{"name": "MitID kodeviser"}]}
+
+
+class TestAuthenticatorSelection:
+    """MitID serves the same authenticator under different combination ids per account,
+    so the id the server listed during identify is the one to post back."""
+
+    @pytest.mark.asyncio
+    async def test_selects_the_id_the_account_was_offered(self):
+        """This account carries the app as S4; posting a hardcoded S3 would fail."""
+        server = FakeMitID(combinations=[APP_CHIP, KODEVISER], default_authenticator="TOKEN")
+        client, _ = await _identified_client(server)
+
+        await client._select_authenticator("APP")
+
+        assert server.selected == ["S4"]
+        assert client._authenticator_type == "APP"
+
+    @pytest.mark.asyncio
+    async def test_prefers_the_plain_app_over_the_chip_variant(self):
+        """S4 needs a physical chip, so it must not win when a plain app is offered."""
+        server = FakeMitID(
+            combinations=[APP_CHIP, APP, APP_LOW, KODEVISER], default_authenticator="TOKEN"
+        )
+        client, _ = await _identified_client(server)
+
+        await client._select_authenticator("APP")
+
+        assert server.selected == ["S3"]
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_the_low_assurance_app(self):
+        server = FakeMitID(combinations=[APP_LOW, KODEVISER], default_authenticator="TOKEN")
+        client, _ = await _identified_client(server)
+
+        await client._select_authenticator("APP")
+
+        assert server.selected == ["L2"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_ids_do_not_disturb_selection(self):
+        """An id we have no name for (S2 and friends) is skipped, not treated as the app."""
+        server = FakeMitID(
+            combinations=[{"id": "S2", "combinationItems": [{"name": "?"}]}, APP_CHIP, KODEVISER],
+            default_authenticator="TOKEN",
+        )
+        client, _ = await _identified_client(server)
+
+        await client._select_authenticator("APP")
+
+        assert server.selected == ["S4"]
+
+    @pytest.mark.asyncio
+    async def test_kodeviser_selection_is_unchanged(self):
+        server = FakeMitID()
+        client, _ = await _identified_client(server)
+
+        await client._select_authenticator("TOKEN")
+
+        assert server.selected == ["S1"]
+
+    @pytest.mark.asyncio
+    async def test_refuses_an_authenticator_the_account_does_not_have(self):
+        """Better a named error than an HTTP failure on a combination MitID never listed."""
+        server = FakeMitID(combinations=[KODEVISER], default_authenticator="TOKEN")
+        client, _ = await _identified_client(server)
+
+        with pytest.raises(MitIDError, match="APP authentication is not available"):
+            await client._select_authenticator("APP")
+
+        assert server.selected == []
+
+    @pytest.mark.asyncio
+    async def test_rejects_a_name_no_authenticator_maps_to(self):
+        server = FakeMitID()
+        client, _ = await _identified_client(server)
+
+        with pytest.raises(MitIDError, match="No such authenticator name"):
+            await client._select_authenticator("FACE_ID")
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_the_static_table_without_identify(self):
+        """Selecting without identifying first has no offered ids to go on."""
+        server = FakeMitID()
+        http_client = httpx.AsyncClient(transport=httpx.MockTransport(server))
+        client = BrowserClient("client-hash", SESSION_ID, http_client)
+
+        await client._select_authenticator("APP")
+
+        assert server.selected == ["S3"]
 
 
 class TestFrontEndProcessingTime:


### PR DESCRIPTION
Closes #55.

`_select_authenticator` posted a hardcoded combination id: `S3` for the app, `S1` for the kodeviser. MitID serves the same authenticator under different ids depending on the account, so an account carrying the app only as `S4` (app plus chip) or `L2`, whose session default is not the app, got a request for a combination the server never listed.

The ids are in the identify response already. `identify_as_user_and_get_available_authenticators` now records them per authenticator name, and selection posts the one the server gave us.

## Details

- When several ids map to the same name, the old table decides, so a plain app account keeps selecting `S3` rather than the chip variant `S4`. Behaviour for those accounts is unchanged.
- The table remains the fallback for a caller that selects without identifying first.
- Selecting an authenticator the account does not have now raises a named error listing what it does have, instead of letting MitID answer with an HTTP error.
- Unknown ids such as `S2` are still skipped with the existing warning and no longer risk being confused with a supported combination.

## Tests

New `TestAuthenticatorSelection` covers: selecting the offered id when it is not `S3`, preferring the plain app over the chip variant, falling back to `L2`, ignoring unknown ids during selection, unchanged kodeviser selection, the not-available error, an unmapped authenticator name, and the no-identify fallback. The fake MitID backend now takes a combinations list and a default authenticator, and records the ids the client asked for.

`614 passed, 2 skipped`

## Context

Upstream scaarup/aula hits the neighbouring version of this in [#365](https://github.com/scaarup/aula/issues/365) and [#291](https://github.com/scaarup/aula/issues/291), where an unknown id raises during enumeration. We already skip those, but we were still assuming a fixed id when selecting.
