### PR TITLE
feat(presence): report a child sick, or take the report back

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ async def main():
 asyncio.run(main())
 ```
 
-Key methods on `AulaApiClient`: `get_profile()`, `get_daily_overview(child_id)`, `get_message_threads()`, `get_messages_for_thread(thread_id)`, `get_calendar_events(...)`, `get_posts(...)`, `get_groups(...)`, `get_message_folders(...)`, `search(...)`, `update_presence_template(...)`, `get_profile_master_data(...)`, `get_secure_documents(...)`, `get_consent_responses(...)`, `get_auto_reply()`, `get_vacation_registrations(...)`, `get_notification_settings()`, `keep_alive()`. See `src/aula/api_client.py` for the full list.
+Key methods on `AulaApiClient`: `get_profile()`, `get_daily_overview(child_id)`, `get_message_threads()`, `get_messages_for_thread(thread_id)`, `get_calendar_events(...)`, `get_posts(...)`, `get_groups(...)`, `get_message_folders(...)`, `search(...)`, `update_presence_template(...)`, `update_presence_status(...)`, `get_profile_master_data(...)`, `get_secure_documents(...)`, `get_consent_responses(...)`, `get_auto_reply()`, `get_vacation_registrations(...)`, `get_notification_settings()`, `keep_alive()`. See `src/aula/api_client.py` for the full list.
 
 ### Widget API (Namespace)
 
@@ -183,6 +183,7 @@ The username can also be set via the `AULA_MITID_USERNAME` environment variable 
 | `aula presence` | Presence registrations and states |
 | `aula presence-templates` | Planned entry/exit times |
 | `aula update-presence` | Update pickup/drop-off times |
+| `aula report-sick` | Report a child sick today, or take it back (`--undo`) |
 
 ### Content
 

--- a/src/aula/api_client.py
+++ b/src/aula/api_client.py
@@ -52,6 +52,7 @@ from .models import (
     PresenceConfiguration,
     PresenceRegistration,
     PresenceRegistrationDetail,
+    PresenceState,
     PresenceWeekOverview,
     PresenceWeekTemplate,
     Profile,
@@ -584,6 +585,61 @@ class AulaApiClient:
         )
         resp.raise_for_status()
         return True
+
+    async def update_presence_status(
+        self,
+        institution_profile_ids: list[int],
+        status: PresenceState | int,
+    ) -> bool:
+        """Set today's presence status for children, e.g. report them sick.
+
+        This is the endpoint behind the portal's sick button: reporting a child
+        ill and taking the report back are the same call with a different status.
+        The institution sees the change immediately.
+
+        Aula has no future-dated sick report; this always applies to today. For a
+        planned absence use :meth:`update_presence_template` or a vacation
+        registration instead.
+
+        An institution can withhold this from guardians, in which case Aula
+        rejects the call. :meth:`get_presence_configuration` reports that up
+        front via ``PresenceConfiguration.can_edit(PresenceModule.REPORT_SICK)``.
+
+        Args:
+            institution_profile_ids: Children's institution profile IDs, i.e.
+                ``Child.id``. Several children can be set in one call.
+            status: The status to set. ``PresenceState.SICK`` reports a child
+                sick. To take the report back the portal sends
+                ``PresenceState.NOT_PRESENT`` from the guardian dashboard, and
+                ``PresenceState.PRESENT`` from the presence page, so pick the one
+                that matches the child's real situation. Raw ints are accepted so
+                a status Aula adds later still reaches the backend.
+
+        Returns:
+            True if Aula accepted the change.
+
+        Raises:
+            ValueError: If no institution profile IDs are given.
+        """
+        if not institution_profile_ids:
+            raise ValueError("update_presence_status requires at least one profile ID")
+
+        status_value = status.value if isinstance(status, PresenceState) else status
+        payload: dict[str, Any] = {
+            "institutionProfileIds": institution_profile_ids,
+            "status": status_value,
+        }
+
+        resp = await self._request_with_version_retry(
+            "post",
+            f"{self.api_url}?method=presence.updateStatusByInstitutionProfileIds",
+            json=payload,
+        )
+        resp.raise_for_status()
+        # The endpoint answers with a bare boolean in "data". Older/proxied
+        # responses omit it, so absence is not treated as failure.
+        data = resp.json().get("data")
+        return data if isinstance(data, bool) else True
 
     async def get_pickup_responsibles(
         self,

--- a/src/aula/cli.py
+++ b/src/aula/cli.py
@@ -24,7 +24,18 @@ from .const import (
     WIDGET_MIN_UDDANNELSE_TASKS,
     WIDGET_MIN_UDDANNELSE_UGEPLAN,
 )
-from .models import Child, DailyOverview, Group, Message, MessageThread, Notification, Profile
+from .models import (
+    Child,
+    DailyOverview,
+    Group,
+    Message,
+    MessageThread,
+    Notification,
+    PresenceModule,
+    PresenceModulePermission,
+    PresenceState,
+    Profile,
+)
 from .token_storage import FileTokenStorage
 from .utils.json import to_json
 from .utils.mapping import get_in
@@ -3434,6 +3445,172 @@ async def update_presence(
 
         click.echo()
         click.echo(f"Updated {success_count}/{len(children)} children.")
+
+
+@cli.command("report-sick")
+@click.option(
+    "--child",
+    "child_ids",
+    type=int,
+    multiple=True,
+    help="Specific child institution profile ID(s). Omit to report all children.",
+)
+@click.option(
+    "--undo",
+    is_flag=True,
+    default=False,
+    help="Take the sick report back (sets the child to 'Ikke kommet').",
+)
+@click.option(
+    "--present",
+    is_flag=True,
+    default=False,
+    help="With --undo, set 'Til stede' instead, for a child who is at school.",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip confirmation prompt.",
+)
+@click.pass_context
+@async_cmd
+async def report_sick(ctx, child_ids, undo, present, yes):
+    """Report a child sick for today, or take the report back.
+
+    Writes to Aula and notifies the institution. Applies to today only; Aula has
+    no future-dated sick report, so use `update-presence` or a vacation
+    registration for a planned absence.
+
+    An institution can withhold this from guardians. When it has, the child is
+    skipped with a note rather than sent to a call Aula would reject.
+
+    Examples:
+
+      aula report-sick
+
+      aula report-sick --child 123456 -y
+
+      aula report-sick --undo --child 123456 -y
+    """
+    if present and not undo:
+        print_error("--present only applies together with --undo")
+        return
+
+    if undo:
+        new_status = PresenceState.PRESENT if present else PresenceState.NOT_PRESENT
+    else:
+        new_status = PresenceState.SICK
+
+    is_json = bool(ctx.obj) and ctx.obj.get("OUTPUT_FORMAT") == "json"
+    if is_json and not yes:
+        print_error("--output json requires --yes, since this command writes to Aula")
+        return
+
+    async with await _get_client(ctx) as client:
+        try:
+            prof: Profile = await client.get_profile()
+        except Exception as e:
+            print_error(f"fetching profile: {e}")
+            return
+
+        if not prof.children:
+            print_empty("children")
+            return
+
+        if child_ids:
+            children = [c for c in prof.children if c.id in child_ids]
+            if not children:
+                print_error(f"no children found with IDs: {list(child_ids)}")
+                return
+        else:
+            children = prof.children
+
+        _log = logging.getLogger(__name__)
+
+        # Aula rejects the write when the institution has not granted guardians
+        # the report_sick module, so check first and say which child and why.
+        # A configuration we cannot read is not treated as a denial.
+        blocked: dict[int, str] = {}
+        try:
+            configs = await client.get_presence_configuration([c.id for c in children])
+        except Exception as e:
+            _log.warning("Could not fetch presence configuration: %s", e)
+            configs = []
+
+        by_child = {c.child_id: c for c in configs if c.child_id is not None}
+        for c in children:
+            config = by_child.get(c.id)
+            if config is None:
+                continue
+            if not config.can_edit(PresenceModule.REPORT_SICK):
+                permission = config.permission(PresenceModule.REPORT_SICK)
+                blocked[c.id] = (
+                    "sick reporting is read-only for guardians"
+                    if permission is PresenceModulePermission.READABLE
+                    else "the institution has not enabled sick reporting for guardians"
+                )
+
+        targets = [c for c in children if c.id not in blocked]
+
+        # Current status, so the confirmation shows what actually changes.
+        current: dict[int, DailyOverview] = {}
+        for c in targets:
+            try:
+                overview = await client.get_daily_overview(c.id)
+                if overview:
+                    current[c.id] = overview
+            except Exception as e:
+                _log.warning("Could not fetch daily overview for %s: %s", c.name, e)
+
+        if not is_json:
+            print_heading("Report sick" if not undo else "Take sick report back")
+            click.echo()
+            for c in targets:
+                overview = current.get(c.id)
+                was = overview.status.danish_name if overview and overview.status else "?"
+                click.echo(f"  {c.name:<30s}  {was:<18s} -> {new_status.danish_name}")
+            for child_id, reason in blocked.items():
+                name = next((c.name for c in children if c.id == child_id), str(child_id))
+                click.echo(f"  {name:<30s}  skipped: {reason}")
+            click.echo()
+
+        if not targets:
+            print_empty("children this can be applied to")
+            return
+
+        if not yes and not click.confirm("Apply to Aula now?"):
+            click.echo("Cancelled.")
+            return
+
+        target_ids = [c.id for c in targets]
+        try:
+            await client.update_presence_status(target_ids, new_status)
+        except Exception as e:
+            print_error(f"updating presence status: {e}")
+            return
+
+        result = {
+            "status": new_status.name,
+            "status_value": new_status.value,
+            "updated": [{"id": c.id, "name": c.name} for c in targets],
+            "skipped": [
+                {
+                    "id": child_id,
+                    "name": next((c.name for c in children if c.id == child_id), None),
+                    "reason": reason,
+                }
+                for child_id, reason in blocked.items()
+            ],
+        }
+        if output_json(ctx, result):
+            return
+
+        for c in targets:
+            click.echo(f"  ✓ {c.name}")
+        click.echo()
+        click.echo(f"Set {len(targets)} child(ren) to {new_status.display_name}.")
 
 
 @cli.command("presence-templates")

--- a/src/aula/models/__init__.py
+++ b/src/aula/models/__init__.py
@@ -28,6 +28,9 @@ from .pickup_responsible import ChildPickupResponsibles as ChildPickupResponsibl
 from .pickup_responsible import PickupPerson as PickupPerson
 from .post import Post as Post
 from .presence import ActivityType as ActivityType
+from .presence import PresenceDashboard as PresenceDashboard
+from .presence import PresenceModule as PresenceModule
+from .presence import PresenceModulePermission as PresenceModulePermission
 from .presence import PresenceState as PresenceState
 from .presence_location import PresenceLocation as PresenceLocation
 from .presence_registration import ChildPresenceState as ChildPresenceState

--- a/src/aula/models/presence.py
+++ b/src/aula/models/presence.py
@@ -10,10 +10,26 @@ _DISPLAY_NAMES: dict[int, tuple[str, str]] = {
     6: ("Spare Time Activity", "Til aktivitet"),
     7: ("Physical Placement", "Fysisk placering"),
     8: ("Checked Out", "Gået"),
+    9: ("Not Arrived", "Ikke mødt"),
 }
 
 
 class PresenceState(Enum):
+    """A child's presence status, as both read and written by Aula.
+
+    Aula uses one enum for both directions: ``presence.getDailyOverview``
+    reports these numbers and ``presence.updateStatusByInstitutionProfileIds``
+    accepts them. Verified against the portal bundle (webpack module 31 of
+    ``/static/js/0.*.js``, the only presence status enum the store imports) and
+    against ``Enums.ComeGo.PresenceStatusEnum`` in the decompiled mobile app
+    (``com.netcompany.aulanativeprivate``).
+
+    ``NOT_ARRIVED`` exists only in the app enum; the portal's numeric enum stops
+    at ``CHECKED_OUT``. It is carried here so an institution that does report it
+    gets a name rather than "Unknown Status". The app's trailing ``All = 10`` is
+    a filter sentinel, not a state, so it is deliberately absent.
+    """
+
     NOT_PRESENT = 0
     SICK = 1
     REPORTED_ABSENT = 2
@@ -23,6 +39,7 @@ class PresenceState(Enum):
     SPARE_TIME_ACTIVITY = 6
     PHYSICAL_PLACEMENT = 7
     CHECKED_OUT = 8
+    NOT_ARRIVED = 9
 
     @property
     def display_name(self) -> str:
@@ -41,6 +58,51 @@ class PresenceState(Enum):
             return cls(value).display_name
         except ValueError:
             return "Unknown Status"
+
+
+class PresenceModule(Enum):
+    """A Komme/gå feature an institution can switch on or off per child.
+
+    Wire values come from the portal bundle (webpack module 38) and match
+    ``Enums.ComeGo.PresenceModuleSettingsModule`` in the mobile app. They appear
+    as ``moduleType`` inside ``presenceConfiguration.dashboardModuleSettings``.
+    """
+
+    PICKUP_TIMES = "pickup_times"
+    DROP_OFF_TIME = "drop_off_time"
+    DAILY_MESSAGE = "daily_message"
+    REPORT_SICK = "report_sick"
+    VACATION = "vacation"
+    FIELD_TRIP = "field_trip"
+    SPARE_TIME_ACTIVITY = "spare_time_activity"
+    LOCATION = "location"
+    SLEEP = "sleep"
+    PICKUP_TYPE = "pickup_type"
+
+
+class PresenceModulePermission(Enum):
+    """What the signed-in role may do with a :class:`PresenceModule`.
+
+    ``READABLE`` shows the module without allowing changes; the portal only
+    enables the write when the permission is ``EDITABLE``.
+    """
+
+    DEACTIVATED = "deactivated"
+    READABLE = "readable"
+    EDITABLE = "editable"
+
+
+class PresenceDashboard(Enum):
+    """Which dashboard a set of module permissions applies to.
+
+    Permissions are per dashboard, so a guardian check must read the
+    ``GUARDIAN`` entry: the employee dashboard may edit modules a guardian
+    cannot.
+    """
+
+    GUARDIAN = "guardian_dashboard"
+    EMPLOYEE = "employee_dashboard"
+    CHECK_IN = "check_in_dashboard"
 
 
 _ACTIVITY_DISPLAY_NAMES: dict[int, tuple[str, str]] = {

--- a/src/aula/models/presence_registration.py
+++ b/src/aula/models/presence_registration.py
@@ -3,7 +3,12 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from .base import AulaDataClass
-from .presence import PresenceState
+from .presence import (
+    PresenceDashboard,
+    PresenceModule,
+    PresenceModulePermission,
+    PresenceState,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -123,7 +128,13 @@ class ChildPresenceState(AulaDataClass):
 
 @dataclass
 class PresenceConfiguration(AulaDataClass):
-    """Presence configuration for a child (pickup rules, etc.)."""
+    """Presence configuration for a child (pickup rules, module permissions).
+
+    ``module_permissions`` maps a dashboard context to that dashboard's module
+    permissions, both as raw wire strings so an unfamiliar module or permission
+    is preserved rather than dropped. Read it through :meth:`permission` or
+    :meth:`can_edit` instead of indexing it directly.
+    """
 
     child_id: int | None = None
     institution_code: str | None = None
@@ -131,6 +142,7 @@ class PresenceConfiguration(AulaDataClass):
     pickup: bool | None = None
     go_home_with: bool | None = None
     self_decider: bool | None = None
+    module_permissions: dict[str, dict[str, str]] = field(default_factory=dict)
     _raw: dict | None = field(default=None, repr=False)
 
     @classmethod
@@ -147,7 +159,66 @@ class PresenceConfiguration(AulaDataClass):
             pickup=config.get("pickup"),
             go_home_with=config.get("goHomeWith"),
             self_decider=config.get("selfDecider"),
+            module_permissions=cls._parse_module_permissions(config),
         )
+
+    @staticmethod
+    def _parse_module_permissions(config: dict[str, Any]) -> dict[str, dict[str, str]]:
+        """Flatten ``dashboardModuleSettings`` into ``{dashboard: {module: permission}}``."""
+        permissions: dict[str, dict[str, str]] = {}
+        settings = config.get("dashboardModuleSettings")
+        if not isinstance(settings, list):
+            return permissions
+
+        for setting in settings:
+            if not isinstance(setting, dict):
+                continue
+            dashboard = setting.get("presenceDashboardContext")
+            modules = setting.get("presenceModules")
+            if not dashboard or not isinstance(modules, list):
+                continue
+            by_module = permissions.setdefault(str(dashboard), {})
+            for module in modules:
+                if not isinstance(module, dict):
+                    continue
+                module_type = module.get("moduleType")
+                if module_type:
+                    by_module[str(module_type)] = str(module.get("permission") or "")
+        return permissions
+
+    def permission(
+        self,
+        module: PresenceModule | str,
+        dashboard: PresenceDashboard | str = PresenceDashboard.GUARDIAN,
+    ) -> PresenceModulePermission | None:
+        """Return the permission for ``module``, or None if Aula did not report one.
+
+        None also covers a permission string this client does not know, so treat
+        it as "cannot tell" rather than as permission granted.
+        """
+        module_key = module.value if isinstance(module, PresenceModule) else module
+        dashboard_key = dashboard.value if isinstance(dashboard, PresenceDashboard) else dashboard
+        by_module = self.module_permissions.get(dashboard_key)
+        raw = by_module.get(module_key) if by_module else None
+        if raw is None:
+            return None
+        try:
+            return PresenceModulePermission(raw)
+        except ValueError:
+            _LOGGER.warning("Unknown presence module permission %r for module %r", raw, module_key)
+            return None
+
+    def can_edit(
+        self,
+        module: PresenceModule | str,
+        dashboard: PresenceDashboard | str = PresenceDashboard.GUARDIAN,
+    ) -> bool:
+        """Return True only when Aula reports ``module`` as editable.
+
+        The portal gates its write buttons on exactly this, so a False here means
+        the institution has withheld the feature and the write would be rejected.
+        """
+        return self.permission(module, dashboard) is PresenceModulePermission.EDITABLE
 
 
 @dataclass

--- a/tests/models/test_presence.py
+++ b/tests/models/test_presence.py
@@ -2,7 +2,13 @@
 
 import pytest
 
-from aula.models.presence import ActivityType, PresenceState
+from aula.models.presence import (
+    ActivityType,
+    PresenceDashboard,
+    PresenceModule,
+    PresenceModulePermission,
+    PresenceState,
+)
 
 
 def test_presence_state_values():
@@ -15,6 +21,20 @@ def test_presence_state_values():
     assert PresenceState.SPARE_TIME_ACTIVITY.value == 6
     assert PresenceState.PHYSICAL_PLACEMENT.value == 7
     assert PresenceState.CHECKED_OUT.value == 8
+    assert PresenceState.NOT_ARRIVED.value == 9
+
+
+def test_presence_state_covers_the_app_enum_range():
+    """The app enum runs 0-9 as states; 10 ("All") is a filter, not a state."""
+    assert [s.value for s in PresenceState] == list(range(10))
+    with pytest.raises(ValueError, match="10"):
+        PresenceState(10)
+
+
+def test_presence_state_not_arrived_names():
+    assert PresenceState.NOT_ARRIVED.display_name == "Not Arrived"
+    assert PresenceState.NOT_ARRIVED.danish_name == "Ikke mødt"
+    assert PresenceState.get_display_name(9) == "Not Arrived"
 
 
 def test_presence_state_display_name_present():
@@ -59,6 +79,32 @@ def test_presence_state_danish_name_property():
     assert PresenceState.SPARE_TIME_ACTIVITY.danish_name == "Til aktivitet"
     assert PresenceState.PHYSICAL_PLACEMENT.danish_name == "Fysisk placering"
     assert PresenceState.CHECKED_OUT.danish_name == "Gået"
+
+
+def test_presence_module_wire_values():
+    """Values must match the moduleType strings Aula sends."""
+    assert PresenceModule.REPORT_SICK.value == "report_sick"
+    assert PresenceModule.VACATION.value == "vacation"
+    assert PresenceModule.PICKUP_TIMES.value == "pickup_times"
+    assert PresenceModule.DROP_OFF_TIME.value == "drop_off_time"
+    assert PresenceModule.DAILY_MESSAGE.value == "daily_message"
+    assert PresenceModule.FIELD_TRIP.value == "field_trip"
+    assert PresenceModule.SPARE_TIME_ACTIVITY.value == "spare_time_activity"
+    assert PresenceModule.LOCATION.value == "location"
+    assert PresenceModule.SLEEP.value == "sleep"
+    assert PresenceModule.PICKUP_TYPE.value == "pickup_type"
+
+
+def test_presence_module_permission_wire_values():
+    assert PresenceModulePermission.DEACTIVATED.value == "deactivated"
+    assert PresenceModulePermission.READABLE.value == "readable"
+    assert PresenceModulePermission.EDITABLE.value == "editable"
+
+
+def test_presence_dashboard_wire_values():
+    assert PresenceDashboard.GUARDIAN.value == "guardian_dashboard"
+    assert PresenceDashboard.EMPLOYEE.value == "employee_dashboard"
+    assert PresenceDashboard.CHECK_IN.value == "check_in_dashboard"
 
 
 def test_activity_type_values():

--- a/tests/models/test_presence_registration.py
+++ b/tests/models/test_presence_registration.py
@@ -1,6 +1,11 @@
 """Tests for aula.models.presence_registration."""
 
-from aula.models.presence import PresenceState
+from aula.models.presence import (
+    PresenceDashboard,
+    PresenceModule,
+    PresenceModulePermission,
+    PresenceState,
+)
 from aula.models.presence_registration import (
     ChildPresenceState,
     PresenceActivity,
@@ -120,6 +125,110 @@ class TestPresenceConfiguration:
         config = PresenceConfiguration.from_dict({})
         assert config.child_id is None
         assert config.pickup is None
+
+
+class TestPresenceConfigurationModulePermissions:
+    """Module permissions gate the presence writes, per dashboard."""
+
+    @staticmethod
+    def _config(*dashboards: dict) -> PresenceConfiguration:
+        return PresenceConfiguration.from_dict(
+            {
+                "uniStudentId": 201,
+                "presenceConfiguration": {"dashboardModuleSettings": list(dashboards)},
+            }
+        )
+
+    def test_reads_guardian_permissions(self):
+        config = self._config(
+            {
+                "presenceDashboardContext": "guardian_dashboard",
+                "presenceModules": [
+                    {"moduleType": "report_sick", "permission": "editable"},
+                    {"moduleType": "vacation", "permission": "readable"},
+                ],
+            }
+        )
+        assert config.permission(PresenceModule.REPORT_SICK) is PresenceModulePermission.EDITABLE
+        assert config.can_edit(PresenceModule.REPORT_SICK) is True
+        assert config.permission(PresenceModule.VACATION) is PresenceModulePermission.READABLE
+        assert config.can_edit(PresenceModule.VACATION) is False
+
+    def test_readable_and_deactivated_are_not_editable(self):
+        for permission in ("readable", "deactivated"):
+            config = self._config(
+                {
+                    "presenceDashboardContext": "guardian_dashboard",
+                    "presenceModules": [{"moduleType": "report_sick", "permission": permission}],
+                }
+            )
+            assert config.can_edit(PresenceModule.REPORT_SICK) is False
+
+    def test_employee_permission_does_not_grant_guardian_access(self):
+        """Permissions are per dashboard; the guardian check must not read another."""
+        config = self._config(
+            {
+                "presenceDashboardContext": "employee_dashboard",
+                "presenceModules": [{"moduleType": "report_sick", "permission": "editable"}],
+            }
+        )
+        assert config.can_edit(PresenceModule.REPORT_SICK) is False
+        assert config.can_edit(PresenceModule.REPORT_SICK, PresenceDashboard.EMPLOYEE) is True
+
+    def test_missing_module_reports_none_rather_than_denial(self):
+        config = self._config(
+            {
+                "presenceDashboardContext": "guardian_dashboard",
+                "presenceModules": [{"moduleType": "vacation", "permission": "editable"}],
+            }
+        )
+        assert config.permission(PresenceModule.REPORT_SICK) is None
+        assert config.can_edit(PresenceModule.REPORT_SICK) is False
+
+    def test_unknown_permission_string_is_not_editable(self):
+        """A permission Aula adds later must not be read as granted."""
+        config = self._config(
+            {
+                "presenceDashboardContext": "guardian_dashboard",
+                "presenceModules": [{"moduleType": "report_sick", "permission": "future_value"}],
+            }
+        )
+        assert config.permission(PresenceModule.REPORT_SICK) is None
+        assert config.can_edit(PresenceModule.REPORT_SICK) is False
+
+    def test_unknown_module_is_preserved_and_readable_by_name(self):
+        config = self._config(
+            {
+                "presenceDashboardContext": "guardian_dashboard",
+                "presenceModules": [{"moduleType": "future_module", "permission": "editable"}],
+            }
+        )
+        assert config.module_permissions["guardian_dashboard"]["future_module"] == "editable"
+        assert config.can_edit("future_module") is True
+
+    def test_malformed_settings_are_skipped(self):
+        config = PresenceConfiguration.from_dict(
+            {
+                "presenceConfiguration": {
+                    "dashboardModuleSettings": [
+                        "not-a-dict",
+                        {"presenceModules": [{"moduleType": "report_sick"}]},
+                        {"presenceDashboardContext": "guardian_dashboard", "presenceModules": None},
+                        {
+                            "presenceDashboardContext": "guardian_dashboard",
+                            "presenceModules": ["nope", {"permission": "editable"}],
+                        },
+                    ]
+                }
+            }
+        )
+        assert config.module_permissions == {"guardian_dashboard": {}}
+        assert config.can_edit(PresenceModule.REPORT_SICK) is False
+
+    def test_absent_settings_leave_permissions_empty(self):
+        config = PresenceConfiguration.from_dict({"uniStudentId": 201})
+        assert config.module_permissions == {}
+        assert config.permission(PresenceModule.REPORT_SICK) is None
 
 
 class TestPresenceWeekOverview:

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -3103,3 +3103,85 @@ class TestUpdatePresenceTemplate:
             "entryTime": "08:00",
             "exitTime": "16:00",
         }
+
+
+class TestUpdatePresenceStatus:
+    """Tests for AulaApiClient.update_presence_status method."""
+
+    @pytest.fixture
+    def mock_client(self):
+        """Create a mock API client whose request layer records the call."""
+        client = AulaApiClient(http_client=AsyncMock(), access_token="test_token")
+        mock_response = HttpResponse(status_code=200, data={"status": {"code": 200}, "data": True})
+        mock_response.raise_for_status = MagicMock()  # type: ignore[assignment]
+        client._request_with_version_retry = AsyncMock(return_value=mock_response)
+        return client
+
+    @staticmethod
+    def _call(mock_client):
+        """Return the recorded (args, kwargs) of the request."""
+        return mock_client._request_with_version_retry.await_args
+
+    @pytest.mark.asyncio
+    async def test_posts_sick_status_for_profile_ids(self, mock_client):
+        """The sick report is a POST of profile IDs plus the status number."""
+        from aula.models.presence import PresenceState
+
+        result = await mock_client.update_presence_status([201, 202], PresenceState.SICK)
+
+        method, url = self._call(mock_client).args
+        assert method == "post"
+        assert url.endswith("?method=presence.updateStatusByInstitutionProfileIds")
+        assert self._call(mock_client).kwargs["json"] == {
+            "institutionProfileIds": [201, 202],
+            "status": 1,
+        }
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_undo_sends_not_present(self, mock_client):
+        """Taking the report back is the same call with a different status."""
+        from aula.models.presence import PresenceState
+
+        await mock_client.update_presence_status([201], PresenceState.NOT_PRESENT)
+
+        assert self._call(mock_client).kwargs["json"]["status"] == 0
+
+    @pytest.mark.asyncio
+    async def test_accepts_raw_int_for_compatibility(self, mock_client):
+        """A status Aula adds later still reaches the backend."""
+        await mock_client.update_presence_status([201], 42)
+
+        assert self._call(mock_client).kwargs["json"]["status"] == 42
+
+    @pytest.mark.asyncio
+    async def test_returns_the_boolean_aula_answers_with(self, mock_client):
+        """A false body is reported as failure, not swallowed."""
+        from aula.models.presence import PresenceState
+
+        response = HttpResponse(status_code=200, data={"status": {"code": 200}, "data": False})
+        response.raise_for_status = MagicMock()  # type: ignore[assignment]
+        mock_client._request_with_version_retry = AsyncMock(return_value=response)
+
+        assert await mock_client.update_presence_status([201], PresenceState.SICK) is False
+
+    @pytest.mark.asyncio
+    async def test_missing_data_is_treated_as_success(self, mock_client):
+        """Aula answering without a body is not a failure signal."""
+        from aula.models.presence import PresenceState
+
+        response = HttpResponse(status_code=200, data={"status": {"code": 200}})
+        response.raise_for_status = MagicMock()  # type: ignore[assignment]
+        mock_client._request_with_version_retry = AsyncMock(return_value=response)
+
+        assert await mock_client.update_presence_status([201], PresenceState.SICK) is True
+
+    @pytest.mark.asyncio
+    async def test_empty_profile_ids_raises_before_the_request(self, mock_client):
+        """An empty list would write nothing, so it is a caller error."""
+        from aula.models.presence import PresenceState
+
+        with pytest.raises(ValueError, match="at least one profile ID"):
+            await mock_client.update_presence_status([], PresenceState.SICK)
+
+        mock_client._request_with_version_retry.assert_not_awaited()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,11 @@
 """Tests for aula.cli helpers."""
 
-from unittest.mock import MagicMock
+import json
+from unittest.mock import AsyncMock, MagicMock
 
 import click
 import pytest
+from click.testing import CliRunner
 
 from aula.cli import (
     _WIDGET_ID_CACHE,
@@ -16,8 +18,15 @@ from aula.cli import (
     _require_widget,
     _token_digits_provider,
     _with_child,
+    report_sick,
 )
-from aula.models import Child, EasyIQHomework
+from aula.models import (
+    Child,
+    EasyIQHomework,
+    PresenceConfiguration,
+    PresenceState,
+    Profile,
+)
 
 
 def _pager(total: int):
@@ -239,3 +248,177 @@ class TestOtpDisplay:
         _print_otp_code("A1B2")
 
         assert "A1B2" in capsys.readouterr().out
+
+
+class TestReportSick:
+    """The sick report writes to Aula, so who it touches must be exact."""
+
+    @staticmethod
+    def _child(child_id: int, name: str) -> Child:
+        return Child(
+            id=child_id,
+            profile_id=child_id + 1000,
+            name=name,
+            institution_name="Test School",
+            profile_picture="",
+        )
+
+    @staticmethod
+    def _config(child_id: int, permission: str) -> PresenceConfiguration:
+        return PresenceConfiguration.from_dict(
+            {
+                "uniStudentId": child_id,
+                "presenceConfiguration": {
+                    "dashboardModuleSettings": [
+                        {
+                            "presenceDashboardContext": "guardian_dashboard",
+                            "presenceModules": [
+                                {"moduleType": "report_sick", "permission": permission}
+                            ],
+                        }
+                    ]
+                },
+            }
+        )
+
+    @pytest.fixture
+    def fake_client(self):
+        """A client recording presence writes, with two children by default."""
+        client = MagicMock()
+        client.get_profile = AsyncMock(
+            return_value=Profile(
+                profile_id=1,
+                display_name="Guardian",
+                children=[self._child(201, "Alfa"), self._child(202, "Beta")],
+            )
+        )
+        client.get_presence_configuration = AsyncMock(
+            return_value=[self._config(201, "editable"), self._config(202, "editable")]
+        )
+        client.get_daily_overview = AsyncMock(return_value=None)
+        client.update_presence_status = AsyncMock(return_value=True)
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        return client
+
+    @pytest.fixture
+    def run(self, fake_client, monkeypatch):
+        """Invoke report-sick against the fake client."""
+        monkeypatch.setattr("aula.cli._get_client", AsyncMock(return_value=fake_client))
+
+        def invoke(*args, output_format="text"):
+            return CliRunner().invoke(report_sick, list(args), obj={"OUTPUT_FORMAT": output_format})
+
+        return invoke
+
+    def test_reports_every_child_sick(self, run, fake_client):
+        result = run("-y")
+
+        assert result.exit_code == 0
+        fake_client.update_presence_status.assert_awaited_once_with([201, 202], PresenceState.SICK)
+
+    def test_child_option_limits_the_write(self, run, fake_client):
+        result = run("--child", "202", "-y")
+
+        assert result.exit_code == 0
+        fake_client.update_presence_status.assert_awaited_once_with([202], PresenceState.SICK)
+
+    def test_undo_sets_not_present(self, run, fake_client):
+        run("--undo", "-y")
+
+        fake_client.update_presence_status.assert_awaited_once_with(
+            [201, 202], PresenceState.NOT_PRESENT
+        )
+
+    def test_undo_present_sets_present(self, run, fake_client):
+        run("--undo", "--present", "-y")
+
+        fake_client.update_presence_status.assert_awaited_once_with(
+            [201, 202], PresenceState.PRESENT
+        )
+
+    def test_present_without_undo_is_rejected(self, run, fake_client):
+        result = run("--present", "-y")
+
+        assert "--present only applies together with --undo" in result.output
+        fake_client.update_presence_status.assert_not_awaited()
+
+    def test_children_without_permission_are_skipped(self, run, fake_client):
+        """An institution that withholds the module would reject the whole call."""
+        fake_client.get_presence_configuration = AsyncMock(
+            return_value=[self._config(201, "editable"), self._config(202, "deactivated")]
+        )
+
+        result = run("-y")
+
+        fake_client.update_presence_status.assert_awaited_once_with([201], PresenceState.SICK)
+        assert "Beta" in result.output
+        assert "not enabled" in result.output
+
+    def test_read_only_permission_names_the_reason(self, run, fake_client):
+        fake_client.get_presence_configuration = AsyncMock(
+            return_value=[self._config(201, "readable"), self._config(202, "readable")]
+        )
+
+        result = run("-y")
+
+        fake_client.update_presence_status.assert_not_awaited()
+        assert "read-only" in result.output
+
+    def test_unreadable_configuration_does_not_block_the_write(self, run, fake_client):
+        """Not being able to check permission is not the same as being denied."""
+        fake_client.get_presence_configuration = AsyncMock(side_effect=RuntimeError("boom"))
+
+        run("-y")
+
+        fake_client.update_presence_status.assert_awaited_once_with([201, 202], PresenceState.SICK)
+
+    def test_confirmation_prompt_can_cancel(self, run, fake_client, monkeypatch):
+        monkeypatch.setattr(click, "confirm", MagicMock(return_value=False))
+
+        result = run()
+
+        assert "Cancelled." in result.output
+        fake_client.update_presence_status.assert_not_awaited()
+
+    def test_json_output_requires_yes(self, run, fake_client):
+        """A scripted write must be explicit, since JSON mode cannot prompt."""
+        result = run(output_format="json")
+
+        assert "requires --yes" in result.output
+        fake_client.update_presence_status.assert_not_awaited()
+
+    def test_json_output_reports_updated_and_skipped(self, run, fake_client):
+        fake_client.get_presence_configuration = AsyncMock(
+            return_value=[self._config(201, "editable"), self._config(202, "deactivated")]
+        )
+
+        result = run("-y", output_format="json")
+
+        payload = json.loads(result.output)
+        assert payload["status"] == "SICK"
+        assert payload["status_value"] == 1
+        assert payload["updated"] == [{"id": 201, "name": "Alfa"}]
+        assert [s["id"] for s in payload["skipped"]] == [202]
+
+    def test_no_children_writes_nothing(self, run, fake_client):
+        fake_client.get_profile = AsyncMock(
+            return_value=Profile(profile_id=1, display_name="Guardian", children=[])
+        )
+
+        run("-y")
+
+        fake_client.update_presence_status.assert_not_awaited()
+
+    def test_unknown_child_id_writes_nothing(self, run, fake_client):
+        result = run("--child", "999", "-y")
+
+        assert "no children found" in result.output
+        fake_client.update_presence_status.assert_not_awaited()
+
+    def test_api_failure_is_reported(self, run, fake_client):
+        fake_client.update_presence_status = AsyncMock(side_effect=RuntimeError("403"))
+
+        result = run("-y")
+
+        assert "updating presence status" in result.output


### PR DESCRIPTION
## What

Adds the guardian sick write that Aula's own presence UI uses, and the two supporting pieces needed to call it safely.

| Piece | Change |
|---|---|
| Client | `AulaApiClient.update_presence_status(institution_profile_ids, status)` posts `presence.updateStatusByInstitutionProfileIds` |
| CLI | `aula report-sick`, with `--undo`, `--child`, `-y` |
| Model | `PresenceConfiguration` parses `dashboardModuleSettings`, exposing `permission()` / `can_edit()` |
| Enum | `PresenceState.NOT_ARRIVED = 9`, plus `PresenceModule`, `PresenceModulePermission`, `PresenceDashboard` |

```
aula report-sick                          # all children, with confirmation
aula report-sick --child 123456 -y
aula report-sick --undo --child 123456 -y # take it back
```

Today only. Aula has no future-dated sick report, so a planned absence still belongs in `update-presence` or a vacation registration.

## Why the permission check

An institution can withhold sick reporting from guardians, and Aula then rejects the call. The portal gates its own button on the same data, so `report-sick` reads it per child and skips the ones it would fail for, naming the reason. A configuration it cannot read is not treated as a denial, so a config fetch failure does not block the write.

## Grounding

Both numbers and shapes are read out of Aula's two clients, not inferred from another library.

**Portal bundle** (`https://www.aula.dk/static/js/0.*.js`, presence Vuex store, webpack module 152):

