### PR TITLE
feat(mu): reach opgaver via widget 0023 and expose the real opgave link

### DIFF
--- a/src/aula/agent_skill.py
+++ b/src/aula/agent_skill.py
@@ -116,6 +116,9 @@ Returns: list of presence template objects with day templates.
 aula --output json mu:opgaver
 aula --output json mu:opgaver --week 10
 ```
+Each task carries `url` (an SSO wrapper that only works in a browser) and
+`deep_link` (the MinUddannelse page it points at, or `null`). Link to
+`deep_link`, never to `url`.
 
 #### `mu:ugeplan` — Min Uddannelse weekly letter
 ```bash

--- a/src/aula/cli.py
+++ b/src/aula/cli.py
@@ -6,7 +6,7 @@ import functools
 import logging
 import os
 import sys
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from zoneinfo import ZoneInfo
 
 import click
@@ -16,12 +16,12 @@ from .api_client import AulaApiClient
 from .auth_flow import authenticate_and_create_client
 from .config import CONFIG_FILE, DEFAULT_TOKEN_FILE, load_config, save_config
 from .const import (
+    MIN_UDDANNELSE_TASK_WIDGETS,
     WIDGET_BIBLIOTEKET,
     WIDGET_EASYIQ_HOMEWORK,
     WIDGET_EASYIQ_WEEKPLAN,
     WIDGET_HUSKELISTEN,
     WIDGET_MEEBOOK,
-    WIDGET_MIN_UDDANNELSE_TASKS,
     WIDGET_MIN_UDDANNELSE_UGEPLAN,
 )
 from .models import (
@@ -381,6 +381,12 @@ async def _has_widget(client: AulaApiClient, widget_id: str) -> bool:
     A lookup that fails does not block: better to attempt the call and show
     whatever comes back than to refuse on incomplete information.
     """
+    available = await _available_widget_ids(client)
+    return True if available is None else widget_id in available
+
+
+async def _available_widget_ids(client: AulaApiClient) -> set[str] | None:
+    """Widget IDs on this account, or None when the list could not be read."""
     if id(client) not in _WIDGET_ID_CACHE:
         try:
             widgets = await client.get_widgets()
@@ -389,8 +395,23 @@ async def _has_widget(client: AulaApiClient, widget_id: str) -> bool:
             logging.getLogger(__name__).warning("Could not read the widget list: %s", e)
             _WIDGET_ID_CACHE[id(client)] = None
 
-    available = _WIDGET_ID_CACHE[id(client)]
-    return True if available is None else widget_id in available
+    return _WIDGET_ID_CACHE[id(client)]
+
+
+async def _first_available_widget(client: AulaApiClient, widget_ids: Sequence[str]) -> str | None:
+    """Pick the first widget in ``widget_ids`` this account has.
+
+    ``widget_ids`` is in preference order, so a school with the primary widget
+    keeps using it and only the schools missing it fall back.
+
+    A widget list that could not be read yields the preferred ID rather than
+    None, matching :func:`_has_widget`: attempting the call and showing whatever
+    comes back beats refusing on incomplete information.
+    """
+    available = await _available_widget_ids(client)
+    if available is None:
+        return widget_ids[0] if widget_ids else None
+    return next((widget_id for widget_id in widget_ids if widget_id in available), None)
 
 
 async def _require_widget(client: AulaApiClient, widget_id: str, name: str) -> bool:
@@ -402,6 +423,21 @@ async def _require_widget(client: AulaApiClient, widget_id: str, name: str) -> b
         f"so there is nothing to fetch. Run 'aula widgets' to see what is available."
     )
     return False
+
+
+async def _require_any_widget(
+    client: AulaApiClient, widget_ids: Sequence[str], name: str
+) -> str | None:
+    """Return the usable widget ID for ``name``, or report that none is present."""
+    widget_id = await _first_available_widget(client, widget_ids)
+    if widget_id is not None:
+        return widget_id
+    listed = ", ".join(widget_ids)
+    print_error(
+        f"no {name} widget ({listed}) is on this account, "
+        f"so there is nothing to fetch. Run 'aula widgets' to see what is available."
+    )
+    return None
 
 
 async def _get_widget_context(
@@ -1717,7 +1753,10 @@ async def mu_opgaver(ctx, week):
     """Fetch Min Uddannelse tasks (opgaver) for children."""
     week = _resolve_week(week)
     async with await _get_client(ctx) as client:
-        if not await _require_widget(client, WIDGET_MIN_UDDANNELSE_TASKS, "MinUddannelse Opgaver"):
+        widget_id = await _require_any_widget(
+            client, MIN_UDDANNELSE_TASK_WIDGETS, "MinUddannelse Opgaver"
+        )
+        if widget_id is None:
             return
 
         try:
@@ -1737,7 +1776,7 @@ async def mu_opgaver(ctx, week):
 
         try:
             opgaver = await client.widgets.get_mu_tasks(
-                WIDGET_MIN_UDDANNELSE_TASKS,
+                widget_id,
                 child_filter,
                 institution_filter,
                 week,
@@ -1769,6 +1808,7 @@ async def mu_opgaver(ctx, week):
                         ("Type", task.task_type),
                         ("Classes", classes),
                         ("Course", course),
+                        ("Link", task.deep_link),
                     ],
                 ):
                     click.echo(line)
@@ -2798,12 +2838,15 @@ async def weekly_summary(ctx, child, week, providers):
             child_filter = [uid for uid in child_filter if uid in selected_user_ids]
 
         # ── Min Uddannelse – Homework & Tasks ────────────────────────────────
-        if WeeklySummaryProvider.MU_OPGAVER in enabled and await _has_widget(
-            client, WIDGET_MIN_UDDANNELSE_TASKS
-        ):
+        mu_task_widget = (
+            await _first_available_widget(client, MIN_UDDANNELSE_TASK_WIDGETS)
+            if WeeklySummaryProvider.MU_OPGAVER in enabled
+            else None
+        )
+        if mu_task_widget is not None:
             try:
                 tasks = await client.widgets.get_mu_tasks(
-                    WIDGET_MIN_UDDANNELSE_TASKS,
+                    mu_task_widget,
                     child_filter,
                     institution_filter,
                     week,
@@ -4131,7 +4174,8 @@ async def daily_summary(ctx, child, target_date):
         # ── Homework due today ────────────────────────────────────────────────
         today_tasks: list = []
         widget_ctx = await _get_widget_context(client, prof)
-        if widget_ctx is not None:
+        mu_task_widget = await _first_available_widget(client, MIN_UDDANNELSE_TASK_WIDGETS)
+        if widget_ctx is not None and mu_task_widget is not None:
             child_filter, institution_filter, session_uuid = widget_ctx
 
             if child:
@@ -4142,7 +4186,7 @@ async def daily_summary(ctx, child, target_date):
 
             try:
                 all_tasks = await client.widgets.get_mu_tasks(
-                    WIDGET_MIN_UDDANNELSE_TASKS,
+                    mu_task_widget,
                     child_filter,
                     institution_filter,
                     week,

--- a/src/aula/const.py
+++ b/src/aula/const.py
@@ -24,8 +24,15 @@ WIDGET_EASYIQ_HOMEWORK = "0142"
 WIDGET_BIBLIOTEKET = "0019"
 WIDGET_MIN_UDDANNELSE_UGEPLAN = "0029"
 WIDGET_MIN_UDDANNELSE_TASKS = "0030"
+WIDGET_MIN_UDDANNELSE_SSO = "0023"
 WIDGET_MEEBOOK = "0004"
 WIDGET_HUSKELISTEN = "0062"
+
+# Widget IDs that can mint a token for MinUddannelse's opgaveliste endpoint, in
+# preference order. Not every school lists 0030, and a school that only has the
+# SSO widget still has opgaver: a 0023 token is accepted by the same endpoint
+# with the same parameters (scaarup/aula#364, verified live 2026-08-11).
+MIN_UDDANNELSE_TASK_WIDGETS = (WIDGET_MIN_UDDANNELSE_TASKS, WIDGET_MIN_UDDANNELSE_SSO)
 
 USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"  # noqa: E501
 

--- a/src/aula/models/mu_task.py
+++ b/src/aula/models/mu_task.py
@@ -1,9 +1,55 @@
+import base64
+import binascii
+import logging
 import re
+import urllib.parse
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
 from .base import AulaDataClass
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def decode_mu_deep_link(url: str | None) -> str | None:
+    """Return the MinUddannelse page URL wrapped inside an opgave ``url``.
+
+    An opgave's ``url`` is an SSO entry point of the form
+    ``https://api.minuddannelse.net/aula/redirect/<id>/<base64>``. The widget
+    never navigates to it directly; it submits it as a form with the Aula token
+    in a hidden field, so fetching it server side lands on ``/Error/IngenAdgang``
+    and the raw value is useless as a link.
+
+    The last path segment is the base64 of the percent-encoded real page URL, so
+    decoding it yields a link that opens the right week. Returns None whenever
+    that does not hold, which keeps callers on plain text rather than handing out
+    a broken link.
+    """
+    if not url:
+        return None
+
+    segment = url.rsplit("/", 1)[-1]
+    if not segment:
+        return None
+
+    try:
+        # validate=True rejects a segment that is not base64 at all, e.g. the
+        # last path element of an ordinary URL, instead of decoding it to bytes
+        # that only look like a result.
+        raw = base64.b64decode(segment + "=" * (-len(segment) % 4), validate=True)
+        decoded = urllib.parse.unquote(raw.decode("utf-8"))
+    except binascii.Error, UnicodeDecodeError, ValueError:
+        _LOGGER.debug("Could not decode Min Uddannelse deep link: %s", url)
+        return None
+
+    # Anything that is not an absolute http(s) URL is not a link we should show,
+    # however cleanly it decoded.
+    if not decoded.startswith(("http://", "https://")):
+        _LOGGER.debug("Decoded Min Uddannelse deep link is not a URL: %s", url)
+        return None
+
+    return decoded
 
 
 def _parse_dotnet_date(value: str | None) -> datetime | None:
@@ -70,6 +116,7 @@ class MUTask(AulaDataClass):
     student_name: str
     unilogin: str
     url: str
+    deep_link: str | None = None
     classes: list[MUTaskClass] = field(default_factory=list)
     course: MUTaskCourse | None = None
     student_count: int | None = None
@@ -94,6 +141,8 @@ class MUTask(AulaDataClass):
             student_name=data.get("kuvertnavn", ""),
             unilogin=data.get("unilogin", ""),
             url=data.get("url", ""),
+            # ``url`` is kept exactly as Aula sent it; the usable link is derived.
+            deep_link=decode_mu_deep_link(data.get("url")),
             classes=classes,
             course=MUTaskCourse.from_dict(forloeb) if forloeb else None,
             student_count=data.get("antalElever"),

--- a/tests/models/test_mu_task.py
+++ b/tests/models/test_mu_task.py
@@ -1,6 +1,12 @@
 """Tests for aula.models.mu_task."""
 
-from aula.models.mu_task import MUTask, MUTaskClass, MUTaskCourse, _parse_dotnet_date
+from aula.models.mu_task import (
+    MUTask,
+    MUTaskClass,
+    MUTaskCourse,
+    _parse_dotnet_date,
+    decode_mu_deep_link,
+)
 
 
 def test_parse_dotnet_date_valid():
@@ -123,3 +129,90 @@ def test_mu_task_from_dict_minimal():
     assert task.due_date is None
     assert task.classes == []
     assert task.course is None
+
+
+class TestDecodeMuDeepLink:
+    """An opgave's raw ``url`` is an SSO wrapper; the usable link is inside it."""
+
+    def test_decodes_the_last_path_segment(self):
+        url = (
+            "https://api.minuddannelse.net/aula/redirect/123456/"
+            "aHR0cHMlM2ElMmYlMmZ3d3cubWludWRkYW5uZWxzZS5uZXQlMmZOb2RlJTJmbWludWdlJTJmMTIzNDU2"
+            "NyUzZnVnZSUzZDIwMjYtVzMz"
+        )
+        assert (
+            decode_mu_deep_link(url)
+            == "https://www.minuddannelse.net/Node/minuge/1234567?uge=2026-W33"
+        )
+
+    def test_pads_a_segment_whose_length_is_not_a_multiple_of_four(self):
+        import base64
+
+        target = "https://www.minuddannelse.net/Node/minuge/1"
+        segment = base64.b64encode(target.encode()).decode().rstrip("=")
+        assert len(segment) % 4 != 0, "fixture should need padding to be decodable"
+
+        assert decode_mu_deep_link(f"https://api.minuddannelse.net/aula/redirect/1/{segment}")
+
+    def test_malformed_base64_gives_none(self):
+        assert decode_mu_deep_link("not-a-valid-deeplink") is None
+
+    def test_ordinary_url_path_segment_is_not_decoded(self):
+        """A plain URL must not be mangled into something that looks like a link."""
+        assert decode_mu_deep_link("https://www.minuddannelse.net/Node/minuge/1234567") is None
+
+    def test_decoded_value_that_is_not_a_url_gives_none(self):
+        import base64
+
+        segment = base64.b64encode(b"just some text").decode()
+        assert (
+            decode_mu_deep_link(f"https://api.minuddannelse.net/aula/redirect/1/{segment}") is None
+        )
+
+    def test_non_utf8_payload_gives_none(self):
+        import base64
+
+        segment = base64.b64encode(b"\xff\xfe\xfd\xfc").decode()
+        assert (
+            decode_mu_deep_link(f"https://api.minuddannelse.net/aula/redirect/1/{segment}") is None
+        )
+
+    def test_empty_and_missing_urls_give_none(self):
+        assert decode_mu_deep_link("") is None
+        assert decode_mu_deep_link(None) is None
+
+    def test_url_ending_in_a_separator_gives_none(self):
+        assert decode_mu_deep_link("https://api.minuddannelse.net/aula/redirect/123456/") is None
+
+    def test_url_with_no_path_separator_gives_none(self):
+        assert decode_mu_deep_link("nopath") is None
+
+
+class TestMuTaskDeepLink:
+    def test_from_dict_exposes_the_decoded_link_and_keeps_url(self):
+        raw_url = (
+            "https://api.minuddannelse.net/aula/redirect/123456/"
+            "aHR0cHMlM2ElMmYlMmZ3d3cubWludWRkYW5uZWxzZS5uZXQlMmZOb2RlJTJmbWludWdlJTJmMTIzNDU2"
+            "NyUzZnVnZSUzZDIwMjYtVzMz"
+        )
+        task = MUTask.from_dict({"id": "1", "url": raw_url})
+
+        assert task.url == raw_url
+        assert task.deep_link == "https://www.minuddannelse.net/Node/minuge/1234567?uge=2026-W33"
+
+    def test_undecodable_url_is_kept_verbatim_with_no_link(self):
+        task = MUTask.from_dict({"id": "1", "url": "not-a-valid-deeplink"})
+
+        assert task.url == "not-a-valid-deeplink"
+        assert task.deep_link is None
+
+    def test_missing_url_leaves_both_empty(self):
+        task = MUTask.from_dict({"id": "1"})
+
+        assert task.url == ""
+        assert task.deep_link is None
+
+    def test_deep_link_is_serialised_for_json_consumers(self):
+        task = MUTask.from_dict({"id": "1", "url": "not-a-valid-deeplink"})
+
+        assert dict(task)["deep_link"] is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,14 +12,17 @@ from aula.cli import (
     CONTACTS_PAGE_SIZE,
     MAX_CONTACT_PAGES,
     _fetch_contact_pages,
+    _first_available_widget,
     _has_widget,
     _password_provider,
     _print_otp_code,
+    _require_any_widget,
     _require_widget,
     _token_digits_provider,
     _with_child,
     report_sick,
 )
+from aula.const import MIN_UDDANNELSE_TASK_WIDGETS
 from aula.models import (
     Child,
     EasyIQHomework,
@@ -106,6 +109,75 @@ class TestWidgetAvailability:
     async def test_require_widget_is_quiet_when_present(self, capsys):
         assert await _require_widget(self._client(["0019"]), "0019", "Biblioteket") is True
         assert capsys.readouterr().out == ""
+
+
+class TestWidgetPreference:
+    """MinUddannelse opgaver are reachable through more than one widget."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        _WIDGET_ID_CACHE.clear()
+        yield
+        _WIDGET_ID_CACHE.clear()
+
+    def _client(self, widget_ids, side_effect=None):
+        client = MagicMock()
+        widgets = [MagicMock(widget_id=wid) for wid in widget_ids]
+        client.get_widgets = AsyncMock(return_value=widgets, side_effect=side_effect)
+        return client
+
+    @pytest.mark.asyncio
+    async def test_prefers_the_first_widget_when_present(self):
+        client = self._client(["0023", "0030", "0029"])
+
+        assert await _first_available_widget(client, MIN_UDDANNELSE_TASK_WIDGETS) == "0030"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_only_the_sso_widget_is_listed(self):
+        """The reported case: 0029, 0023, 0072 and 0138, but no 0030."""
+        client = self._client(["0029", "0023", "0072", "0138"])
+
+        assert await _first_available_widget(client, MIN_UDDANNELSE_TASK_WIDGETS) == "0023"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_candidate_is_listed(self):
+        client = self._client(["0128", "0142"])
+
+        assert await _first_available_widget(client, MIN_UDDANNELSE_TASK_WIDGETS) is None
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_list_falls_back_to_the_preferred_widget(self):
+        """Same rule as _has_widget: try the call rather than refuse."""
+        client = self._client([], side_effect=RuntimeError("boom"))
+
+        assert await _first_available_widget(client, MIN_UDDANNELSE_TASK_WIDGETS) == "0030"
+
+    @pytest.mark.asyncio
+    async def test_the_list_is_fetched_once(self):
+        client = self._client(["0023"])
+
+        await _first_available_widget(client, MIN_UDDANNELSE_TASK_WIDGETS)
+        await _first_available_widget(client, MIN_UDDANNELSE_TASK_WIDGETS)
+
+        assert client.get_widgets.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_require_any_widget_returns_the_usable_id(self, capsys):
+        client = self._client(["0023"])
+
+        assert await _require_any_widget(client, MIN_UDDANNELSE_TASK_WIDGETS, "Opgaver") == "0023"
+        assert capsys.readouterr().out == ""
+
+    @pytest.mark.asyncio
+    async def test_require_any_widget_lists_every_candidate_when_none_is_present(self, capsys):
+        client = self._client(["0128"])
+
+        assert await _require_any_widget(client, MIN_UDDANNELSE_TASK_WIDGETS, "Opgaver") is None
+        out = capsys.readouterr().out
+        assert "Opgaver" in out
+        assert "0030" in out
+        assert "0023" in out
+        assert "aula widgets" in out
 
 
 class TestWithChild:


### PR DESCRIPTION
Closes #59.

## Problem 1: opgaver were unreachable without widget 0030

`MIN_UDDANNELSE_TASK_WIDGETS = ("0030", "0023")` in `const.py`, plus two helpers in `cli.py`:

- `_first_available_widget(client, ids)` returns the first id the account has, in preference order.
- `_require_any_widget(client, ids, name)` does the same and reports every candidate when none is present.

Both sit on a new `_available_widget_ids()` that `_has_widget` now shares, so the widget list is still fetched once per client. A list that could not be read yields the preferred id rather than None, which keeps the existing "attempt the call rather than refuse on incomplete information" rule.

Schools that expose `0030` keep using `0030`, so nothing changes for them.

All three call sites now share the choice:

| Site | Before | After |
|---|---|---|
| `mu:opgaver` | `_require_widget(0030)` | `_require_any_widget(0030, 0023)` |
| `weekly-summary` | `_has_widget(0030)` | `_first_available_widget(...)` |
| `daily-summary` | called with `0030` unconditionally | skips only when the account demonstrably has neither |

## Problem 2: the opgave link was stored but unusable

`decode_mu_deep_link()` reads the base64 last path segment of an opgave `url`, and `MUTask.deep_link` exposes the decoded MinUddannelse page url. `url` keeps the raw value. `deep_link` is a dataclass field rather than a property, so it lands in `dict(task)` and reaches JSON consumers such as hass-aula.

`mu:opgaver` now prints a `Link:` line when there is one, and prints nothing extra when there is not.

Stricter than the upstream implementation this is based on, in two ways:

- `base64.b64decode(..., validate=True)`, so an ordinary URL's last path segment is rejected instead of being decoded into bytes that merely look like a result. `https://www.minuddannelse.net/Node/minuge/1234567` yields None, not garbage.
- The decoded value must be an absolute `http(s)` URL, so a segment that decodes to arbitrary text yields None.

## Grounding, and what this PR does not verify

Confirmed from the live widget source (`W0030V0001`, portal sourcemaps): the widget calls `opgaveliste` with the same parameters `get_mu_tasks` sends, the response fields match what `MUTask.from_dict` parses, and the widget submits `assignment.url` as a form with the Aula token in a hidden field rather than navigating to it. That last point is why the raw `url` is not usable as a link.

Two claims came from upstream ([scaarup/aula#364](https://github.com/scaarup/aula/pull/364)) rather than from our own source reading, and **both have now been verified live against a real account** (see the verification comment below):

1. **A 0023 token is accepted by `opgaveliste`.** Confirmed: the same call with only the widget id changed returned identical payloads for `0030` and `0023`. No client source can settle this from code, since the widget receives its token as an injected prop and the binding is enforced server side.
2. **The base64 deep link.** Confirmed on live data: all opgaver decoded to `https://www.minuddannelse.net/Node/minuge/<id>?opgave=<guid>&uge=<year>-W<week>`.

Both still fail safe if a school differs: a rejected token surfaces as the supplier's error on accounts that today get nothing at all, and a segment that does not decode leaves `deep_link` as None with output unchanged.

## Tests

21 new tests. Widget preference: `0030` when present, `0023` when only it is listed, None when neither is, preferred id on an unreadable list, single fetch, and the error naming both ids. Deep link: valid segment, padding, malformed base64, ordinary URL path segment, non-URL payload, non-UTF-8 payload, empty/None url, trailing separator, no separator. Model: `url` unchanged in every case, `deep_link` present in `dict(task)`.

Full suite: 672 passed, 2 skipped. `ruff check`, `ruff format` and `ty check` clean.

