### PR TITLE
feat: expose post and message attachments as objects

### DIFF
--- a/src/aula/__init__.py
+++ b/src/aula/__init__.py
@@ -23,6 +23,10 @@ from .http_httpx import HttpxHttpClient
 from .models import (
     ActivityType,
     Attachment,
+    AttachmentDocument,
+    AttachmentFile,
+    AttachmentLink,
+    AttachmentMedia,
     CalendarEvent,
     Child,
     DailyOverview,
@@ -60,6 +64,10 @@ __all__ = [
     "WidgetConfiguration",
     "ActivityType",
     "Attachment",
+    "AttachmentDocument",
+    "AttachmentFile",
+    "AttachmentLink",
+    "AttachmentMedia",
     "PresenceState",
     "__version__",
 ]

--- a/src/aula/__init__.py
+++ b/src/aula/__init__.py
@@ -22,6 +22,7 @@ from .http import (
 from .http_httpx import HttpxHttpClient
 from .models import (
     ActivityType,
+    Attachment,
     CalendarEvent,
     Child,
     DailyOverview,
@@ -58,6 +59,7 @@ __all__ = [
     "CalendarEvent",
     "WidgetConfiguration",
     "ActivityType",
+    "Attachment",
     "PresenceState",
     "__version__",
 ]

--- a/src/aula/api_client.py
+++ b/src/aula/api_client.py
@@ -925,12 +925,7 @@ class AulaApiClient:
         for msg_dict in raw_messages:
             if msg_dict.get("messageType") in ("Message", "MessageEdited"):
                 try:
-                    text = get_in(msg_dict, "text.html", default="") or get_in(
-                        msg_dict, "text", default=""
-                    )
-                    messages.append(
-                        Message(_raw=msg_dict, id=msg_dict.get("id"), content_html=text)
-                    )
+                    messages.append(Message.from_dict(msg_dict))
                 except (TypeError, ValueError) as e:
                     _LOGGER.warning(
                         "Skipping message due to parsing error: %s - Data: %s", e, msg_dict

--- a/src/aula/api_client.py
+++ b/src/aula/api_client.py
@@ -1619,16 +1619,7 @@ class AulaApiClient:
                 break
 
             for msg_dict in results:
-                raw_text = msg_dict.get("text")
-                if isinstance(raw_text, dict):
-                    content_html = raw_text.get("html", "")
-                elif isinstance(raw_text, str):
-                    content_html = raw_text
-                else:
-                    content_html = ""
-                all_messages.append(
-                    Message(_raw=msg_dict, id=msg_dict.get("id", ""), content_html=content_html)
-                )
+                all_messages.append(Message.from_dict(msg_dict))
 
             total = data.get("totalSize", 0)
             offset += limit

--- a/src/aula/models/__init__.py
+++ b/src/aula/models/__init__.py
@@ -1,4 +1,9 @@
 from .appointment import Appointment as Appointment
+from .attachment import Attachment as Attachment
+from .attachment import AttachmentDocument as AttachmentDocument
+from .attachment import AttachmentFile as AttachmentFile
+from .attachment import AttachmentLink as AttachmentLink
+from .attachment import AttachmentMedia as AttachmentMedia
 from .auto_reply import AutoReply as AutoReply
 from .calendar_event import CalendarEvent as CalendarEvent
 from .child import Child as Child

--- a/src/aula/models/attachment.py
+++ b/src/aula/models/attachment.py
@@ -124,6 +124,7 @@ class Attachment(AulaDataClass):
     id: int | None = None
     name: str = ""
     status: str = ""
+    created: datetime.datetime | None = None
     file: AttachmentFile | None = None
     media: AttachmentMedia | None = None
     link: AttachmentLink | None = None
@@ -139,11 +140,6 @@ class Attachment(AulaDataClass):
         if self.link is not None:
             return self.link.url
         return None
-
-    @property
-    def created(self) -> datetime.datetime | None:
-        """When the attached file was created."""
-        return self.file.created if self.file is not None else None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Attachment:
@@ -173,10 +169,16 @@ class Attachment(AulaDataClass):
             elif document is not None:
                 name = document.title
 
+        # Only some attachments date the envelope; the rest date their file.
+        created = parse_api_datetime(data.get("created"))
+        if created is None and file is not None:
+            created = file.created
+
         return cls(
             id=data.get("id"),
             name=name,
             status=data.get("status") or "",
+            created=created,
             file=file,
             media=media,
             link=link,
@@ -186,14 +188,14 @@ class Attachment(AulaDataClass):
         )
 
 
-def parse_attachments(items: Any) -> list[Attachment]:
+def parse_attachments(raw_attachments: Any) -> list[Attachment]:
     """Read an API ``attachments`` list, skipping anything unreadable."""
     attachments: list[Attachment] = []
-    for item in items or []:
-        if not isinstance(item, dict):
+    for raw in raw_attachments or []:
+        if not isinstance(raw, dict):
             continue
         try:
-            attachments.append(Attachment.from_dict(item))
+            attachments.append(Attachment.from_dict(raw))
         except (TypeError, ValueError, KeyError) as e:
-            _LOGGER.warning("Skipping attachment due to parsing error: %s - Data: %s", e, item)
+            _LOGGER.warning("Skipping attachment due to parsing error: %s - Data: %s", e, raw)
     return attachments

--- a/src/aula/models/attachment.py
+++ b/src/aula/models/attachment.py
@@ -1,0 +1,199 @@
+"""Attachments on posts and messages.
+
+Aula sends one attachment shape everywhere: an envelope carrying an id, a
+status, its creator, and exactly one of four content variants — a file, a
+gallery media item, a link into a cloud drive, or a link to a secure document.
+Verified against ``AulaFileResultDto`` in the decompiled mobile app.
+
+The file behind a media item sits one level deeper than a plain file's, so
+:class:`Attachment` hoists it: ``attachment.file`` is the file to download
+whichever way the attachment arrived, and ``attachment.media`` keeps the
+gallery metadata that came with it.
+"""
+
+import datetime
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..utils.dates import parse_api_datetime
+from .base import AulaDataClass
+from .institution_profile import InstitutionProfile
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class AttachmentFile(AulaDataClass):
+    """The file behind an attachment."""
+
+    id: int | None = None
+    name: str = ""
+    url: str | None = None
+    created: datetime.datetime | None = None
+    scanning_status: str = ""
+    _raw: dict | None = field(default=None, repr=False)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AttachmentFile:
+        return cls(
+            id=data.get("id"),
+            name=data.get("name") or "",
+            url=data.get("url"),
+            created=parse_api_datetime(data.get("created")),
+            scanning_status=data.get("scanningStatus") or "",
+            _raw=data,
+        )
+
+
+@dataclass
+class AttachmentMedia(AulaDataClass):
+    """The gallery metadata Aula adds when an attachment is a media item.
+
+    The media's own file is hoisted onto :attr:`Attachment.file`.
+    """
+
+    title: str = ""
+    description: str = ""
+    media_type: str = ""
+    thumbnail_url: str | None = None
+    _raw: dict | None = field(default=None, repr=False)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AttachmentMedia:
+        return cls(
+            title=data.get("title") or "",
+            description=data.get("description") or "",
+            media_type=data.get("mediaType") or "",
+            thumbnail_url=data.get("thumbnailUrl"),
+            _raw=data,
+        )
+
+
+@dataclass
+class AttachmentLink(AulaDataClass):
+    """A link to a file in a cloud drive, attached instead of an upload."""
+
+    service: str = ""
+    name: str = ""
+    url: str | None = None
+    _raw: dict | None = field(default=None, repr=False)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AttachmentLink:
+        return cls(
+            service=data.get("service") or "",
+            name=data.get("name") or "",
+            url=data.get("url"),
+            _raw=data,
+        )
+
+
+@dataclass
+class AttachmentDocument(AulaDataClass):
+    """A link to a secure document, which Aula keeps behind its own access check."""
+
+    id: int | None = None
+    title: str = ""
+    document_type: str = ""
+    can_access: bool = False
+    is_deleted: bool = False
+    _raw: dict | None = field(default=None, repr=False)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AttachmentDocument:
+        return cls(
+            id=data.get("id"),
+            title=data.get("title") or "",
+            document_type=data.get("documentType") or "",
+            can_access=data.get("canAccess", False),
+            is_deleted=data.get("isDeleted", False),
+            _raw=data,
+        )
+
+
+@dataclass
+class Attachment(AulaDataClass):
+    """Something attached to a post or a message.
+
+    :attr:`name` is the attachment's own name, whichever variant it arrived as,
+    and :attr:`url` is where its bytes are, so a caller that only wants to name
+    or fetch an attachment never has to ask which variant it is.
+    """
+
+    id: int | None = None
+    name: str = ""
+    status: str = ""
+    file: AttachmentFile | None = None
+    media: AttachmentMedia | None = None
+    link: AttachmentLink | None = None
+    document: AttachmentDocument | None = None
+    creator: InstitutionProfile | None = None
+    _raw: dict | None = field(default=None, repr=False)
+
+    @property
+    def url(self) -> str | None:
+        """Where the attachment's bytes are, or ``None`` for a secure document."""
+        if self.file is not None:
+            return self.file.url
+        if self.link is not None:
+            return self.link.url
+        return None
+
+    @property
+    def created(self) -> datetime.datetime | None:
+        """When the attached file was created."""
+        return self.file.created if self.file is not None else None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Attachment:
+        media_data = data.get("media") or {}
+        media = AttachmentMedia.from_dict(media_data) if media_data else None
+
+        # A media item wraps its file one level deeper than a plain file.
+        file_data = media_data.get("file") or data.get("file") or {}
+        file = AttachmentFile.from_dict(file_data) if file_data else None
+
+        link_data = data.get("link") or {}
+        link = AttachmentLink.from_dict(link_data) if link_data else None
+
+        document_data = data.get("document") or {}
+        document = AttachmentDocument.from_dict(document_data) if document_data else None
+
+        creator_data = data.get("creator") or {}
+        creator = InstitutionProfile.from_dict(creator_data) if creator_data else None
+
+        # Most attachments name themselves; the rest are named by their content.
+        name = data.get("name") or ""
+        if not name:
+            if file is not None:
+                name = file.name
+            elif link is not None:
+                name = link.name
+            elif document is not None:
+                name = document.title
+
+        return cls(
+            id=data.get("id"),
+            name=name,
+            status=data.get("status") or "",
+            file=file,
+            media=media,
+            link=link,
+            document=document,
+            creator=creator,
+            _raw=data,
+        )
+
+
+def parse_attachments(items: Any) -> list[Attachment]:
+    """Read an API ``attachments`` list, skipping anything unreadable."""
+    attachments: list[Attachment] = []
+    for item in items or []:
+        if not isinstance(item, dict):
+            continue
+        try:
+            attachments.append(Attachment.from_dict(item))
+        except (TypeError, ValueError, KeyError) as e:
+            _LOGGER.warning("Skipping attachment due to parsing error: %s - Data: %s", e, item)
+    return attachments

--- a/src/aula/models/message.py
+++ b/src/aula/models/message.py
@@ -33,9 +33,12 @@ class Message(AulaDataClass):
     def from_dict(cls, data: dict[str, Any]) -> Message:
         """Create a Message instance from API response data."""
         message_id = data.get("id")
+        # A body arrives wrapped as {"text": {"html": ...}} or, on older
+        # messages, as a bare string. Anything else has no body to read.
+        text = get_in(data, "text.html", default="") or get_in(data, "text", default="")
         return cls(
             id=str(message_id) if message_id is not None else "",
-            content_html=get_in(data, "text.html", default="") or get_in(data, "text", default=""),
+            content_html=text if isinstance(text, str) else "",
             attachments=parse_attachments(data.get("attachments")),
             _raw=data,
         )

--- a/src/aula/models/message.py
+++ b/src/aula/models/message.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass, field
+from typing import Any
 
 from ..utils.html import html_to_markdown, html_to_plain
+from ..utils.mapping import get_in
+from .attachment import Attachment, parse_attachments
 from .base import AulaDataClass
 
 
@@ -8,6 +11,7 @@ from .base import AulaDataClass
 class Message(AulaDataClass):
     id: str
     content_html: str
+    attachments: list[Attachment] = field(default_factory=list)
     _raw: dict | None = field(default=None, repr=False)
 
     @property
@@ -19,3 +23,19 @@ class Message(AulaDataClass):
     def content_markdown(self) -> str:
         """Return the content converted to Markdown format."""
         return html_to_markdown(self.content_html)
+
+    @property
+    def has_attachments(self) -> bool:
+        """Whether the message has anything attached to it."""
+        return bool(self.attachments)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Message:
+        """Create a Message instance from API response data."""
+        message_id = data.get("id")
+        return cls(
+            id=str(message_id) if message_id is not None else "",
+            content_html=get_in(data, "text.html", default="") or get_in(data, "text", default=""),
+            attachments=parse_attachments(data.get("attachments")),
+            _raw=data,
+        )

--- a/src/aula/models/post.py
+++ b/src/aula/models/post.py
@@ -2,8 +2,10 @@ import datetime
 from dataclasses import dataclass, field
 from typing import Any
 
+from ..utils.dates import parse_api_datetime
 from ..utils.html import html_to_markdown, html_to_plain
 from ..utils.mapping import get_in
+from .attachment import Attachment, parse_attachments
 from .base import AulaDataClass
 from .profile_reference import ProfileReference
 
@@ -26,7 +28,7 @@ class Post(AulaDataClass):
     is_important: bool
     important_from: datetime.datetime | None
     important_to: datetime.datetime | None
-    attachments: list[dict]
+    attachments: list[Attachment]
     comment_count: int
     can_current_user_delete: bool
     can_current_user_comment: bool
@@ -46,39 +48,27 @@ class Post(AulaDataClass):
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Post:
         """Create a Post instance from API response data."""
-
-        def parse_datetime(dt_str: str | None) -> datetime.datetime | None:
-            if not dt_str:
-                return None
-            try:
-                # Handle timezone offset
-                if dt_str.endswith("Z"):
-                    dt_str = dt_str[:-1] + "+00:00"
-                return datetime.datetime.fromisoformat(dt_str)
-            except ValueError, TypeError:
-                return None
-
         owner = ProfileReference.from_dict(data.get("ownerProfile") or {})
 
         return cls(
             id=data["id"],
             title=data.get("title", ""),
             content_html=get_in(data, "content.html", default=""),
-            timestamp=parse_datetime(data.get("timestamp")),
+            timestamp=parse_api_datetime(data.get("timestamp")),
             owner=owner,
             allow_comments=data.get("allowComments", False),
             shared_with_groups=data.get("sharedWithGroups", []),
-            publish_at=parse_datetime(data.get("publishAt")),
+            publish_at=parse_api_datetime(data.get("publishAt")),
             is_published=data.get("isPublished", False),
-            expire_at=parse_datetime(data.get("expireAt")),
+            expire_at=parse_api_datetime(data.get("expireAt")),
             is_expired=data.get("isExpired", False),
             is_important=data.get("isImportant", False),
-            important_from=parse_datetime(data.get("importantFrom")),
-            important_to=parse_datetime(data.get("importantTo")),
-            attachments=data.get("attachments", []),
+            important_from=parse_api_datetime(data.get("importantFrom")),
+            important_to=parse_api_datetime(data.get("importantTo")),
+            attachments=parse_attachments(data.get("attachments")),
             comment_count=data.get("commentCount", 0),
             can_current_user_delete=data.get("canCurrentUserDelete", False),
             can_current_user_comment=data.get("canCurrentUserComment", False),
-            edited_at=parse_datetime(data.get("editedAt")),
+            edited_at=parse_api_datetime(data.get("editedAt")),
             _raw=data,
         )

--- a/src/aula/utils/dates.py
+++ b/src/aula/utils/dates.py
@@ -1,0 +1,25 @@
+"""Helpers for reading dates and times out of API responses."""
+
+import datetime
+from typing import Any
+
+
+def parse_api_datetime(value: Any) -> datetime.datetime | None:
+    """Parse an ISO 8601 timestamp from Aula, or ``None`` when unreadable.
+
+    Aula writes timestamps three ways in the same response: with an offset,
+    with a trailing ``Z`` for UTC, and naive. A field it has no value for
+    arrives as ``null``, an empty string, or not at all. All of those, and
+    anything else unparseable, give ``None``.
+
+    >>> parse_api_datetime("2026-03-01T09:00:00Z")
+    datetime.datetime(2026, 3, 1, 9, 0, tzinfo=datetime.timezone.utc)
+    >>> parse_api_datetime(None) is None
+    True
+    """
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        return datetime.datetime.fromisoformat(value)
+    except ValueError:
+        return None

--- a/src/aula/utils/download.py
+++ b/src/aula/utils/download.py
@@ -7,6 +7,7 @@ from datetime import date, datetime
 from pathlib import Path
 
 from ..api_client import AulaApiClient
+from ..models.attachment import parse_attachments
 from .mapping import get_in
 
 _LOGGER = logging.getLogger(__name__)
@@ -170,10 +171,11 @@ async def download_post_images(
         post_dir = output / "posts" / folder_name
 
         for attachment in post.attachments:
-            media = attachment.get("media") or {}
-            file_info = media.get("file") or {}
-            url = file_info.get("url")
-            filename = file_info.get("name")
+            # A post can also attach a plain file or a link; only media is an image.
+            if attachment.media is None or attachment.file is None:
+                continue
+            url = attachment.file.url
+            filename = attachment.file.name
             if not url or not filename:
                 continue
 
@@ -263,10 +265,11 @@ async def download_message_images(
             if not msg.get("hasAttachments"):
                 continue
 
-            for attachment in msg.get("attachments") or []:
-                file_info = attachment.get("file") or {}
-                url = file_info.get("url")
-                filename = file_info.get("name")
+            for attachment in parse_attachments(msg.get("attachments")):
+                if attachment.file is None:
+                    continue
+                url = attachment.file.url
+                filename = attachment.file.name
                 if not url or not filename:
                     continue
 

--- a/tests/models/test_attachment.py
+++ b/tests/models/test_attachment.py
@@ -125,6 +125,19 @@ def test_attachment_from_dict_null_nested_objects():
     assert attachment.url is None
 
 
+def test_attachment_created_from_envelope():
+    """An attachment that dates itself keeps its own date, not the file's."""
+    attachment = Attachment.from_dict(
+        {
+            "id": 5009,
+            "created": "2026-03-05T08:00:00Z",
+            "file": {"name": "x.pdf", "created": "2026-03-01T08:00:00Z"},
+        }
+    )
+
+    assert attachment.created == datetime.datetime(2026, 3, 5, 8, 0, tzinfo=datetime.UTC)
+
+
 def test_attachment_from_dict_link():
     attachment = Attachment.from_dict(
         {
@@ -143,6 +156,7 @@ def test_attachment_from_dict_link():
     assert attachment.link is not None
     assert attachment.link.service == "OneDrive"
     assert attachment.file is None
+    assert attachment.created is None
 
 
 def test_attachment_from_dict_document():
@@ -180,6 +194,7 @@ def test_attachment_dict_conversion():
 
     assert result["id"] == 5001
     assert result["name"] == "outing.jpg"
+    assert result["created"] == datetime.datetime(2026, 3, 1, 9, 30, tzinfo=datetime.UTC)
     assert result["file"]["url"] == "https://files.example.test/outing.jpg"
     assert result["media"]["title"] == "Class outing"
     assert result["creator"]["name"] == "Teacher One"

--- a/tests/models/test_attachment.py
+++ b/tests/models/test_attachment.py
@@ -1,0 +1,204 @@
+"""Tests for aula.models.attachment."""
+
+import datetime
+
+from aula.models.attachment import Attachment, parse_attachments
+
+# A gallery photo attached to a post: Aula wraps the file in a "media" object.
+MEDIA_ATTACHMENT = {
+    "id": 5001,
+    "status": "AVAILABLE",
+    "creator": {
+        "id": 200,
+        "profileId": 300,
+        "name": "Teacher One",
+        "shortName": "TEA",
+        "role": "employee",
+        "institutionCode": "A1234",
+        "institutionName": "Example School",
+    },
+    "media": {
+        "title": "Class outing",
+        "description": "On the bus",
+        "mediaType": "image",
+        "thumbnailUrl": "https://files.example.test/thumb.jpg",
+        "file": {
+            "id": 9001,
+            "name": "outing.jpg",
+            "url": "https://files.example.test/outing.jpg",
+            "created": "2026-03-01T09:30:00Z",
+            "scanningStatus": "Available",
+        },
+    },
+}
+
+# A file attached to a message: the file sits directly on the attachment.
+FILE_ATTACHMENT = {
+    "id": 5002,
+    "status": "AVAILABLE",
+    "file": {
+        "id": 9002,
+        "name": "weekplan.pdf",
+        "url": "https://files.example.test/weekplan.pdf",
+        "created": "2026-03-02T11:00:00+01:00",
+        "scanningStatus": "Available",
+    },
+}
+
+
+def test_attachment_from_dict_media():
+    attachment = Attachment.from_dict(MEDIA_ATTACHMENT)
+
+    assert attachment.id == 5001
+    assert attachment.status == "AVAILABLE"
+    assert attachment.name == "outing.jpg"
+    assert attachment.url == "https://files.example.test/outing.jpg"
+    assert attachment.created == datetime.datetime(2026, 3, 1, 9, 30, tzinfo=datetime.UTC)
+    assert attachment.file is not None
+    assert attachment.file.id == 9001
+    assert attachment.file.name == "outing.jpg"
+    assert attachment.file.scanning_status == "Available"
+    assert attachment.media is not None
+    assert attachment.media.title == "Class outing"
+    assert attachment.media.description == "On the bus"
+    assert attachment.media.media_type == "image"
+    assert attachment.media.thumbnail_url == "https://files.example.test/thumb.jpg"
+    assert attachment.creator is not None
+    assert attachment.creator.name == "Teacher One"
+    assert attachment.creator.institution_name == "Example School"
+    assert attachment._raw is MEDIA_ATTACHMENT
+
+
+def test_attachment_from_dict_file():
+    """A message attachment carries its file directly, and reads the same way."""
+    attachment = Attachment.from_dict(FILE_ATTACHMENT)
+
+    assert attachment.id == 5002
+    assert attachment.name == "weekplan.pdf"
+    assert attachment.url == "https://files.example.test/weekplan.pdf"
+    assert attachment.created is not None
+    assert attachment.created.hour == 11
+    assert attachment.media is None
+    assert attachment.creator is None
+
+
+def test_attachment_names_itself():
+    """Aula names most attachments itself, and that name wins over the file's."""
+    attachment = Attachment.from_dict(
+        {
+            "id": 5008,
+            "name": "Week plan, week 34.pdf",
+            "status": "available",
+            "file": {"name": "uge-34.pdf", "url": "https://files.example.test/uge-34.pdf"},
+        }
+    )
+
+    assert attachment.name == "Week plan, week 34.pdf"
+    assert attachment.file is not None
+    assert attachment.file.name == "uge-34.pdf"
+
+
+def test_attachment_from_dict_missing_fields():
+    attachment = Attachment.from_dict({"id": 5003})
+
+    assert attachment.id == 5003
+    assert attachment.name == ""
+    assert attachment.status == ""
+    assert attachment.file is None
+    assert attachment.media is None
+    assert attachment.link is None
+    assert attachment.document is None
+    assert attachment.creator is None
+    assert attachment.url is None
+    assert attachment.created is None
+
+
+def test_attachment_from_dict_null_nested_objects():
+    """Aula sends an explicit null for the variants an attachment is not."""
+    attachment = Attachment.from_dict(
+        {"id": 5004, "file": None, "media": None, "link": None, "document": None, "creator": None}
+    )
+
+    assert attachment.file is None
+    assert attachment.media is None
+    assert attachment.name == ""
+    assert attachment.url is None
+
+
+def test_attachment_from_dict_link():
+    attachment = Attachment.from_dict(
+        {
+            "id": 5005,
+            "status": "AVAILABLE",
+            "link": {
+                "service": "OneDrive",
+                "name": "Parent meeting slides",
+                "url": "https://links.example.test/slides",
+            },
+        }
+    )
+
+    assert attachment.name == "Parent meeting slides"
+    assert attachment.url == "https://links.example.test/slides"
+    assert attachment.link is not None
+    assert attachment.link.service == "OneDrive"
+    assert attachment.file is None
+
+
+def test_attachment_from_dict_document():
+    attachment = Attachment.from_dict(
+        {
+            "id": 5006,
+            "document": {
+                "id": 77,
+                "title": "House rules",
+                "documentType": "secure",
+                "canAccess": True,
+                "isDeleted": False,
+            },
+        }
+    )
+
+    assert attachment.name == "House rules"
+    assert attachment.url is None
+    assert attachment.document is not None
+    assert attachment.document.id == 77
+    assert attachment.document.document_type == "secure"
+    assert attachment.document.can_access is True
+    assert attachment.document.is_deleted is False
+
+
+def test_attachment_from_dict_unreadable_created():
+    attachment = Attachment.from_dict({"id": 5007, "file": {"name": "x.pdf", "created": "soon"}})
+
+    assert attachment.created is None
+    assert attachment.name == "x.pdf"
+
+
+def test_attachment_dict_conversion():
+    result = dict(Attachment.from_dict(MEDIA_ATTACHMENT))
+
+    assert result["id"] == 5001
+    assert result["name"] == "outing.jpg"
+    assert result["file"]["url"] == "https://files.example.test/outing.jpg"
+    assert result["media"]["title"] == "Class outing"
+    assert result["creator"]["name"] == "Teacher One"
+    assert "_raw" not in result
+    assert "_raw" not in result["file"]
+
+
+def test_parse_attachments_reads_every_item():
+    attachments = parse_attachments([MEDIA_ATTACHMENT, FILE_ATTACHMENT])
+
+    assert [a.name for a in attachments] == ["outing.jpg", "weekplan.pdf"]
+
+
+def test_parse_attachments_skips_unreadable_items():
+    attachments = parse_attachments([MEDIA_ATTACHMENT, "not-a-dict", None])
+
+    assert [a.name for a in attachments] == ["outing.jpg"]
+
+
+def test_parse_attachments_of_nothing():
+    assert parse_attachments(None) == []
+    assert parse_attachments([]) == []

--- a/tests/models/test_message.py
+++ b/tests/models/test_message.py
@@ -69,6 +69,12 @@ def test_message_from_dict_plain_text_body():
     assert msg.content_html == "Hello"
 
 
+def test_message_from_dict_body_of_unexpected_shape():
+    """A body that is neither a wrapper nor a string leaves no text to read."""
+    msg = Message.from_dict({"id": "m4", "text": 12345})
+    assert msg.content_html == ""
+
+
 def test_message_from_dict_without_attachments():
     msg = Message.from_dict({"id": "m3", "text": {"html": ""}})
     assert msg.attachments == []

--- a/tests/models/test_message.py
+++ b/tests/models/test_message.py
@@ -36,3 +36,40 @@ def test_message_raw_preserved():
     msg = Message(id="1", content_html="text", _raw={"original": True})
     assert msg._raw == {"original": True}
     assert "_raw" not in dict(msg)
+
+
+def test_message_from_dict():
+    data = {
+        "id": "m1",
+        "text": {"html": "<p>Hello</p>"},
+        "attachments": [
+            {
+                "id": 5002,
+                "status": "AVAILABLE",
+                "file": {
+                    "name": "weekplan.pdf",
+                    "url": "https://files.example.test/weekplan.pdf",
+                },
+            }
+        ],
+    }
+    msg = Message.from_dict(data)
+    assert msg.id == "m1"
+    assert msg.content_html == "<p>Hello</p>"
+    assert msg.has_attachments is True
+    assert len(msg.attachments) == 1
+    assert msg.attachments[0].name == "weekplan.pdf"
+    assert msg.attachments[0].url == "https://files.example.test/weekplan.pdf"
+    assert msg._raw is data
+
+
+def test_message_from_dict_plain_text_body():
+    """Older messages carry their body as a bare string instead of a wrapper."""
+    msg = Message.from_dict({"id": "m2", "text": "Hello"})
+    assert msg.content_html == "Hello"
+
+
+def test_message_from_dict_without_attachments():
+    msg = Message.from_dict({"id": "m3", "text": {"html": ""}})
+    assert msg.attachments == []
+    assert msg.has_attachments is False

--- a/tests/models/test_post.py
+++ b/tests/models/test_post.py
@@ -124,3 +124,41 @@ def test_post_from_dict_null_content():
     }
     post = Post.from_dict(data)
     assert post.content_html == ""
+
+
+def test_post_attachments_are_objects():
+    """A post's attachments arrive as Attachment objects, not raw dicts."""
+    data = {
+        "id": 3,
+        "ownerProfile": {"id": 1, "profileId": 1},
+        "attachments": [
+            {
+                "id": 5001,
+                "status": "AVAILABLE",
+                "media": {
+                    "title": "Class outing",
+                    "mediaType": "image",
+                    "file": {
+                        "name": "outing.jpg",
+                        "url": "https://files.example.test/outing.jpg",
+                    },
+                },
+            }
+        ],
+    }
+    post = Post.from_dict(data)
+    assert len(post.attachments) == 1
+    attachment = post.attachments[0]
+    assert attachment.name == "outing.jpg"
+    assert attachment.url == "https://files.example.test/outing.jpg"
+
+
+def test_post_attachments_null():
+    """Aula sends an explicit null when a post has no attachments."""
+    data = {
+        "id": 4,
+        "ownerProfile": {"id": 1, "profileId": 1},
+        "attachments": None,
+    }
+    post = Post.from_dict(data)
+    assert post.attachments == []

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1571,6 +1571,39 @@ class TestSearchMessages:
         assert messages[2].content_html == ""
 
     @pytest.mark.asyncio
+    async def test_attachments_are_parsed(self, client):
+        """A search filtered on attachments returns them on the message."""
+        client._request_with_version_retry = AsyncMock(
+            return_value=HttpResponse(
+                status_code=200,
+                data={
+                    "data": {
+                        "results": [
+                            {
+                                "id": "m1",
+                                "text": {"html": "<p>See the plan</p>"},
+                                "attachments": [
+                                    {
+                                        "id": 5002,
+                                        "name": "weekplan.pdf",
+                                        "file": {
+                                            "name": "weekplan.pdf",
+                                            "url": "https://files.example.test/weekplan.pdf",
+                                        },
+                                    }
+                                ],
+                            }
+                        ],
+                        "totalSize": 1,
+                    }
+                },
+            )
+        )
+        messages = await client.search_messages([1], ["INST1"], has_attachments=True)
+        assert messages[0].has_attachments is True
+        assert messages[0].attachments[0].url == "https://files.example.test/weekplan.pdf"
+
+    @pytest.mark.asyncio
     async def test_empty_results_stops(self, client):
         """Empty results stops pagination immediately."""
         client._request_with_version_retry = AsyncMock(

--- a/tests/utils/test_dates.py
+++ b/tests/utils/test_dates.py
@@ -1,0 +1,36 @@
+"""Tests for aula.utils.dates."""
+
+import datetime
+
+from aula.utils.dates import parse_api_datetime
+
+
+def test_parses_offset_timestamp():
+    parsed = parse_api_datetime("2026-03-01T10:00:00+01:00")
+    assert parsed == datetime.datetime(
+        2026, 3, 1, 10, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=1))
+    )
+
+
+def test_parses_utc_z_suffix():
+    """Aula writes UTC as a trailing Z."""
+    parsed = parse_api_datetime("2026-03-01T09:00:00Z")
+    assert parsed == datetime.datetime(2026, 3, 1, 9, 0, tzinfo=datetime.UTC)
+
+
+def test_parses_naive_timestamp():
+    parsed = parse_api_datetime("2026-03-01T09:00:00")
+    assert parsed == datetime.datetime(2026, 3, 1, 9, 0)
+
+
+def test_unreadable_value_is_none():
+    assert parse_api_datetime("not-a-date") is None
+
+
+def test_missing_value_is_none():
+    assert parse_api_datetime(None) is None
+    assert parse_api_datetime("") is None
+
+
+def test_non_string_value_is_none():
+    assert parse_api_datetime(12345) is None

--- a/tests/utils/test_download.py
+++ b/tests/utils/test_download.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from aula.models.attachment import Attachment
 from aula.models.message import Message
 from aula.utils.download import (
     _parse_date_str,
@@ -179,7 +180,13 @@ class TestDownloadPostImages:
             title="School Trip",
             timestamp_str="2026-03-01T10:00:00+01:00",
             attachments=[
-                {"media": {"file": {"url": "http://example.com/photo.jpg", "name": "photo.jpg"}}},
+                Attachment.from_dict(
+                    {
+                        "media": {
+                            "file": {"url": "http://example.com/photo.jpg", "name": "photo.jpg"}
+                        }
+                    }
+                ),
             ],
         )
         client.get_posts.side_effect = [[post], []]
@@ -188,6 +195,33 @@ class TestDownloadPostImages:
 
         assert downloaded == 1
         assert (tmp_path / "posts" / "20260301 School Trip" / "photo.jpg").exists()
+
+    @pytest.mark.asyncio
+    async def test_skips_non_media_attachments(self, tmp_path):
+        """A post can attach a PDF or a link, neither of which is an image."""
+        client = _make_mock_client()
+        post = self._make_post(
+            id=11,
+            title="Week Plan",
+            timestamp_str="2026-03-01T10:00:00+01:00",
+            attachments=[
+                Attachment.from_dict(
+                    {
+                        "name": "plan.pdf",
+                        "file": {"url": "http://example.com/plan.pdf", "name": "plan.pdf"},
+                    }
+                ),
+                Attachment.from_dict(
+                    {"link": {"name": "Slides", "url": "http://example.com/slides"}}
+                ),
+            ],
+        )
+        client.get_posts.side_effect = [[post], []]
+
+        downloaded, skipped = await download_post_images(client, [100], tmp_path, date(2026, 1, 1))
+
+        assert downloaded == 0
+        client.download_file.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_stops_paginating_at_cutoff(self, tmp_path):


### PR DESCRIPTION
Posts carried their attachments through as the raw API dicts, so anything that wanted a file's name or URL had to know that a media attachment keeps its file one level deeper than a plain file does, and that Aula sends an explicit null for the variants an attachment is not.

Implements nickknissen/astridOS#124.

## What changed

`Attachment` carries the envelope (id, name, status, created, creator) and one of the four content variants Aula sends: a file, a gallery media item, a cloud drive link, or a secure document. The file behind a media item is hoisted onto `.file`, so `attachment.name` and `attachment.url` answer "what is this called" and "where are the bytes" without the caller asking which variant it got.

* `Post.attachments` is now `list[Attachment]`.
* `Message` gained `attachments` and `has_attachments`, plus a `from_dict()` of its own like every other model. Both `messaging.getMessagesForThread` and `search.findMessage` parse through it, so a search filtered on `hasAttachments=True` now actually returns them.
* `utils/download.py` reads both post and message attachments through the new type. The post path stays restricted to media, so `download-images` keeps downloading only images.
* New `utils/dates.py` with `parse_api_datetime`, replacing the private parser inside `Post.from_dict` and shared with the attachment models.

Shapes were verified against `AulaFileResultDto` in the decompiled mobile app and against a captured `posts` response.

## Note for JSON consumers

`aula --output json posts` now shows attachments in the library's own field names. `name`, `status` and `file.url` keep the names they had, so the documented path to a weekly plan PDF is unchanged, but keys the model does not carry are no longer echoed.

## Tests

30 new tests covering a full attachment, one with fields missing, explicit nulls, each of the four variants, and attachments arriving from a message search. Full suite: 749 passed. `ruff` and `ty` clean.

## Follow up

`get_all_messages_for_thread` still returns `list[dict]` while its sibling returns `list[Message]` from the same endpoint. Migrating it needs `send_datetime` on `Message`, so it is left for a separate change.