```js
UPDATE_SICK: ({commit}, {institutionProfileIds, status}) =>
  post("?method=presence.updateStatusByInstitutionProfileIds", {institutionProfileIds, status})
    .then(r => { commit(MUTATE_SUCCESS_TEXT, status === f.a.SICK
      ? "SUCCESS_TOAST_REGISTER_SICK" : "SUCCESS_TOAST_UNREGISTER_SICK"); return r })
```

- `f` is `n(31)`, and module 31 is the only presence status enum the store imports: `NOT_PRESENT=0, SICK=1, REPORTED_ABSENT=2, PRESENT=3, FIELDTRIP=4, SLEEPING=5, SPARE_TIME_ACTIVITY=6, PHYSICAL_PLACEMENT=7, CHECKED_OUT=8`.
- The daily-overview label map in `app.*.js` uses that same module (`Zf = i(31)`), so the read and write enums are one enum. Our existing `PresenceState` already matched it; this PR does not change any existing value.
- Ids round-trip: `presence.getPresenceStates?institutionProfileIds=...` returns `{uniStudent: {id}, state}`, and the dashboard writes `uniStudent.id` back, so these are institution profile ids (our `Child.id`).
- Undo differs by call site. The guardian dashboard sends `NOT_PRESENT`; the presence page row sends `PRESENT`. Hence `--undo` defaulting to `NOT_PRESENT` with `--present` available.
- Gate: `presenceConfiguration.dashboardModuleSettings`, entry `presenceDashboardContext == "guardian_dashboard"`, then `presenceModules[].moduleType == "report_sick"` with `permission == "editable"`. Module keys from module 38, permission values (`deactivated`/`readable`/`editable`) from module 119.

