### PR TITLE
fix: match the MitID identity-picker redirect on path, not full URL

### DIFF
--- a/src/aula/auth/mitid_client.py
+++ b/src/aula/auth/mitid_client.py
@@ -39,6 +39,23 @@ from .exceptions import (
 _LOGGER = logging.getLogger(__name__)
 
 
+def _page_message(soup: BeautifulSoup) -> str:
+    """Best-effort user-visible text from a NemLog-in page, for error reporting."""
+    for selector in (
+        ".validation-summary-errors",
+        ".alert",
+        ".error-message",
+        "[role=alert]",
+        "h1",
+    ):
+        element = soup.select_one(selector)
+        if element:
+            text = element.get_text(" ", strip=True)
+            if text:
+                return text
+    return ""
+
+
 def _extract_form_data(soup: BeautifulSoup) -> tuple[str, dict[str, str]]:
     """Extract the action URL and hidden input values from the first form on a page.
 
@@ -429,17 +446,28 @@ class MitIDAuthClient:
                 f"{MITID_BASE_URL}/login/mitid", data=params, follow_redirects=True
             )
 
-            if str(response.url).endswith("/loginoption"):
+            # Match on the path: the redirect can carry a query string.
+            if response.url.path.rstrip("/").endswith("/loginoption"):
                 _LOGGER.info("Multiple identities detected, handling identity selection")
-                soup = await self._handle_login_option_page(response)
-            else:
-                soup = BeautifulSoup(response.text, features="html.parser")
+                response = await self._handle_login_option_page(response)
+
+            _LOGGER.debug(
+                "MitID completion landed on %s (HTTP %s)", response.url, response.status_code
+            )
+            soup = BeautifulSoup(response.text, features="html.parser")
 
             relay_state_input = soup.find("input", {"name": "RelayState"})
             saml_response_input = soup.find("input", {"name": "SAMLResponse"})
 
             if not isinstance(relay_state_input, Tag) or not isinstance(saml_response_input, Tag):
-                raise SAMLError("Could not find SAML data in MitID completion response")
+                _LOGGER.debug("Page without SAML form:\n%s", response.text)
+                message = _page_message(soup)
+                detail = f' Page says: "{message}".' if message else ""
+                raise SAMLError(
+                    "Could not find SAML data in MitID completion response "
+                    f"(landed on {response.url.path}, HTTP {response.status_code})."
+                    f"{detail} Re-run with -vvv to log the page that was returned."
+                )
 
             return {
                 "relay_state": str(relay_state_input.get("value", "")),
@@ -449,7 +477,7 @@ class MitIDAuthClient:
         except httpx.HTTPError as e:
             raise NetworkError(f"Network error during MitID completion: {e}") from e
 
-    async def _handle_login_option_page(self, response: httpx.Response) -> BeautifulSoup:
+    async def _handle_login_option_page(self, response: httpx.Response) -> httpx.Response:
         """Handle the identity selection page when a user has multiple identities."""
         soup = BeautifulSoup(response.text, features="html.parser")
         links = soup.select("a.list-link")
@@ -502,8 +530,7 @@ class MitIDAuthClient:
 
         login_option_url = str(response.url)
         # Submitting the choice redirects on to the page carrying the SAML form.
-        result = await self._client.post(login_option_url, data=form_data, follow_redirects=True)
-        return BeautifulSoup(result.text, features="html.parser")
+        return await self._client.post(login_option_url, data=form_data, follow_redirects=True)
 
     async def _step5_saml_broker_flow(self, saml_data: dict[str, str]) -> dict[str, str]:
         """Step 5: Complete SAML broker authentication."""

--- a/tests/auth/test_mitid_client_loginoption.py
+++ b/tests/auth/test_mitid_client_loginoption.py
@@ -116,6 +116,27 @@ class TestStep4CompleteMitIDFlow:
         assert "GET /login/saml" in backend.paths
 
     @pytest.mark.asyncio
+    async def test_login_option_redirect_with_query_string_is_recognised(self):
+        """The identity picker redirect can carry a query string, so match on the path."""
+
+        class QueryStringRedirect(FakeNemLogIn):
+            async def __call__(self, request: httpx.Request) -> httpx.Response:
+                if request.url.path == "/login/mitid":
+                    self.paths.append(f"{request.method} {request.url.path}")
+                    return httpx.Response(
+                        302, headers={"Location": f"{MITID}/loginoption?returnUrl=%2Flogin"}
+                    )
+                return await super().__call__(request)
+
+        backend = QueryStringRedirect(identities=2)
+        client = _client(backend)
+
+        result = await client._step4_complete_mitid_flow("verify-token", "auth-code")
+
+        assert result == {"relay_state": "relay-123", "saml_response": "saml-abc"}
+        assert "POST /loginoption" in backend.paths
+
+    @pytest.mark.asyncio
     async def test_reports_missing_saml_data(self):
         class NoSaml(FakeNemLogIn):
             async def __call__(self, request: httpx.Request) -> httpx.Response:
@@ -125,3 +146,27 @@ class TestStep4CompleteMitIDFlow:
 
         with pytest.raises(SAMLError, match="Could not find SAML data"):
             await client._step4_complete_mitid_flow("verify-token", "auth-code")
+
+    @pytest.mark.asyncio
+    async def test_missing_saml_error_names_the_page_it_landed_on(self):
+        """A bare "no SAML data" message is undiagnosable from a user's traceback."""
+
+        class ErrorPage(FakeNemLogIn):
+            async def __call__(self, request: httpx.Request) -> httpx.Response:
+                if request.url.path == "/login/mitid":
+                    return httpx.Response(302, headers={"Location": f"{MITID}/login/error"})
+                return httpx.Response(
+                    200,
+                    text=(
+                        '<html><body><div class="validation-summary-errors">'
+                        "Session timed out</div></body></html>"
+                    ),
+                )
+
+        client = _client(ErrorPage())
+
+        with pytest.raises(SAMLError) as excinfo:
+            await client._step4_complete_mitid_flow("verify-token", "auth-code")
+
+        assert "/login/error" in str(excinfo.value)
+        assert "Session timed out" in str(excinfo.value)


### PR DESCRIPTION
A redirect to `/loginoption` carrying a query string was not recognised, so identity selection was skipped and SAML was parsed from the picker page.

The resulting error named neither the page nor the reason, so it now reports the landing URL, status and any message on the page, and logs the page body at debug level.