### PR TITLE
feat(mu): render ugeplan and opgaver as readable layouts

### DIFF
--- a/src/aula/cli.py
+++ b/src/aula/cli.py
@@ -6,6 +6,7 @@ import functools
 import logging
 import os
 import sys
+from collections import defaultdict
 from collections.abc import Awaitable, Callable, Sequence
 from zoneinfo import ZoneInfo
 
@@ -30,6 +31,7 @@ from .models import (
     Group,
     Message,
     MessageThread,
+    MUTask,
     Notification,
     PresenceModule,
     PresenceModulePermission,
@@ -42,6 +44,7 @@ from .utils.mapping import get_in
 from .utils.output import (
     build_contact_table,
     clip,
+    danish_sort_key,
     format_calendar_context_lines,
     format_message_lines,
     format_notification_lines,
@@ -55,7 +58,13 @@ from .utils.output import (
     print_heading,
     scope_relations_to_children,
 )
-from .utils.table import print_row_table
+from .utils.table import (
+    card_width,
+    print_row_table,
+    print_text_card,
+    print_wrapped_row_table,
+)
+from .utils.week import DANISH_WEEKDAYS, weekday_index
 from .widgets import EasyIQChildNotInPortal
 
 
@@ -1689,6 +1698,78 @@ async def widgets(ctx):
             click.echo()
 
 
+# Min Uddannelse's internal task types; the portal itself labels a
+# ``SimpelLektie`` simply as a homework note.
+_MU_TASK_TYPE_LABELS = {"SimpelLektie": "Lektie"}
+
+
+def _mu_task_classes(task: MUTask) -> str:
+    """Format a task's classes, keeping the subject only when it adds something."""
+    names = []
+    for cls in task.classes:
+        subject = cls.subject_name.strip()
+        if subject and subject.lower() not in cls.name.lower():
+            names.append(f"{cls.name} ({subject})")
+        else:
+            names.append(cls.name)
+    return ", ".join(names)
+
+
+def _mu_task_rows(tasks: Sequence[MUTask]) -> tuple[list[list[str]], list[str]]:
+    """Build the table rows for one student's tasks plus the links they footnote."""
+    links: list[str] = []
+    rows = []
+    previous_day = None
+    for task in tasks:
+        task_cell = task.title
+        if task.deep_link:
+            links.append(task.deep_link)
+            task_cell = f"{task_cell} [{len(links)}]"
+        if task.course:
+            task_cell = f"{task_cell}\n  Course: {task.course.name}"
+        rows.append(
+            [
+                # Repeating the day on every row of the same day is just noise.
+                "" if task.weekday == previous_day else task.weekday,
+                task_cell,
+                _mu_task_classes(task),
+                _MU_TASK_TYPE_LABELS.get(task.task_type, task.task_type),
+                "✓" if task.is_completed else "",
+            ]
+        )
+        previous_day = task.weekday
+    return rows, links
+
+
+def print_mu_task_tables(tasks: Sequence[MUTask]) -> None:
+    """Print one day-ordered table per student, with task links as footnotes."""
+    width = card_width()
+    headers = ["Day", "Task", "Class", "Type", "Done"]
+    by_student: dict[str, list[MUTask]] = defaultdict(list)
+    for task in tasks:
+        by_student[task.student_name].append(task)
+
+    for position, student in enumerate(sorted(by_student, key=danish_sort_key)):
+        student_tasks = sorted(
+            by_student[student],
+            key=lambda t: (weekday_index(t.weekday), t.due_date or datetime.datetime.max, t.title),
+        )
+        if position:
+            click.echo()
+
+        rows, links = _mu_task_rows(student_tasks)
+        # A column every task leaves blank is noise, so drop it.
+        keep = [i for i in range(len(headers)) if any(row[i].strip() for row in rows)]
+        print_wrapped_row_table(
+            [headers[i] for i in keep],
+            [[row[i] for i in keep] for row in rows],
+            title=student or "(unknown student)",
+            width=width,
+        )
+        for number, link in enumerate(links, start=1):
+            click.echo(f"  [{number}] {link}")
+
+
 @cli.command("mu:opgaver")
 @click.option(
     "--week",
@@ -1743,26 +1824,8 @@ async def mu_opgaver(ctx, week):
         if not opgaver:
             print_empty("tasks")
         else:
-            for i, task in enumerate(opgaver):
-                classes = ", ".join(
-                    f"{cls.name} ({cls.subject_name})" if cls.subject_name else cls.name
-                    for cls in task.classes
-                )
-                course = task.course.name if task.course else ""
-                for line in format_record_lines(
-                    title=task.title,
-                    properties=[
-                        ("Student", task.student_name),
-                        ("Day", task.weekday),
-                        ("Type", task.task_type),
-                        ("Classes", classes),
-                        ("Course", course),
-                        ("Link", task.deep_link),
-                    ],
-                ):
-                    click.echo(line)
-                if i < len(opgaver) - 1:
-                    click.echo()
+            click.echo()
+            print_mu_task_tables(opgaver)
 
 
 @cli.command("mu:ugeplan")
@@ -1798,7 +1861,7 @@ async def mu_ugeplan(ctx, week):
             return
         child_filter, institution_filter, session_uuid = widget_ctx
 
-        from .utils.html import html_to_plain
+        from .utils.html import html_to_blocks
 
         try:
             personer = await client.widgets.get_ugeplan(
@@ -1820,23 +1883,23 @@ async def mu_ugeplan(ctx, week):
             return
 
         print_heading(f"Min Uddannelse weekly plans [{week}]")
+        click.echo()
 
+        width = card_width()
         rendered = 0
         for person in personer:
             for inst in person.institutions:
                 for letter in inst.letters:
                     rendered += 1
-                    for line in format_record_lines(
-                        title=f"{person.name} [{letter.group_name}]",
-                        properties=[
-                            ("Institution", inst.name),
-                            ("Week", str(letter.week_number)),
+                    print_text_card(
+                        header_lines=[
+                            f"{person.name} · {letter.group_name} · Week {letter.week_number}",
+                            inst.name,
                         ],
-                        body_lines=html_to_plain(letter.content_html).splitlines(),
-                        body_label="Body",
+                        body_blocks=html_to_blocks(letter.content_html),
+                        width=width,
                         empty_body_text="(no weekly plan body)",
-                    ):
-                        click.echo(line)
+                    )
                     click.echo()
 
         if rendered == 0:
@@ -3917,9 +3980,6 @@ async def presence(ctx, from_date, to_date, week, states):
             click.echo()
 
 
-_DANISH_WEEKDAYS = ["Mandag", "Tirsdag", "Onsdag", "Torsdag", "Fredag", "Lørdag", "Søndag"]
-
-
 @cli.command("daily-summary")
 @click.option(
     "--child",
@@ -3959,7 +4019,7 @@ async def daily_summary(ctx, child, target_date):
 
     iso = today.isocalendar()
     week = f"{iso[0]}-W{iso[1]}"
-    today_weekday_da = _DANISH_WEEKDAYS[today.weekday()]
+    today_weekday_da = DANISH_WEEKDAYS[today.weekday()]
     day_label = today.strftime("%A, %d %B %Y")
 
     async with await _get_client(ctx) as client:

--- a/src/aula/utils/html.py
+++ b/src/aula/utils/html.py
@@ -3,8 +3,11 @@
 import logging
 
 import html2text
+from bs4 import BeautifulSoup
 
 _LOGGER = logging.getLogger(__name__)
+
+_BLOCK_TAGS = ("p", "div", "li", "h1", "h2", "h3", "h4", "h5", "h6", "blockquote", "pre", "tr")
 
 
 def html_to_plain(html: str) -> str:
@@ -37,3 +40,46 @@ def html_to_markdown(html: str) -> str:
     except (ValueError, AttributeError, UnicodeError) as e:
         _LOGGER.warning("Error converting HTML to Markdown: %s", e)
         return html
+
+
+def _normalize_block(text: str) -> str:
+    """Collapse runs of whitespace per line while keeping explicit line breaks."""
+    lines = [" ".join(line.split()) for line in text.split("\n")]
+    return "\n".join(line for line in lines if line)
+
+
+def html_to_blocks(html: str) -> list[str]:
+    """Convert HTML into text blocks, one per paragraph, heading or list item.
+
+    Blocks are normalized and empty ones dropped, so joining them with a blank
+    line restores the paragraph spacing that :func:`html_to_plain` collapses.
+    List items get a bullet prefix.
+    """
+    if not html:
+        return []
+    try:
+        soup = BeautifulSoup(html, "html.parser")
+    except Exception as e:  # noqa: BLE001 - parser failures must not break rendering
+        _LOGGER.warning("Error splitting HTML into blocks: %s", e)
+        return [line for line in html_to_plain(html).splitlines() if line.strip()]
+
+    for line_break in soup.find_all("br"):
+        line_break.replace_with("\n")
+
+    elements = soup.find_all(_BLOCK_TAGS)
+    if not elements:
+        text = _normalize_block(soup.get_text())
+        return [text] if text else []
+
+    blocks = []
+    for element in elements:
+        if element.find(_BLOCK_TAGS):
+            # A container; its descendants contribute the text instead.
+            continue
+        text = _normalize_block(element.get_text())
+        if not text:
+            continue
+        if element.name == "li" and not text.startswith(("-", "*", "•")):
+            text = f"- {text}"
+        blocks.append(text)
+    return blocks

--- a/src/aula/utils/table.py
+++ b/src/aula/utils/table.py
@@ -1,3 +1,5 @@
+import shutil
+import textwrap
 from collections import defaultdict
 from collections.abc import Sequence
 from datetime import date, time
@@ -145,3 +147,182 @@ def print_calendar_table(table_data: CalendarTableData) -> None:
 
     if not _print_with_rich(date_headers, slot_labels, matrix):
         _print_plain(date_headers, slot_labels, matrix)
+
+
+CARD_MAX_WIDTH = 100
+CARD_MIN_WIDTH = 40
+
+
+def card_width(max_width: int = CARD_MAX_WIDTH) -> int:
+    """Return the card width to use for the current terminal."""
+    columns = shutil.get_terminal_size((80, 24)).columns
+    return max(CARD_MIN_WIDTH, min(max_width, columns - 1))
+
+
+BULLET_PREFIXES = ("-", "*", "•")
+
+
+def _is_bullet(block: str) -> bool:
+    return block.lstrip().startswith(BULLET_PREFIXES)
+
+
+def _wrap_block(block: str, width: int) -> list[str]:
+    """Wrap one text block to ``width``, hanging-indenting bullet lines."""
+    lines = []
+    for line in block.split("\n"):
+        indent = "  " if _is_bullet(line) else ""
+        lines.extend(textwrap.wrap(line, width=width, subsequent_indent=indent) or [""])
+    return lines
+
+
+def _print_card_with_rich(
+    header_lines: Sequence[str], body_lines: Sequence[str], width: int
+) -> bool:
+    """Render a card with ``rich``. Returns ``False`` if rich is not installed."""
+    try:
+        from rich import box  # type: ignore[import-not-found]
+        from rich.console import Console  # type: ignore[import-not-found]
+        from rich.table import Table  # type: ignore[import-not-found]
+        from rich.text import Text  # type: ignore[import-not-found]
+    except ImportError:
+        return False
+
+    table = Table(box=box.ROUNDED, show_header=False, width=width)
+    table.add_column(overflow="fold")
+    if header_lines:
+        table.add_row(Text("\n".join(header_lines), style="bold"))
+        table.add_section()
+    table.add_row(Text("\n".join(body_lines)))
+    Console().print(table)
+    return True
+
+
+def _print_card_plain(header_lines: Sequence[str], body_lines: Sequence[str], width: int) -> None:
+    """Render a card as a plain-text box."""
+    inner = width - 4
+
+    def row(text: str) -> str:
+        return f"│ {text.ljust(inner)} │"
+
+    click.echo("┌" + "─" * (width - 2) + "┐")
+    if header_lines:
+        for line in header_lines:
+            click.echo(row(line))
+        click.echo("├" + "─" * (width - 2) + "┤")
+    for line in body_lines:
+        click.echo(row(line))
+    click.echo("└" + "─" * (width - 2) + "┘")
+
+
+def print_text_card(
+    header_lines: Sequence[str],
+    body_blocks: Sequence[str],
+    width: int | None = None,
+    empty_body_text: str = "(no content)",
+) -> None:
+    """Print a bordered card: header lines, a divider, then wrapped body blocks.
+
+    ``body_blocks`` are separated by a blank line, so paragraphs stay apart.
+    Uses rich if available, else plain box-drawing characters.
+    """
+    box_width = width if width is not None else card_width()
+    inner = box_width - 4
+
+    body_lines: list[str] = []
+    previous_block = ""
+    for block in body_blocks:
+        # Consecutive bullets belong to one list, so they stay on adjacent lines.
+        if body_lines and not (_is_bullet(block) and _is_bullet(previous_block)):
+            body_lines.append("")
+        body_lines.extend(_wrap_block(block, inner))
+        previous_block = block
+    if not body_lines:
+        body_lines = [empty_body_text]
+
+    wrapped_headers = [
+        line for header in header_lines for line in (_wrap_block(header, inner) or [""])
+    ]
+
+    if not _print_card_with_rich(wrapped_headers, body_lines, box_width):
+        _print_card_plain(wrapped_headers, body_lines, box_width)
+
+
+MIN_COLUMN_WIDTH = 8
+
+
+def _natural_widths(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> list[int]:
+    """Return the width each column needs to render unwrapped."""
+    return [
+        max(
+            [len(header)] + [len(line) for row in rows for line in str(row[index]).split("\n")],
+        )
+        for index, header in enumerate(headers)
+    ]
+
+
+def _fit_widths(widths: list[int], available: int) -> list[int]:
+    """Shrink the widest columns until the table fits ``available`` characters."""
+    fitted = list(widths)
+    floors = [min(width, MIN_COLUMN_WIDTH) for width in widths]
+    separators = 3 * (len(fitted) - 1)
+    while sum(fitted) + separators > available:
+        shrinkable = [i for i, width in enumerate(fitted) if width > floors[i]]
+        if not shrinkable:
+            break
+        widest = max(shrinkable, key=lambda i: fitted[i])
+        fitted[widest] -= 1
+    return fitted
+
+
+def _print_rows_plain_wrapped(
+    headers: Sequence[str],
+    rows: Sequence[Sequence[str]],
+    title: str | None,
+    width: int,
+) -> None:
+    """Render a row table as plain text, wrapping cells to fit ``width``."""
+    widths = _fit_widths(_natural_widths(headers, rows), width)
+
+    def render(cells: Sequence[str]) -> str:
+        return " | ".join(
+            cell.ljust(cell_width) for cell, cell_width in zip(cells, widths, strict=True)
+        ).rstrip()
+
+    wrapped_rows = [
+        [_wrap_block(str(cell), cell_width) for cell, cell_width in zip(row, widths, strict=True)]
+        for row in rows
+    ]
+    heights = [max(len(cell) for cell in wrapped) for wrapped in wrapped_rows]
+
+    if title:
+        click.echo(title)
+    click.echo(render(headers))
+    click.echo("-+-".join("-" * cell_width for cell_width in widths))
+    for index, wrapped in enumerate(wrapped_rows):
+        # A row spanning several lines is hard to tell from its neighbours, so
+        # give it breathing room while leaving runs of single-line rows dense.
+        if index and max(heights[index - 1], heights[index]) > 1:
+            click.echo()
+        for line_index in range(heights[index]):
+            click.echo(
+                render([cell[line_index] if line_index < len(cell) else "" for cell in wrapped])
+            )
+
+
+def print_wrapped_row_table(
+    headers: Sequence[str],
+    rows: Sequence[Sequence[str]],
+    title: str | None = None,
+    width: int | None = None,
+) -> None:
+    """Print a header + rows table that wraps long cells instead of overflowing.
+
+    Unlike :func:`print_row_table` this never renders a line wider than the
+    terminal, which keeps tables with free-text columns readable.
+    """
+    if not rows:
+        return
+    if not _print_rows_with_rich(headers, rows, title):
+        _print_rows_plain_wrapped(
+            headers, rows, title, width if width is not None else card_width()
+        )

--- a/src/aula/utils/week.py
+++ b/src/aula/utils/week.py
@@ -5,6 +5,8 @@ import logging
 
 _LOGGER = logging.getLogger(__name__)
 
+DANISH_WEEKDAYS = ("Mandag", "Tirsdag", "Onsdag", "Torsdag", "Fredag", "Lørdag", "Søndag")
+
 
 def monday_of_week(week: str) -> str:
     """Return the Monday of ``YYYY-Wnn`` as an ISO timestamp with a ``Z`` suffix.
@@ -21,3 +23,17 @@ def monday_of_week(week: str) -> str:
         _LOGGER.warning("Could not parse week %r, using today's date instead", week)
         monday = datetime.date.today()
     return f"{monday.isoformat()}T00:00:00Z"
+
+
+def weekday_index(name: str | None) -> int:
+    """Return the Monday-first index of a Danish weekday name.
+
+    Unknown or missing names sort last, so a task Aula did not place on a day
+    still shows up instead of breaking the ordering.
+    """
+    if not name:
+        return len(DANISH_WEEKDAYS)
+    try:
+        return DANISH_WEEKDAYS.index(name.strip().capitalize())
+    except ValueError:
+        return len(DANISH_WEEKDAYS)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,8 @@ from aula.cli import (
     _fetch_contact_pages,
     _first_available_widget,
     _has_widget,
+    _mu_task_classes,
+    _mu_task_rows,
     _password_provider,
     _print_otp_code,
     _require_any_widget,
@@ -22,6 +24,7 @@ from aula.cli import (
     _with_child,
     easyiq_homework,
     easyiq_ugeplan,
+    print_mu_task_tables,
     report_sick,
 )
 from aula.const import (
@@ -36,6 +39,7 @@ from aula.models import (
     PresenceState,
     Profile,
 )
+from aula.models.mu_task import MUTask, MUTaskClass, MUTaskCourse
 from aula.widgets import EasyIQChildNotInPortal
 
 
@@ -652,3 +656,146 @@ class TestEasyiqPerChildInstitutionScoping:
         calls = client.widgets.get_easyiq_homework.await_args_list
         assert calls[0].args[2] == ["SCH-1"]
         assert calls[1].args[2] == ["SCH-1"]
+
+
+def _make_task(
+    *,
+    title: str,
+    weekday: str,
+    student: str = "Barn Et",
+    task_type: str = "SimpelLektie",
+    classes: tuple[tuple[str, str], ...] = (("Dansk 3.1", "Dansk"),),
+    course: str | None = None,
+    deep_link: str | None = None,
+    is_completed: bool = False,
+    due_date=None,
+) -> MUTask:
+    return MUTask(
+        id=title,
+        title=title,
+        task_type=task_type,
+        due_date=due_date,
+        weekday=weekday,
+        week_number=34,
+        is_completed=is_completed,
+        student_name=student,
+        unilogin="barn123",
+        url="https://api.minuddannelse.net/aula/redirect/1/abc",
+        deep_link=deep_link,
+        classes=[
+            MUTaskClass(id=1, name=name, subject_id=2, subject_name=subject)
+            for name, subject in classes
+        ],
+        course=(
+            MUTaskCourse(id="1", name=course, icon="", yearly_plan_id="", color=None, url=None)
+            if course
+            else None
+        ),
+    )
+
+
+class TestMuTaskClasses:
+    def test_adds_the_subject_when_it_is_not_in_the_class_name(self):
+        task = _make_task(title="T", weekday="Mandag", classes=(("Bibliotek", "Andet"),))
+        assert _mu_task_classes(task) == "Bibliotek (Andet)"
+
+    def test_skips_a_subject_the_class_name_already_carries(self):
+        task = _make_task(title="T", weekday="Mandag", classes=(("Historie 3.1", "Historie"),))
+        assert _mu_task_classes(task) == "Historie 3.1"
+
+    def test_joins_several_classes(self):
+        task = _make_task(
+            title="T",
+            weekday="Mandag",
+            classes=(("Dansk 3.1", "Dansk"), ("Matematik 3.1", "Matematik")),
+        )
+        assert _mu_task_classes(task) == "Dansk 3.1, Matematik 3.1"
+
+
+class TestMuTaskRows:
+    def test_repeated_day_is_only_shown_once(self):
+        rows, _ = _mu_task_rows(
+            [
+                _make_task(title="En", weekday="Tirsdag"),
+                _make_task(title="To", weekday="Tirsdag"),
+                _make_task(title="Tre", weekday="Onsdag"),
+            ]
+        )
+
+        assert [row[0] for row in rows] == ["Tirsdag", "", "Onsdag"]
+
+    def test_links_become_numbered_footnotes(self):
+        rows, links = _mu_task_rows(
+            [
+                _make_task(title="En", weekday="Tirsdag", deep_link="https://example.com/1"),
+                _make_task(title="To", weekday="Tirsdag"),
+                _make_task(title="Tre", weekday="Onsdag", deep_link="https://example.com/3"),
+            ]
+        )
+
+        assert [row[1] for row in rows] == ["En [1]", "To", "Tre [2]"]
+        assert links == ["https://example.com/1", "https://example.com/3"]
+
+    def test_course_is_a_second_line_of_the_task_cell(self):
+        rows, _ = _mu_task_rows(
+            [_make_task(title="En", weekday="Tirsdag", course="Kirkens historie")]
+        )
+
+        assert rows[0][1] == "En\n  Course: Kirkens historie"
+
+    def test_task_type_uses_the_portal_label(self):
+        rows, _ = _mu_task_rows(
+            [
+                _make_task(title="En", weekday="Tirsdag"),
+                _make_task(title="To", weekday="Tirsdag", task_type="Opgave"),
+                _make_task(title="Tre", weekday="Tirsdag", task_type="NyType"),
+            ]
+        )
+
+        assert [row[3] for row in rows] == ["Lektie", "Opgave", "NyType"]
+
+    def test_completed_tasks_are_marked(self):
+        rows, _ = _mu_task_rows(
+            [
+                _make_task(title="En", weekday="Tirsdag", is_completed=True),
+                _make_task(title="To", weekday="Tirsdag"),
+            ]
+        )
+
+        assert [row[4] for row in rows] == ["✓", ""]
+
+
+class TestPrintMuTaskTables:
+    def test_one_table_per_student_in_day_order(self, capsys, monkeypatch):
+        monkeypatch.setattr("aula.utils.table._print_rows_with_rich", lambda *a: False)
+
+        print_mu_task_tables(
+            [
+                _make_task(title="Fredagsopgave", weekday="Fredag", student="Barn To"),
+                _make_task(title="Mandagsopgave", weekday="Mandag", student="Barn To"),
+                _make_task(title="Onsdagsopgave", weekday="Onsdag", student="Barn Et"),
+            ]
+        )
+        out = capsys.readouterr().out
+
+        assert out.index("Barn Et") < out.index("Barn To")
+        assert out.index("Mandagsopgave") < out.index("Fredagsopgave")
+
+    def test_empty_columns_are_dropped(self, capsys, monkeypatch):
+        monkeypatch.setattr("aula.utils.table._print_rows_with_rich", lambda *a: False)
+
+        print_mu_task_tables([_make_task(title="En", weekday="Mandag")])
+        out = capsys.readouterr().out
+
+        assert "Day" in out
+        assert "Done" not in out
+
+    def test_links_are_listed_under_the_table(self, capsys, monkeypatch):
+        monkeypatch.setattr("aula.utils.table._print_rows_with_rich", lambda *a: False)
+
+        print_mu_task_tables(
+            [_make_task(title="En", weekday="Mandag", deep_link="https://example.com/1")]
+        )
+        lines = capsys.readouterr().out.splitlines()
+
+        assert lines[-1] == "  [1] https://example.com/1"

--- a/tests/utils/test_html.py
+++ b/tests/utils/test_html.py
@@ -1,6 +1,6 @@
 """Tests for aula.utils.html."""
 
-from aula.utils.html import html_to_markdown, html_to_plain
+from aula.utils.html import html_to_blocks, html_to_markdown, html_to_plain
 
 
 def test_html_to_plain_strips_tags():
@@ -33,3 +33,32 @@ def test_html_to_plain_nested_tags():
     result = html_to_plain("<div><p><b>nested</b></p></div>")
     assert "nested" in result
     assert "<" not in result
+
+
+class TestHtmlToBlocks:
+    def test_empty_string(self):
+        assert html_to_blocks("") == []
+
+    def test_paragraphs_become_separate_blocks(self):
+        blocks = html_to_blocks("<p>First</p><p>Second</p>")
+        assert blocks == ["First", "Second"]
+
+    def test_drops_spacer_paragraphs(self):
+        blocks = html_to_blocks("<p>Text</p><p><br></p><p>&nbsp;</p><p>More</p>")
+        assert blocks == ["Text", "More"]
+
+    def test_nested_container_is_not_duplicated(self):
+        assert html_to_blocks("<div><p>Only once</p></div>") == ["Only once"]
+
+    def test_line_break_stays_inside_block(self):
+        assert html_to_blocks("<p>One<br>Two</p>") == ["One\nTwo"]
+
+    def test_list_items_get_bullets(self):
+        blocks = html_to_blocks("<ul><li>A</li><li>- B</li></ul>")
+        assert blocks == ["- A", "- B"]
+
+    def test_collapses_whitespace_and_decodes_entities(self):
+        assert html_to_blocks("<p>l&aelig;se   hjemme</p>") == ["læse hjemme"]
+
+    def test_html_without_block_tags(self):
+        assert html_to_blocks("just <b>text</b>") == ["just text"]

--- a/tests/utils/test_table.py
+++ b/tests/utils/test_table.py
@@ -1,19 +1,28 @@
 """Tests for aula.utils.table."""
 
 import builtins
+import os
 from datetime import date, datetime, time
 
 import pytest
 
 from aula.models.calendar_event import CalendarEvent
 from aula.utils.table import (
+    CARD_MAX_WIDTH,
+    CARD_MIN_WIDTH,
     CalendarTableData,
+    _fit_widths,
+    _natural_widths,
+    _print_card_with_rich,
     _print_plain,
     _print_rows_with_rich,
     _print_with_rich,
     build_calendar_table,
+    card_width,
     print_calendar_table,
     print_row_table,
+    print_text_card,
+    print_wrapped_row_table,
 )
 
 
@@ -203,3 +212,185 @@ class TestPrintRowTable:
     def test_no_output_for_empty_rows(self, capsys):
         print_row_table(self.HEADERS, [], title="Contacts")
         assert capsys.readouterr().out == ""
+
+
+class TestCardWidth:
+    def test_follows_terminal_width(self, monkeypatch):
+        monkeypatch.setattr("shutil.get_terminal_size", lambda fallback: os.terminal_size((72, 24)))
+        assert card_width() == 71
+
+    def test_clamped_to_max(self, monkeypatch):
+        monkeypatch.setattr(
+            "shutil.get_terminal_size", lambda fallback: os.terminal_size((400, 24))
+        )
+        assert card_width() == CARD_MAX_WIDTH
+
+    def test_clamped_to_min(self, monkeypatch):
+        monkeypatch.setattr("shutil.get_terminal_size", lambda fallback: os.terminal_size((10, 24)))
+        assert card_width() == CARD_MIN_WIDTH
+
+
+class TestPrintTextCard:
+    HEADERS = ["Barn Et · 3.1 · Week 34", "Skole"]
+    BLOCKS = ["DANSK:", "En kort tekst.", "- Et punkt", "- Et andet punkt"]
+
+    def _plain_lines(self, capsys, monkeypatch, **kwargs):
+        monkeypatch.setattr("aula.utils.table._print_card_with_rich", lambda *a: False)
+        print_text_card(**kwargs)
+        return capsys.readouterr().out.splitlines()
+
+    def test_plain_box_is_rectangular(self, capsys, monkeypatch):
+        lines = self._plain_lines(
+            capsys, monkeypatch, header_lines=self.HEADERS, body_blocks=self.BLOCKS, width=40
+        )
+
+        assert all(len(line) == 40 for line in lines)
+        assert lines[0].startswith("┌") and lines[0].endswith("┐")
+        assert lines[-1].startswith("└") and lines[-1].endswith("┘")
+
+    def test_header_is_divided_from_body(self, capsys, monkeypatch):
+        lines = self._plain_lines(
+            capsys, monkeypatch, header_lines=self.HEADERS, body_blocks=self.BLOCKS, width=40
+        )
+        divider = next(index for index, line in enumerate(lines) if line.startswith("├"))
+
+        assert "Skole" in lines[divider - 1]
+        assert "DANSK:" in lines[divider + 1]
+
+    def test_blocks_are_separated_but_bullets_are_not(self, capsys, monkeypatch):
+        lines = self._plain_lines(
+            capsys, monkeypatch, header_lines=[], body_blocks=self.BLOCKS, width=40
+        )
+        body = [line.strip("│").strip() for line in lines[1:-1]]
+
+        assert body == ["DANSK:", "", "En kort tekst.", "", "- Et punkt", "- Et andet punkt"]
+
+    def test_long_text_wraps_with_bullet_indent(self, capsys, monkeypatch):
+        lines = self._plain_lines(
+            capsys,
+            monkeypatch,
+            header_lines=[],
+            body_blocks=["- " + "ord " * 20],
+            width=40,
+        )
+        body = [line.strip("│").rstrip() for line in lines[1:-1]]
+
+        assert len(body) > 1
+        assert body[0].strip().startswith("- ord")
+        assert body[1].startswith("   ord")
+
+    def test_empty_body_uses_placeholder(self, capsys, monkeypatch):
+        lines = self._plain_lines(
+            capsys,
+            monkeypatch,
+            header_lines=[],
+            body_blocks=[],
+            width=40,
+            empty_body_text="(no weekly plan body)",
+        )
+
+        assert any("(no weekly plan body)" in line for line in lines)
+
+    def test_renders_with_rich(self, capsys):
+        pytest.importorskip("rich")
+
+        print_text_card(header_lines=self.HEADERS, body_blocks=self.BLOCKS, width=60)
+        out = capsys.readouterr().out
+
+        assert "Barn Et" in out
+        assert "Et andet punkt" in out
+
+    def test_reports_missing_rich(self, monkeypatch):
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name.startswith("rich"):
+                raise ImportError("no rich")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        assert _print_card_with_rich(["Head"], ["Body"], 40) is False
+
+
+class TestFitWidths:
+    def test_keeps_natural_widths_when_they_fit(self):
+        assert _fit_widths([10, 20], 40) == [10, 20]
+
+    def test_shrinks_the_widest_column_first(self):
+        assert _fit_widths([10, 30], 30) == [10, 17]
+
+    def test_never_shrinks_below_the_floor(self):
+        # 3 separator chars + two floors of 8 is already wider than 12.
+        assert _fit_widths([20, 20], 12) == [8, 8]
+
+    def test_narrow_column_keeps_its_natural_width(self):
+        assert _fit_widths([3, 40], 20) == [3, 14]
+
+
+class TestNaturalWidths:
+    def test_uses_the_longest_line_of_a_cell(self):
+        widths = _natural_widths(["Task"], [["short"], ["a longer line\nshort"]])
+        assert widths == [len("a longer line")]
+
+    def test_header_sets_the_floor(self):
+        assert _natural_widths(["Weekday"], [["Mon"]]) == [len("Weekday")]
+
+
+class TestPrintWrappedRowTable:
+    HEADERS = ["Day", "Task"]
+    ROWS = [["Tirsdag", "Bibliotek"], ["Onsdag", "Tur i skoven"]]
+
+    def _plain_lines(self, capsys, monkeypatch, **kwargs):
+        monkeypatch.setattr("aula.utils.table._print_rows_with_rich", lambda *a: False)
+        print_wrapped_row_table(**kwargs)
+        return capsys.readouterr().out.splitlines()
+
+    def test_no_rows_prints_nothing(self, capsys):
+        print_wrapped_row_table(self.HEADERS, [])
+        assert capsys.readouterr().out == ""
+
+    def test_renders_title_header_and_rows(self, capsys, monkeypatch):
+        lines = self._plain_lines(
+            capsys, monkeypatch, headers=self.HEADERS, rows=self.ROWS, title="Barn Et", width=40
+        )
+
+        assert lines[0] == "Barn Et"
+        assert lines[1].startswith("Day     | Task")
+        assert lines[2] == "--------+-------------"
+        assert lines[3] == "Tirsdag | Bibliotek"
+
+    def test_never_exceeds_the_given_width(self, capsys, monkeypatch):
+        lines = self._plain_lines(
+            capsys,
+            monkeypatch,
+            headers=["Day", "Task", "Class"],
+            rows=[["Tirsdag", "En meget lang opgavetitel som ikke kan passe", "Historie 3.1"]],
+            width=40,
+        )
+
+        assert lines and all(len(line) <= 40 for line in lines)
+
+    def test_single_line_rows_stay_dense(self, capsys, monkeypatch):
+        lines = self._plain_lines(
+            capsys, monkeypatch, headers=self.HEADERS, rows=self.ROWS, width=40
+        )
+
+        assert "" not in lines
+
+    def test_wrapped_rows_are_spaced_from_neighbours(self, capsys, monkeypatch):
+        rows = [["Tirsdag", "Kort"], ["Onsdag", "Titel\n  Course: Et forløb"], ["Fredag", "Kort"]]
+        lines = self._plain_lines(capsys, monkeypatch, headers=self.HEADERS, rows=rows, width=40)
+        blanks = [index for index, line in enumerate(lines) if line == ""]
+
+        assert len(blanks) == 2
+        assert "Course: Et forløb" in lines[blanks[0] + 2]
+
+    def test_renders_with_rich(self, capsys):
+        pytest.importorskip("rich")
+
+        print_wrapped_row_table(self.HEADERS, self.ROWS, title="Barn Et")
+        out = capsys.readouterr().out
+
+        assert "Tur i skoven" in out
+        assert "Barn Et" in out

--- a/tests/utils/test_week.py
+++ b/tests/utils/test_week.py
@@ -1,0 +1,25 @@
+"""Tests for aula.utils.week."""
+
+from aula.utils.week import DANISH_WEEKDAYS, monday_of_week, weekday_index
+
+
+class TestMondayOfWeek:
+    def test_returns_monday_of_iso_week(self):
+        assert monday_of_week("2026-W34") == "2026-08-17T00:00:00Z"
+
+    def test_falls_back_to_today_on_bad_input(self):
+        assert monday_of_week("nonsense").endswith("T00:00:00Z")
+
+
+class TestWeekdayIndex:
+    def test_known_days_are_monday_first(self):
+        assert weekday_index("Mandag") == 0
+        assert weekday_index("Søndag") == 6
+
+    def test_case_and_padding_are_ignored(self):
+        assert weekday_index(" tirsdag ") == 1
+
+    def test_unknown_and_missing_sort_last(self):
+        assert weekday_index("Someday") == len(DANISH_WEEKDAYS)
+        assert weekday_index("") == len(DANISH_WEEKDAYS)
+        assert weekday_index(None) == len(DANISH_WEEKDAYS)


### PR DESCRIPTION
## Why

Both Min Uddannelse commands were hard to read.

`mu:ugeplan` sent the weekly letter through `html_to_plain`, which collapsed the blank lines between paragraphs, and html2text escaped the `- ` bullets teachers type by hand as `\-`. A letter arrived as one dense block of text.

`mu:opgaver` printed six lines per task. With two children and a full week that is more than a screen, and the same task repeats per child.

## What changed

`mu:ugeplan` renders one bordered card per letter: name, class and week on top, then the body wrapped to the terminal width with paragraphs and bullet lists intact.

```
Min Uddannelse weekly plans [2026-W15]
======================================

┌─────────────────────────────────────────────────────────────────────────────┐
│ Barn Et · 2.1 · Week 15                                                     │
│ Byskolen                                                                    │
├─────────────────────────────────────────────────────────────────────────────┤
│ DANSK:                                                                      │
│                                                                             │
│ I denne uge arbejder vi i SPA med:                                          │
│                                                                             │
│ - Kineserlyden                                                              │
│ - Synonymer                                                                 │
│                                                                             │
│ Husk biblioteksbøger torsdag, hvor alle har mulighed for at låne 3          │
│ biblioteksbøger.                                                            │
└─────────────────────────────────────────────────────────────────────────────┘
```

`mu:opgaver` prints one day-ordered table per child.

```
Min Uddannelse tasks [2026-W34]
===============================

Barn Et
Day     | Task                          | Class                   | Type
--------+-------------------------------+-------------------------+-------
Tirsdag | Bibliotek [1]                 | Bibliotek (Andet)       | Lektie
        | HUSK COMPUTER [2]             | Historie 3.1            | Lektie
        | Link til opgave [3]           | Historie 3.1            | Lektie

        | Hvad er historie?             | Historie 3.1            | Opgave
        |   Course: Hvad er historie    |                         |

Onsdag  | PÅ TUR I SPEJDERHYTTEN [4]    | Dansk 3.1               | Lektie
Torsdag | HUSK BIBLIOTEKSBØGER [5]      | Dansk 3.1               | Lektie
Fredag  | Spil til matematik [6]        | Matematik 3.1           | Lektie
  [1] https://example.com/opgave/1
```

Layout decisions behind that table:

- Grouped per child, sorted by Danish weekday, then due date, then title. The day is printed once per run of tasks.
- Deep links became numbered footnotes. A URL column would have squeezed every other column down to its 8 character floor.
- Columns every task leaves blank are dropped, so `Course` and `Done` (a check mark for `is_completed`) only show up when they carry something.
- Content trimmed to fit 80 columns: the subject is only appended to a class name that does not already contain it (`Bibliotek (Andet)`, but plain `Historie 3.1`), the course moves to a second line of the task cell, and `SimpelLektie` renders as `Lektie`, the label the portal itself uses. Unknown task types pass through verbatim.

## Shared pieces

- `html_to_blocks()` in `utils/html.py` splits letter HTML into paragraph blocks with bs4, dropping the `<p><br></p>` spacers the platform emits and bulleting `<li>`.
- `print_text_card()` in `utils/table.py` draws the card, a rich `Panel` when rich is installed, box drawing characters otherwise.
- `print_wrapped_row_table()` in `utils/table.py` fits a table to the terminal: natural column widths when they fit, otherwise the widest columns shrink (never below 8, never below a naturally narrow column's own width) and cells wrap. Multi line rows get a blank line from their neighbours while runs of single line rows stay dense. Existing `print_row_table` callers are untouched.
- `DANISH_WEEKDAYS` and a new `weekday_index()` move from `cli.py` to `utils/week.py`.

The samples above use placeholder names and links; the layouts were verified against live data locally.

## Testing

- 722 passed, 4 skipped locally. The skips are the rich only tests; `uv run --with rich pytest` runs 726 passed.
- Checked both commands against live data at 79 and 52 columns, with and without rich, piped to a non tty, and on an empty week.
- Smoke tested `daily-summary`, the other caller of the weekday list.
- `--output json` is unchanged for both commands.

No version bump in this PR.
