### PR TITLE
fix: tell the user when STIL's security check blocks the login

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,16 +119,18 @@ The kodeviser code rotates, so `--token-code` is only useful for a single run. T
 
 ### If Login Is Blocked
 
-Some logins are stopped before MitID is reached, with an error naming `security-check.stil.dk`:
+If you are outside Denmark, the login can be stopped before MitID is reached:
 
 ```
-MitID authentication failed: STIL's security check blocked the login at
-https://security-check.stil.dk/NDBD/validate?config=UNILOGIN&data=...
+Login blocked: you are most likely not connecting from a Danish IP address.
+
+STIL diverted the redirect to MitID into a security check on
+security-check.stil.dk. ...
 ```
 
-This is a bot check STIL put in front of the UniLogin broker. Getting past it needs a browser that runs JavaScript, so this client cannot complete a login while the check is active.
+STIL puts a bot check in front of the UniLogin broker. Getting past it needs a browser that runs JavaScript, so this client cannot complete a login while the check is active.
 
-The check does not fire for everyone. Reports so far point at the connecting IP address: logins from a Danish IP address are let through, while logins from other countries are challenged. If you are outside Denmark, a connection with a Danish IP address is the only known workaround. See [issue #43](https://github.com/nickknissen/aula/issues/43).
+The check does not fire for everyone. Every report so far comes from outside Denmark: logins from a Danish IP address are let through, while logins from other countries are challenged. If you are outside Denmark, a connection with a Danish IP address is the only known workaround. See [issue #43](https://github.com/nickknissen/aula/issues/43).
 
 ### Token Security
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,19 @@ aula --auth-method token --token-code 123456 messages
 
 The kodeviser code rotates, so `--token-code` is only useful for a single run. The password is never written to the config file; supply it per-run or via the environment.
 
+### If Login Is Blocked
+
+Some logins are stopped before MitID is reached, with an error naming `security-check.stil.dk`:
+
+```
+MitID authentication failed: STIL's security check blocked the login at
+https://security-check.stil.dk/NDBD/validate?config=UNILOGIN&data=...
+```
+
+This is a bot check STIL put in front of the UniLogin broker. Getting past it needs a browser that runs JavaScript, so this client cannot complete a login while the check is active.
+
+The check does not fire for everyone. Reports so far point at the connecting IP address: logins from a Danish IP address are let through, while logins from other countries are challenged. If you are outside Denmark, a connection with a Danish IP address is the only known workaround. See [issue #43](https://github.com/nickknissen/aula/issues/43).
+
 ### Token Security
 
 Tokens provide full access to your Aula account — treat them like passwords and never commit token files to version control.

--- a/docs/aula-authentication.md
+++ b/docs/aula-authentication.md
@@ -242,6 +242,42 @@ Session cookies stale:
   create_client() gets 403 -> force_login=True -> full MitID re-auth
 ```
 
+## STIL Security Check
+
+STIL fronts the UniLogin broker with an F5 BIG-IP bot defence. It does not fire
+for every client. The evidence collected in
+[issue #43](https://github.com/nickknissen/aula/issues/43) points at the
+connecting IP address: a Danish IP is let straight through to the broker, while
+IPs in other countries are diverted into the check.
+
+In a browser the check is invisible. It is a four hop detour that ends back at
+the URL it started from:
+
+```
+broker.unilogin.dk/auth/realms/broker/protocol/saml-stil   302 -> /NDBD/init?data=...
+broker.unilogin.dk/NDBD/init                               302 -> security-check.stil.dk/NDBD/validate?config=UNILOGIN&data=...
+security-check.stil.dk/NDBD/validate                       200    challenge page (window["bobcmn"], TSPD_101 cookies)
+security-check.stil.dk/TSPD/<hex>?type=10                  200    ~294 KB of obfuscated JavaScript
+security-check.stil.dk/NDBD/validate                       302 -> broker.unilogin.dk/NDBD/issue?data=...
+broker.unilogin.dk/NDBD/issue                              302 -> idp.unilogin.dk/NDBD/issue?data=...
+idp.unilogin.dk/NDBD/issue                                 302 -> broker.unilogin.dk/.../saml-stil (the original URL)
+broker.unilogin.dk/auth/realms/broker/protocol/saml-stil   200    IdP picker
+```
+
+The second request to `/NDBD/validate` is identical to the first and answers 302
+instead of 200. The JavaScript ran in between and set the cookie. The `data=`
+token then carries the pass across the three hosts.
+
+There is no meta refresh and no auto submitting form on the challenge page, so a
+plain HTTP client has nothing to follow. `_step2_follow_redirect_to_mitid`
+detects the host and raises `SecurityCheckError` rather than reporting an
+unrecognised page. Completing the check would need a JavaScript engine, which
+this library does not carry.
+
+Browser fingerprint is not the trigger. The reporter in issue #43 was challenged
+while sending a full Chrome header set over HTTP/2, and passed only by running
+the script.
+
 ## Widget Authentication
 
 Third-party widget APIs (Min Uddannelse, EasyIQ, Meebook, Systematic, Cicero) use a separate token mechanism:

--- a/src/aula/auth/exceptions.py
+++ b/src/aula/auth/exceptions.py
@@ -41,3 +41,9 @@ class PasswordInvalidError(MitIDError):
     """Exception raised when the MitID password is rejected."""
 
     pass
+
+
+class SecurityCheckError(SAMLError):
+    """Exception raised when STIL's bot-defence gate blocks the login."""
+
+    pass

--- a/src/aula/auth/mitid_client.py
+++ b/src/aula/auth/mitid_client.py
@@ -40,6 +40,23 @@ from .exceptions import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# The full challenge URL carries a long opaque ``data=`` blob, so keep it out of
+# the message and leave it to the redirect chain debug log.
+_SECURITY_CHECK_MESSAGE = (
+    "Login blocked: you are most likely not connecting from a Danish IP address.\n"
+    "\n"
+    "STIL diverted the redirect to MitID into a security check on\n"
+    "security-check.stil.dk. Every report of this so far comes from outside\n"
+    "Denmark, and logins from a Danish IP address are let through. Getting past\n"
+    "the check needs a browser that runs JavaScript, so this client cannot\n"
+    "complete the login while the check is active.\n"
+    "\n"
+    "If you are outside Denmark, connecting through a Danish IP address is the\n"
+    "only known way around it.\n"
+    "\n"
+    "Details: https://github.com/nickknissen/aula/issues/43"
+)
+
 
 def _page_message(soup: BeautifulSoup) -> str:
     """Best-effort user-visible text from a NemLog-in page, for error reporting."""
@@ -275,15 +292,7 @@ class MitIDAuthClient:
 
                 if response.is_success:
                     if STIL_SECURITY_CHECK_HOST in str(response.url):
-                        raise SecurityCheckError(
-                            "STIL's security check blocked the login at "
-                            f"{response.url}. Getting past it needs a browser that runs "
-                            "JavaScript, so this client cannot complete the login while the "
-                            "check is active. It is not triggered for everyone: reports so far "
-                            "point at the connecting IP address, and logins from a Danish IP "
-                            "address are let through. See "
-                            "https://github.com/nickknissen/aula/issues/43."
-                        )
+                        raise SecurityCheckError(_SECURITY_CHECK_MESSAGE)
 
                     soup = BeautifulSoup(response.text, "html.parser")
 

--- a/src/aula/auth/mitid_client.py
+++ b/src/aula/auth/mitid_client.py
@@ -25,6 +25,7 @@ from ..const import (
     OAUTH_CLIENT_ID,
     OAUTH_SCOPE,
     OAUTH_TOKEN_PATH,
+    STIL_SECURITY_CHECK_HOST,
     USER_AGENT,
 )
 from .browser_client import BrowserClient
@@ -34,6 +35,7 @@ from .exceptions import (
     NetworkError,
     OAuthError,
     SAMLError,
+    SecurityCheckError,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -272,6 +274,17 @@ class MitIDAuthClient:
                 )
 
                 if response.is_success:
+                    if STIL_SECURITY_CHECK_HOST in str(response.url):
+                        raise SecurityCheckError(
+                            "STIL's security check blocked the login at "
+                            f"{response.url}. Getting past it needs a browser that runs "
+                            "JavaScript, so this client cannot complete the login while the "
+                            "check is active. It is not triggered for everyone: reports so far "
+                            "point at the connecting IP address, and logins from a Danish IP "
+                            "address are let through. See "
+                            "https://github.com/nickknissen/aula/issues/43."
+                        )
+
                     soup = BeautifulSoup(response.text, "html.parser")
 
                     if BROKER_URL in str(response.url):

--- a/src/aula/auth_flow.py
+++ b/src/aula/auth_flow.py
@@ -18,7 +18,7 @@ import httpx
 import qrcode
 
 from .api_client import AulaApiClient
-from .auth.exceptions import MitIDAuthError, OAuthError
+from .auth.exceptions import MitIDAuthError, OAuthError, SecurityCheckError
 from .auth.mitid_client import MitIDAuthClient
 from .const import AUTH_BASE_URL, CSRF_TOKEN_COOKIE, OAUTH_CLIENT_ID, OAUTH_TOKEN_PATH
 from .http import AulaAuthenticationError, HttpClient
@@ -232,6 +232,10 @@ async def authenticate(
                 if token_storage:
                     await token_storage.save(result_data)
                 _LOGGER.info("Authentication successful! Tokens saved.")
+            except SecurityCheckError as e:
+                # Already says what happened and what to do, so no prefix.
+                _LOGGER.error("Authentication failed: %s", e)
+                raise RuntimeError(str(e)) from e
             except MitIDAuthError as e:
                 _LOGGER.error("Authentication failed: %s", e)
                 raise RuntimeError(f"MitID authentication failed: {e}") from e

--- a/src/aula/const.py
+++ b/src/aula/const.py
@@ -58,3 +58,8 @@ CSRF_TOKEN_HEADER = "csrfp-token"
 # MitID / SAML broker
 BROKER_URL = "https://broker.unilogin.dk"
 MITID_BASE_URL = "https://nemlog-in.mitid.dk"
+
+# STIL puts an F5 bot-defence gate in front of the UniLogin broker for some
+# clients. It answers on this host, and passing it needs a JavaScript engine,
+# so the flow can only be reported, not completed. See nickknissen/aula#43.
+STIL_SECURITY_CHECK_HOST = "security-check.stil.dk"

--- a/tests/auth/test_mitid_client_security_check.py
+++ b/tests/auth/test_mitid_client_security_check.py
@@ -63,8 +63,9 @@ class TestStep2SecurityCheck:
             await client._step2_follow_redirect_to_mitid(SAML_STIL)
 
         message = str(excinfo.value)
+        # The likely cause has to be the first thing read, not a closing detail.
+        assert "not connecting from a Danish IP address" in message.splitlines()[0]
         assert "security-check.stil.dk" in message
-        assert "Danish IP" in message
 
     @pytest.mark.asyncio
     async def test_gate_error_is_still_a_saml_error(self):

--- a/tests/auth/test_mitid_client_security_check.py
+++ b/tests/auth/test_mitid_client_security_check.py
@@ -1,0 +1,84 @@
+"""Tests for aula.auth.mitid_client step 2 — STIL's bot-defence gate.
+
+Some clients get an F5 bot check spliced into the redirect chain in front of
+the UniLogin broker. Passing it needs a JavaScript engine, so all this client
+can do is say so clearly instead of reporting an unrecognised page.
+"""
+
+import httpx
+import pytest
+
+from aula.auth.exceptions import SAMLError, SecurityCheckError
+from aula.auth.mitid_client import MitIDAuthClient
+
+BROKER = "https://broker.unilogin.dk"
+SECURITY_CHECK = "https://security-check.stil.dk"
+MITID = "https://nemlog-in.mitid.dk"
+SAML_STIL = f"{BROKER}/auth/realms/broker/protocol/saml-stil?SAMLRequest=fZLd"
+
+# What the gate serves: an F5 challenge page whose cookie is set by script.
+CHALLENGE_PAGE = """
+<html><head><script>window["bobcmn"] = "10111110101010200";</script></head>
+<body><noscript>Please enable JavaScript to view the page content.</noscript></body></html>
+"""
+
+MITID_PAGE = """
+<html><body><input type="hidden" name="__RequestVerificationToken" value="tok-1"/></body></html>
+"""
+
+
+async def _challenged(request: httpx.Request) -> httpx.Response:
+    """The chain observed in issue #43: the broker bounces through NDBD to the gate."""
+    if request.url.path.startswith("/auth/realms/broker"):
+        return httpx.Response(302, headers={"Location": f"{BROKER}/NDBD/init?data=e3N0"})
+    if request.url.host == "broker.unilogin.dk" and request.url.path == "/NDBD/init":
+        return httpx.Response(
+            302, headers={"Location": f"{SECURITY_CHECK}/NDBD/validate?config=UNILOGIN&data=YLi0"}
+        )
+    if request.url.host == "security-check.stil.dk":
+        return httpx.Response(200, text=CHALLENGE_PAGE)
+    return httpx.Response(404)
+
+
+async def _unchallenged(request: httpx.Request) -> httpx.Response:
+    if request.url.path.startswith("/auth/realms/broker"):
+        return httpx.Response(302, headers={"Location": f"{MITID}/login/mitid"})
+    return httpx.Response(200, text=MITID_PAGE)
+
+
+def _client(handler) -> MitIDAuthClient:
+    transport = httpx.MockTransport(handler)
+    return MitIDAuthClient(
+        mitid_username="tester",
+        httpx_client=httpx.AsyncClient(transport=transport, follow_redirects=False),
+    )
+
+
+class TestStep2SecurityCheck:
+    @pytest.mark.asyncio
+    async def test_gate_is_reported_as_a_security_check(self):
+        client = _client(_challenged)
+
+        with pytest.raises(SecurityCheckError) as excinfo:
+            await client._step2_follow_redirect_to_mitid(SAML_STIL)
+
+        message = str(excinfo.value)
+        assert "security-check.stil.dk" in message
+        assert "Danish IP" in message
+
+    @pytest.mark.asyncio
+    async def test_gate_error_is_still_a_saml_error(self):
+        """Callers that already handle SAMLError keep working."""
+        client = _client(_challenged)
+
+        with pytest.raises(SAMLError):
+            await client._step2_follow_redirect_to_mitid(SAML_STIL)
+
+    @pytest.mark.asyncio
+    async def test_unchallenged_chain_still_reaches_mitid(self):
+        client = _client(_unchallenged)
+
+        result = await client._step2_follow_redirect_to_mitid(SAML_STIL)
+
+        assert result["verification_token"] == "tok-1"
+        assert result["mitid_url"] == f"{MITID}/login/mitid"


### PR DESCRIPTION
Logins from outside Denmark get diverted into a bot check on `security-check.stil.dk` and fail with `Unexpected page reached`, which tells the user nothing.

Step 2 now detects the host and raises `SecurityCheckError` with the likely cause on the first line:

```
Login blocked: you are most likely not connecting from a Danish IP address.

STIL diverted the redirect to MitID into a security check on
security-check.stil.dk. Every report of this so far comes from outside
Denmark, and logins from a Danish IP address are let through. Getting past
the check needs a browser that runs JavaScript, so this client cannot
complete the login while the check is active.
```

`SecurityCheckError` subclasses `SAMLError`, so existing handling is unchanged.

Also documents the check in the README and records the full redirect chain in `docs/aula-authentication.md`, taken from the HAR on the issue.

This does not make blocked logins work. Getting past the check needs a JavaScript engine. A Danish IP address is the only known workaround.

Refs #43