### PR TITLE
fix: warn when EasyIQ answers with no readable data

### DIFF
--- a/src/aula/widgets/client.py
+++ b/src/aula/widgets/client.py
@@ -36,6 +36,9 @@ from ..utils.week import monday_of_week
 
 _LOGGER = logging.getLogger(__name__)
 
+# Enough of an unreadable body to identify it, not enough to fill a log file.
+_BODY_LOG_LIMIT = 300
+
 
 def _as_list(data: Any, provider: str) -> list[Any]:
     """Return ``data`` if it is a list of dicts, else log and return an empty list.
@@ -75,11 +78,13 @@ def _ordered_unique(pairs: list[tuple[str, str]]) -> list[tuple[str, str]]:
     return unique
 
 
-def _extract_events(payload: Any) -> list[dict[str, Any]]:
+def _find_events(payload: Any) -> list[dict[str, Any]] | None:
     """Pull the event list out of EasyIQ's calendar response.
 
     The portal has answered with both a bare array and an object wrapping one,
-    so both shapes are unwrapped rather than assumed.
+    so both shapes are unwrapped rather than assumed. ``None`` means neither
+    was there, which is how an error answer arrives: 2xx, a body, no events
+    anywhere in it. An empty list is a real answer and stays distinct from it.
     """
     if isinstance(payload, list):
         return [event for event in payload if isinstance(event, dict)]
@@ -89,10 +94,32 @@ def _extract_events(payload: Any) -> list[dict[str, Any]]:
             if isinstance(value, list):
                 return [event for event in value if isinstance(event, dict)]
             if isinstance(value, dict):
-                nested = _extract_events(value)
+                nested = _find_events(value)
                 if nested:
                     return nested
-    return []
+    return None
+
+
+def _log_unreadable_body(source: str, payload: Any, **context: str) -> None:
+    """Warn about a 2xx body carrying nothing we recognise.
+
+    EasyIQ answers this way when a school is not licensed for a widget, and the
+    body is the only place the reason appears. Without a warning it is
+    indistinguishable from a genuinely empty week, which has cost people hours.
+    The envelope is undocumented and differs between EasyIQ's two backends, so
+    the keys and a truncated body are logged rather than named fields.
+    """
+    body = repr(payload)
+    if len(body) > _BODY_LOG_LIMIT:
+        body = body[:_BODY_LOG_LIMIT] + "..."
+
+    _LOGGER.warning(
+        "%s returned no readable data (%s): keys=%s body=%s",
+        source,
+        ", ".join(f"{name}={value}" for name, value in context.items()),
+        sorted(payload) if isinstance(payload, dict) else None,
+        body,
+    )
 
 
 class _WidgetRequestClient(Protocol):
@@ -355,6 +382,7 @@ class AulaWidgetsClient:
 
         first_empty: list[EasyIQCalendarEvent] | None = None
         last_error: Exception | None = None
+        unreadable: list[Any] = []
 
         for login_id, child_header in self.easyiq_identifier_variants(
             child_profile_id,
@@ -377,12 +405,29 @@ class AulaWidgetsClient:
                 _LOGGER.debug("EasyIQ %s rejected loginId=%s: %s", path, login_id, e)
                 continue
 
-            events = [EasyIQCalendarEvent.from_dict(e) for e in _extract_events(resp.json())]
+            payload = resp.json()
+            found = _find_events(payload)
+            if found is None:
+                # Nothing readable in this answer; the next identifier may fare
+                # better, so keep the body for the warning and carry on.
+                unreadable.append(payload)
+                continue
+
+            events = [EasyIQCalendarEvent.from_dict(e) for e in found]
             if events:
                 self._easyiq_identifiers[child_user_id] = [(login_id, child_header)]
                 return events
             if first_empty is None:
                 first_empty = events
+
+        if unreadable:
+            _log_unreadable_body(
+                f"EasyIQ {path}",
+                unreadable[0],
+                widget=widget_id,
+                child=child_user_id,
+                week=week,
+            )
 
         if first_empty is not None:
             return first_empty
@@ -494,6 +539,12 @@ class AulaWidgetsClient:
             envelope = data.get("data") if isinstance(data, dict) else None
             if isinstance(envelope, dict):
                 appointments = _as_list(envelope.get("appointments", []), "EasyIQ weekplan")
+            elif not (isinstance(data, dict) and "data" in data):
+                # An explicit null under "data" is the API saying it has none.
+                # Anything else means we are reading a shape we do not know.
+                _log_unreadable_body(
+                    "EasyIQ weekplaninfo", data, widget=widget_id, child=child_id, week=week
+                )
         except Exception as e:
             if child_profile_id is None:
                 raise

--- a/tests/test_widgets_client.py
+++ b/tests/test_widgets_client.py
@@ -575,6 +575,119 @@ class TestWidgetsClient:
         assert [a.title for a in appointments] == ["Idræt"]
 
     @pytest.mark.asyncio
+    async def test_easyiq_calendar_warns_when_the_body_carries_no_events(self, client, caplog):
+        """A licensing error arrives as 2xx with an error object; silence reads as an empty week."""
+        envelope = {"ErrorCode": "1", "ErrorDescription": "No license for this school"}
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[
+                _token_response("token-easy"),
+                *[_calendar_response(envelope)] * 4,
+            ]
+        )
+
+        homework = await client.widgets.get_easyiq_homework(
+            week="2026-W09",
+            session_uuid="guardian-1",
+            institution_filter=["inst-1"],
+            child_id="child-user-1",
+            child_profile_id="4242",
+        )
+
+        assert homework == []
+        assert "returned no readable data" in caplog.text
+        assert "ErrorDescription" in caplog.text
+        assert "No license for this school" in caplog.text
+        # The context needed to tell which child and week went missing.
+        assert "child=child-user-1" in caplog.text
+        assert "week=2026-W09" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_easyiq_calendar_stays_quiet_on_a_genuinely_empty_week(self, client, caplog):
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[_token_response("token-easy"), *[_calendar_response([])] * 4]
+        )
+
+        homework = await client.widgets.get_easyiq_homework(
+            week="2026-W09",
+            session_uuid="guardian-1",
+            institution_filter=["inst-1"],
+            child_id="child-user-1",
+            child_profile_id="4242",
+        )
+
+        assert homework == []
+        assert "no readable data" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_easyiq_calendar_truncates_a_long_body(self, client, caplog):
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[
+                _token_response("token-easy"),
+                *[_calendar_response({"error": "x" * 5000})] * 4,
+            ]
+        )
+
+        await client.widgets.get_easyiq_homework(
+            week="2026-W09",
+            session_uuid="guardian-1",
+            institution_filter=["inst-1"],
+            child_id="child-user-1",
+            child_profile_id="4242",
+        )
+
+        assert "..." in caplog.text
+        assert len(caplog.text) < 1000
+
+    @pytest.mark.asyncio
+    async def test_weekplaninfo_warns_when_the_envelope_is_missing(self, client, caplog):
+        """weekplaninfo has the same hole: no data key, and the fallback hides why."""
+        envelope = _calendar_response({"ErrorCode": "1", "ErrorDescription": "Not licensed"})
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[
+                _token_response("token-easy"),
+                envelope,
+                _token_response("token-easy"),
+                _calendar_response([{"itemType": 8, "courses": "Idræt"}]),
+            ]
+        )
+
+        appointments = await client.widgets.get_easyiq_weekplan(
+            "2026-W09",
+            "guardian-1",
+            ["inst-1"],
+            "child-user-1",
+            child_profile_id="4242",
+        )
+
+        # The portal fallback still answers; the warning explains the first leg.
+        assert [a.title for a in appointments] == ["Idræt"]
+        assert "EasyIQ weekplaninfo returned no readable data" in caplog.text
+        assert "Not licensed" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_weekplaninfo_stays_quiet_on_an_explicit_null_envelope(self, client, caplog):
+        """A null under "data" is the API saying it has none, not a shape we cannot read."""
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[
+                _token_response("token-easy"),
+                _calendar_response({"data": None}),
+                _token_response("token-easy"),
+                _calendar_response([{"itemType": 8, "courses": "Idræt"}]),
+            ]
+        )
+
+        appointments = await client.widgets.get_easyiq_weekplan(
+            "2026-W09",
+            "guardian-1",
+            ["inst-1"],
+            "child-user-1",
+            child_profile_id="4242",
+        )
+
+        assert [a.title for a in appointments] == ["Idræt"]
+        assert "no readable data" not in caplog.text
+
+    @pytest.mark.asyncio
     async def test_get_easyiq_weekplan_raises_when_no_profile_id_to_fall_back_with(self, client):
         failing = Mock()
         failing.raise_for_status = Mock(side_effect=AulaNotFoundError("HTTP 404", 404))


### PR DESCRIPTION
Closes #57.

EasyIQ answers 2xx with an error object when a school is not licensed for a widget. Both read paths treated that as an empty week:

- `_extract_events` found none of the known event keys and returned an empty list
- `get_easyiq_weekplan` found no `data` envelope and fell through in silence

The body is the only place the reason appears, and nothing logged it at default verbosity, so a licensing error looked exactly like a quiet week.

## Changes

- `_extract_events` becomes `_find_events` and returns `None` when neither the array nor the wrapped-array shape is there. An empty list stays a real answer, distinct from an unreadable one.
- The calendar caller warns once per call, with the widget id, child and week, and no longer lets an unreadable answer end the identifier loop. The next identifier may still work.
- `get_easyiq_weekplan` warns when the body is not a dict, or is a dict with no `data` key at all. An explicit `{"data": null}` stays quiet, because that is the API saying it has none rather than a shape we cannot read.

## On the message

The warning logs the body keys and a truncated body (300 chars) rather than named fields.

Grounding for the exact envelope is thin, as noted in the issue: widgets `0128` and `0142` are vendor hosted and absent from Aula's sourcemaps, and the decompiled app has no EasyIQ code, so the `{"ErrorCode", "ErrorDescription"}` shape rests on [scaarup/aula#355](https://github.com/scaarup/aula/pull/355) alone, from a different EasyIQ backend than the one we read. Logging the shape rather than the guessed key names means the first user to hit this captures the real payload, and a future envelope with different names is caught too.

## Tests

Five new cases: the error envelope warns and carries child and week context, a genuinely empty week stays quiet, a long body is truncated, `weekplaninfo` warns while the portal fallback still answers, and an explicit null envelope stays quiet.

`619 passed, 2 skipped`