**Mobile app** (`com.netcompany.aulanativeprivate`, ILSpy decompilation published in [eisbaw/aulalibre](https://github.com/eisbaw/aulalibre)):

- Endpoint table: `UPDATE_STATUS_BY_PROFILE_IDS | POST | ?method=presence.updateStatusByInstitutionProfileIds | bool`.
- DTO `DTOs.ComeGo.UpdateStatusByInstitutionProfileIdsDTO`: `InstitutionProfileIds: List<int64>`, `Status: int32`. Two fields only, which is the second confirmation that there is no date parameter.
- `Enums.ComeGo.PresenceStatusEnum` matches module 31 exactly for 0-8, and adds `NotArrived = 9` and `All = 10`. `NOT_ARRIVED` is added here; `All` is a filter sentinel rather than a state, so it is deliberately left out.

App-side evidence is someone else's ILSpy output, not our own decompilation. It is independent of the bundle, and the two agree on every shared value.

## Tests

38 new tests: request body and status mapping, `data: false` returned rather than swallowed, empty id list rejected before any request, module-permission parsing (per-dashboard, readable vs deactivated vs unknown strings, malformed settings), and command behaviour through `CliRunner` (child selection, undo variants, skip-on-no-permission, unreadable config not blocking, cancel at the prompt, JSON mode requiring `-y`).

Full suite: 644 passed, 2 skipped. `ruff check`, `ruff format` and `ty check` clean.

## Not included

`calendar.addVacation`, the guardian absence write, spotted in the same store while reading. Tracked separately.
