### PR TITLE
fix: animate the two MitID QR halves in place

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Pick with `--auth-method` (or the `AULA_AUTH_METHOD` env var):
 
 | Method | Flag | What happens |
 |---|---|---|
-| MitID app | `--auth-method app` (default) | QR codes are printed in the terminal for you to scan. If your app asks for a code instead of a scan, that code is printed too. |
+| MitID app | `--auth-method app` (default) | A QR code is printed in the terminal for you to scan. It comes in two halves that take turns in the same spot, so hold the app on it until both have been read. If your app asks for a code instead of a scan, that code is printed too. |
 | MitID kodeviser | `--auth-method token` | You're asked for the 6 digits on your kodeviser, then your MitID password. |
 
 MitID chip and audio code readers (kodeoplæser) are not supported. If your account offers one, it's listed in a warning at `-v` and the login falls back to whatever else you have.

--- a/src/aula/auth/browser_client.py
+++ b/src/aula/auth/browser_client.py
@@ -19,6 +19,9 @@ from .srp import CustomSRP
 
 _LOGGER = logging.getLogger(__name__)
 
+_POLL_SECONDS = 0.5
+_QR_POLL_SECONDS = 1.0
+
 _BLOCK_SIZE = 16
 
 # Authenticator mapping tables
@@ -91,12 +94,14 @@ class BrowserClient:
         authentication_session_id: str,
         http_client: httpx.AsyncClient,
         on_qr_codes: Callable[[qrcode.QRCode, qrcode.QRCode], None] | None = None,
+        on_qr_done: Callable[[], None] | None = None,
         on_otp_code: Callable[[str], None] | None = None,
     ):
         self._client = http_client
         self._client_hash = client_hash
         self._authentication_session_id = authentication_session_id
         self._on_qr_codes = on_qr_codes
+        self._on_qr_done = on_qr_done
         self._on_otp_code = on_otp_code
 
         # Authenticator state (populated after identify step)
@@ -118,6 +123,7 @@ class BrowserClient:
         # Storage for QR codes (can be accessed externally)
         self.qr1: qrcode.QRCode | None = None
         self.qr2: qrcode.QRCode | None = None
+        self._qr_state: tuple[str, int] | None = None
         self.otp_code: str | None = None
         self.status_message: str | None = None
 
@@ -281,12 +287,13 @@ class BrowserClient:
                 raise MitIDError("Login request was not accepted")
 
             if data["status"] == "OK" and data["confirmation"] is True:
+                self._end_qr_phase()
                 return data["payload"]["response"], data["payload"]["responseSignature"]
 
             status = data["status"]
 
             if status == "timeout":
-                await asyncio.sleep(0.5)
+                await asyncio.sleep(_POLL_SECONDS)
                 continue
 
             if status == "channel_validation_otp":
@@ -298,29 +305,41 @@ class BrowserClient:
                     _LOGGER.debug("OTP channel validation requested")
                     if self._on_otp_code:
                         self._on_otp_code(otp_code)
-                await asyncio.sleep(0.5)
+                await asyncio.sleep(_POLL_SECONDS)
                 continue
 
             if status == "channel_validation_tqr":
                 self._handle_qr_code_poll(data)
-                await asyncio.sleep(1)
+                await asyncio.sleep(_QR_POLL_SECONDS)
                 continue
 
             if status == "channel_verified":
+                self._end_qr_phase()
                 self.status_message = (
                     "The OTP/QR code has been verified, now waiting user to approve login"
                 )
                 _LOGGER.debug("Channel verified, awaiting user approval")
-                await asyncio.sleep(0.5)
+                await asyncio.sleep(_POLL_SECONDS)
                 continue
 
             raise MitIDError(f"Unexpected poll status: {status}")
 
+    def _end_qr_phase(self) -> None:
+        """Retire the codes once the app has read them; they no longer scan."""
+        if self._qr_state is None:
+            return
+        self._qr_state = None
+        self.qr1 = None
+        self.qr2 = None
+        if self._on_qr_done:
+            self._on_qr_done()
+
     def _handle_qr_code_poll(self, data: dict) -> None:
         """Generate and display QR codes from a TQR poll response."""
         channel_binding = data["channelBindingValue"]
-        half = len(channel_binding) // 2
         update_count = data["updateCount"]
+        self._qr_state = (channel_binding, update_count)
+        half = len(channel_binding) // 2
 
         self.qr1 = qrcode.QRCode(border=1)
         self.qr1.add_data(

--- a/src/aula/auth/browser_client.py
+++ b/src/aula/auth/browser_client.py
@@ -338,6 +338,9 @@ class BrowserClient:
         """Generate and display QR codes from a TQR poll response."""
         channel_binding = data["channelBindingValue"]
         update_count = data["updateCount"]
+        # The poll repeats every second; MitID rotates the codes far less often.
+        if (channel_binding, update_count) == self._qr_state:
+            return
         self._qr_state = (channel_binding, update_count)
         half = len(channel_binding) // 2
 

--- a/src/aula/auth/mitid_client.py
+++ b/src/aula/auth/mitid_client.py
@@ -120,6 +120,7 @@ class MitIDAuthClient:
         mitid_username: str,
         timeout: int = 30,
         on_qr_codes: Callable[[qrcode.QRCode, qrcode.QRCode], None] | None = None,
+        on_qr_done: Callable[[], None] | None = None,
         httpx_client: httpx.AsyncClient | None = None,
         on_identity_selected: Callable[[list[str]], Awaitable[int]] | None = None,
         auth_method: str = "app",
@@ -132,6 +133,7 @@ class MitIDAuthClient:
         self._mitid_username = mitid_username
         self._timeout = timeout
         self._on_qr_codes = on_qr_codes
+        self._on_qr_done = on_qr_done
         self._on_identity_selected = on_identity_selected
         self._auth_method = auth_method
         self._on_token_digits = on_token_digits
@@ -379,8 +381,9 @@ class MitIDAuthClient:
             client_hash,
             authentication_session_id,
             self._client,
-            self._on_qr_codes,
-            self._on_otp_code,
+            on_qr_codes=self._on_qr_codes,
+            on_qr_done=self._on_qr_done,
+            on_otp_code=self._on_otp_code,
         )
 
         await self._mitid_client.initialize()

--- a/src/aula/auth_flow.py
+++ b/src/aula/auth_flow.py
@@ -143,6 +143,7 @@ async def authenticate(
     on_token_digits: Callable[[], Awaitable[str]] | None = None,
     on_password: Callable[[], Awaitable[str]] | None = None,
     on_otp_code: Callable[[str], None] | None = None,
+    on_qr_done: Callable[[], None] | None = None,
 ) -> dict[str, Any]:
     """Authenticate via MitID (or cached tokens) and return credential data.
 
@@ -158,6 +159,8 @@ async def authenticate(
             provided, cached tokens are loaded/saved automatically.  When
             *None*, a fresh MitID login is always performed.
         on_qr_codes: Callback for displaying QR codes during MitID flow.
+        on_qr_done: Callback invoked once the app has read the QR codes, so
+            consumers can take them off the screen.
         on_otp_code: Callback for displaying the OTP code the user types into
             the MitID app instead of scanning the QR codes.
         on_login_required: Callback invoked when fresh login is needed.
@@ -176,6 +179,7 @@ async def authenticate(
     async with MitIDAuthClient(
         mitid_username=mitid_username,
         on_qr_codes=on_qr_codes,
+        on_qr_done=on_qr_done,
         httpx_client=httpx_client,
         on_identity_selected=on_identity_selected,
         auth_method=auth_method,
@@ -258,6 +262,7 @@ async def authenticate_and_create_client(
     on_token_digits: Callable[[], Awaitable[str]] | None = None,
     on_password: Callable[[], Awaitable[str]] | None = None,
     on_otp_code: Callable[[str], None] | None = None,
+    on_qr_done: Callable[[], None] | None = None,
 ) -> AulaApiClient:
     """Authenticate via MitID (or cached tokens) and return a ready-to-use client.
 
@@ -268,6 +273,7 @@ async def authenticate_and_create_client(
         mitid_username: MitID username for authentication.
         token_storage: Storage backend for caching tokens.
         on_qr_codes: Callback for displaying QR codes during MitID flow.
+        on_qr_done: Callback invoked once the app has read the QR codes.
         on_login_required: Callback invoked when fresh login is needed.
         httpx_client: Optional ``httpx.AsyncClient`` for the auth flow.
         on_identity_selected: Callback for choosing between multiple identities.
@@ -283,6 +289,7 @@ async def authenticate_and_create_client(
         on_token_digits=on_token_digits,
         on_password=on_password,
         on_otp_code=on_otp_code,
+        on_qr_done=on_qr_done,
     )
     try:
         return await create_client(token_data)
@@ -303,6 +310,7 @@ async def authenticate_and_create_client(
             on_token_digits=on_token_digits,
             on_password=on_password,
             on_otp_code=on_otp_code,
+            on_qr_done=on_qr_done,
         )
         return await create_client(fresh_token_data)
 

--- a/src/aula/cli.py
+++ b/src/aula/cli.py
@@ -202,8 +202,11 @@ def cli(
 _QR_FRAME_SECONDS = 1.0
 _QR_FIRST_FRAME_SECONDS = 2.0
 _QR_HEADER = (
-    "Scan with your MitID app. The code comes in two halves that take turns\n"
-    "below, so the app stays quiet until it has read both."
+    "Scan with your MitID app: open it, start the QR scanner, and hold the\n"
+    "camera steady on the code below. The code comes in two halves that take\n"
+    "turns in the same spot, so keep the phone still until the app has read\n"
+    "both. It stays quiet until then, and asks you to approve the login once\n"
+    "it has them."
 )
 
 
@@ -310,7 +313,8 @@ class _TerminalQRDisplay:
             *self._frames[part].splitlines(),
         ]
         # Every frame occupies the same rows, so the codes never shift as they swap.
-        height = max(len(frame.splitlines()) for frame in self._frames) + 4
+        tallest = max(len(frame.splitlines()) for frame in self._frames)
+        height = tallest + len(_QR_HEADER.splitlines()) + 2
         lines += [""] * (height - len(lines))
 
         if self._drawn_lines:

--- a/src/aula/cli.py
+++ b/src/aula/cli.py
@@ -199,11 +199,17 @@ def cli(
         ctx.obj["MITID_USERNAME"] = username
 
 
-_QR_FRAME_SECONDS = 2.0
+_QR_FRAME_SECONDS = 1.0
+_QR_FIRST_FRAME_SECONDS = 2.0
 _QR_HEADER = (
     "Scan with your MitID app. The code comes in two halves that take turns\n"
     "below, so the app stays quiet until it has read both."
 )
+
+
+def _frame_seconds(index: int) -> float:
+    """How long one half stays up; the first gets longer, before any movement."""
+    return _QR_FIRST_FRAME_SECONDS if index == 0 else _QR_FRAME_SECONDS
 
 
 @functools.cache
@@ -292,8 +298,8 @@ class _TerminalQRDisplay:
         sys.stdout.write("\x1b[?25l")
         while True:
             self._draw(index)
+            await asyncio.sleep(_frame_seconds(index))
             index += 1
-            await asyncio.sleep(_QR_FRAME_SECONDS)
 
     def _draw(self, index: int) -> None:
         part = index % len(self._frames)

--- a/src/aula/cli.py
+++ b/src/aula/cli.py
@@ -3,6 +3,7 @@ import asyncio
 import datetime
 import enum
 import functools
+import io
 import logging
 import os
 import sys
@@ -198,26 +199,129 @@ def cli(
         ctx.obj["MITID_USERNAME"] = username
 
 
-def _print_qr_codes_in_terminal(qr1: qrcode.QRCode, qr2: qrcode.QRCode) -> None:
-    """Print QR codes as ASCII art in the terminal."""
-    click.echo("=" * 60)
-    click.echo("SCAN THESE QR CODES WITH YOUR MITID APP")
-    click.echo("=" * 60)
-    click.echo("QR CODE 1 (Scan this first):")
-    try:
-        qr1.print_ascii(invert=True)
-    except UnicodeEncodeError:
-        qr1.print_tty()
+_QR_FRAME_SECONDS = 2.0
+_QR_HEADER = (
+    "Scan with your MitID app. The code comes in two halves that take turns\n"
+    "below, so the app stays quiet until it has read both."
+)
 
-    click.echo("QR CODE 2 (Scan this second):")
-    try:
-        qr2.print_ascii(invert=True)
-    except UnicodeEncodeError:
-        qr2.print_tty()
 
-    click.echo("=" * 60)
-    click.echo("Waiting for you to scan the QR codes...")
-    click.echo("=" * 60)
+@functools.cache
+def _terminal_draws_blocks() -> bool:
+    """Whether stdout can encode the block characters QR art is drawn with."""
+    encoding = getattr(sys.stdout, "encoding", None) or "utf-8"
+    try:
+        "\u2588".encode(encoding)
+    except UnicodeEncodeError, LookupError:
+        return False
+    return True
+
+
+def _stdout_is_tty() -> bool:
+    try:
+        return sys.stdout.isatty()
+    except ValueError:
+        return False
+
+
+def _render_qr(qr: qrcode.QRCode) -> str:
+    """Render one QR code as a block of terminal text."""
+    if _terminal_draws_blocks():
+        out = io.StringIO()
+        qr.print_ascii(out=out, invert=True)
+        return out.getvalue().rstrip("\n")
+    return "\n".join("".join("##" if cell else "  " for cell in row) for row in qr.get_matrix())
+
+
+class _TerminalQRDisplay:
+    """Alternate the two QR halves in one spot, the way mitid.dk animates them.
+
+    The MitID app has to read both halves, so they take turns in place instead
+    of scrolling past each other.
+    """
+
+    def __init__(self) -> None:
+        self._frames: list[str] = []
+        self._generation = 0
+        self._printed_generation = 0
+        self._task: asyncio.Task[None] | None = None
+        self._drawn_lines = 0
+
+    def show(self, qr1: qrcode.QRCode, qr2: qrcode.QRCode) -> None:
+        """Take a fresh pair of codes and keep them on screen."""
+        frames = [_render_qr(qr1), _render_qr(qr2)]
+        if frames != self._frames:
+            self._frames = frames
+            self._generation += 1
+
+        if not _stdout_is_tty():
+            self._print_once()
+            return
+
+        if self._task is None:
+            self._task = asyncio.create_task(self._animate())
+
+    def done(self) -> None:
+        """The app has read the codes; retire them and say what happens next."""
+        if self._task is None and not self._drawn_lines:
+            return
+        self.stop()
+        click.echo("Codes read. Approve the login in your MitID app.")
+
+    def stop(self) -> None:
+        """Take the codes off the screen, whatever ended the login."""
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+        self._erase()
+        sys.stdout.write("\x1b[?25h")
+        sys.stdout.flush()
+
+    def _print_once(self) -> None:
+        """Without a terminal to redraw, print each new pair a single time."""
+        if self._printed_generation == self._generation:
+            return
+        self._printed_generation = self._generation
+        click.echo(_QR_HEADER)
+        for part, frame in enumerate(self._frames, 1):
+            click.echo(f"\nQR code {part} of 2:\n{frame}")
+
+    async def _animate(self) -> None:
+        """Swap the halves in place until the login moves on."""
+        index = 0
+        sys.stdout.write("\x1b[?25l")
+        while True:
+            self._draw(index)
+            index += 1
+            await asyncio.sleep(_QR_FRAME_SECONDS)
+
+    def _draw(self, index: int) -> None:
+        part = index % len(self._frames)
+        lines = [
+            *_QR_HEADER.splitlines(),
+            "",
+            f"QR code {part + 1} of 2:",
+            *self._frames[part].splitlines(),
+        ]
+        # Every frame occupies the same rows, so the codes never shift as they swap.
+        height = max(len(frame.splitlines()) for frame in self._frames) + 4
+        lines += [""] * (height - len(lines))
+
+        if self._drawn_lines:
+            sys.stdout.write(f"\x1b[{self._drawn_lines}A")
+        for line in lines:
+            sys.stdout.write(f"\x1b[2K{line}\n")
+        sys.stdout.flush()
+        self._drawn_lines = len(lines)
+
+    def _erase(self) -> None:
+        if not self._drawn_lines:
+            return
+        sys.stdout.write(f"\x1b[{self._drawn_lines}A")
+        sys.stdout.write("\x1b[2K\n" * self._drawn_lines)
+        sys.stdout.write(f"\x1b[{self._drawn_lines}A")
+        sys.stdout.flush()
+        self._drawn_lines = 0
 
 
 def _resolve_week(week: str | None) -> str:
@@ -282,17 +386,22 @@ async def _get_client(ctx: click.Context) -> AulaApiClient:
     """Create an authenticated AulaApiClient."""
     username = get_mitid_username(ctx)
     token_storage = FileTokenStorage(DEFAULT_TOKEN_FILE)
-    return await authenticate_and_create_client(
-        username,
-        token_storage,
-        on_qr_codes=_print_qr_codes_in_terminal,
-        on_otp_code=_print_otp_code,
-        on_login_required=_on_login_required,
-        on_identity_selected=_select_identity,
-        auth_method=ctx.obj.get("AUTH_METHOD", "app"),
-        on_token_digits=_token_digits_provider(ctx),
-        on_password=_password_provider(ctx),
-    )
+    qr_display = _TerminalQRDisplay()
+    try:
+        return await authenticate_and_create_client(
+            username,
+            token_storage,
+            on_qr_codes=qr_display.show,
+            on_qr_done=qr_display.done,
+            on_otp_code=_print_otp_code,
+            on_login_required=_on_login_required,
+            on_identity_selected=_select_identity,
+            auth_method=ctx.obj.get("AUTH_METHOD", "app"),
+            on_token_digits=_token_digits_provider(ctx),
+            on_password=_password_provider(ctx),
+        )
+    finally:
+        qr_display.stop()
 
 
 async def _fetch_groups(client: AulaApiClient) -> list[Group] | None:

--- a/tests/auth/test_browser_client.py
+++ b/tests/auth/test_browser_client.py
@@ -7,6 +7,7 @@ import logging
 import httpx
 import pytest
 
+from aula.auth import browser_client as browser_client_module
 from aula.auth.browser_client import _COMBINATION_ID_TO_NAME, BrowserClient
 from aula.auth.exceptions import MitIDError, PasswordInvalidError, TokenInvalidError
 
@@ -392,3 +393,83 @@ class TestFrontEndProcessingTime:
         await client.authenticate_with_token_and_password("123456", "hunter2")
 
         assert server.bodies["password-prove"]["frontEndProcessingTime"] > 0
+
+
+POLL_URL = "https://www.mitid.dk/mitid-code-app-auth/v1/authenticator-sessions/web/poll"
+
+
+def _tqr(binding: str = "0123456789abcdef", update_count: int = 1) -> dict:
+    return {
+        "status": "channel_validation_tqr",
+        "channelBindingValue": binding,
+        "updateCount": update_count,
+    }
+
+
+def _verified() -> dict:
+    return {"status": "channel_verified"}
+
+
+def _otp(code: str = "A1B2") -> dict:
+    return {"status": "channel_validation_otp", "channelBindingValue": code}
+
+
+def _confirmed() -> dict:
+    return {
+        "status": "OK",
+        "confirmation": True,
+        "payload": {"response": "cmVzcG9uc2U=", "responseSignature": "c2lnbmF0dXJl"},
+    }
+
+
+class FakePoll:
+    """MitID's app poll endpoint, answering a scripted sequence of statuses."""
+
+    def __init__(self, responses: list[dict]):
+        self._responses = list(responses)
+
+    async def __call__(self, request: httpx.Request) -> httpx.Response:
+        payload = self._responses.pop(0) if len(self._responses) > 1 else self._responses[0]
+        return httpx.Response(200, json=payload)
+
+
+def _polling_client(responses: list[dict], **callbacks) -> BrowserClient:
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(FakePoll(responses)))
+    return BrowserClient("client-hash", SESSION_ID, http_client, **callbacks)
+
+
+@pytest.fixture
+def _no_poll_waiting(monkeypatch):
+    monkeypatch.setattr(browser_client_module, "_POLL_SECONDS", 0)
+    monkeypatch.setattr(browser_client_module, "_QR_POLL_SECONDS", 0)
+
+
+class TestAppQrCodes:
+    """The codes come down when the app has read them, not when polling goes quiet."""
+
+    @pytest.mark.asyncio
+    async def test_signals_the_codes_are_spent_once_the_app_has_read_them(self, _no_poll_waiting):
+        """The codes stop working the moment the app has them, so they have to come down."""
+        events = []
+        client = _polling_client(
+            [_tqr(), _verified(), _confirmed()],
+            on_qr_codes=lambda qr1, qr2: events.append("shown"),
+            on_qr_done=lambda: events.append("done"),
+        )
+
+        await client._poll_for_app_confirmation(POLL_URL, "ticket")
+
+        assert events == ["shown", "done"]
+
+    @pytest.mark.asyncio
+    async def test_stays_quiet_when_no_codes_were_shown(self, _no_poll_waiting):
+        """App users who type the code instead of scanning never see a QR code."""
+        events = []
+        client = _polling_client(
+            [_otp(), _verified(), _confirmed()],
+            on_qr_done=lambda: events.append("done"),
+        )
+
+        await client._poll_for_app_confirmation(POLL_URL, "ticket")
+
+        assert events == []

--- a/tests/auth/test_browser_client.py
+++ b/tests/auth/test_browser_client.py
@@ -445,7 +445,33 @@ def _no_poll_waiting(monkeypatch):
 
 
 class TestAppQrCodes:
-    """The codes come down when the app has read them, not when polling goes quiet."""
+    """MitID repeats the codes on every poll, but they only change now and then."""
+
+    @pytest.mark.asyncio
+    async def test_notifies_once_while_the_codes_are_unchanged(self, _no_poll_waiting):
+        """Repeating the same codes makes consumers redraw art the user is already scanning."""
+        shown = []
+        client = _polling_client(
+            [_tqr(), _tqr(), _tqr(), _confirmed()],
+            on_qr_codes=lambda qr1, qr2: shown.append((qr1, qr2)),
+        )
+
+        await client._poll_for_app_confirmation(POLL_URL, "ticket")
+
+        assert len(shown) == 1
+
+    @pytest.mark.asyncio
+    async def test_notifies_again_when_the_codes_rotate(self, _no_poll_waiting):
+        """Only the current codes can be scanned, so a rotation has to reach the user."""
+        shown = []
+        client = _polling_client(
+            [_tqr(update_count=1), _tqr(update_count=1), _tqr(update_count=2), _confirmed()],
+            on_qr_codes=lambda qr1, qr2: shown.append((qr1, qr2)),
+        )
+
+        await client._poll_for_app_confirmation(POLL_URL, "ticket")
+
+        assert len(shown) == 2
 
     @pytest.mark.asyncio
     async def test_signals_the_codes_are_spent_once_the_app_has_read_them(self, _no_poll_waiting):

--- a/tests/test_auth_flow.py
+++ b/tests/test_auth_flow.py
@@ -473,10 +473,11 @@ class TestAuthenticateAndCreateClient:
         """Callbacks are forwarded to authenticate."""
         token_storage.load.return_value = None
         qr_cb = MagicMock()
+        qr_done_cb = MagicMock()
         login_cb = MagicMock()
 
         with (
-            patch("aula.auth_flow.MitIDAuthClient", return_value=mock_auth_client),
+            patch("aula.auth_flow.MitIDAuthClient", return_value=mock_auth_client) as MockMitID,
             patch("aula.auth_flow.create_client", new_callable=AsyncMock) as mock_create,
         ):
             mock_create.return_value = MagicMock()
@@ -484,10 +485,13 @@ class TestAuthenticateAndCreateClient:
                 "user",
                 token_storage,
                 on_qr_codes=qr_cb,
+                on_qr_done=qr_done_cb,
                 on_login_required=login_cb,
             )
 
         login_cb.assert_called_once()
+        assert MockMitID.call_args.kwargs["on_qr_codes"] is qr_cb
+        assert MockMitID.call_args.kwargs["on_qr_done"] is qr_done_cb
 
     @pytest.mark.asyncio
     async def test_httpx_client_passed_to_mitid_auth(self, token_storage, mock_auth_client):
@@ -504,6 +508,7 @@ class TestAuthenticateAndCreateClient:
         MockMitID.assert_called_once_with(
             mitid_username="user",
             on_qr_codes=None,
+            on_qr_done=None,
             httpx_client=fake_httpx,
             on_identity_selected=None,
             auth_method="app",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,12 @@
 """Tests for aula.cli helpers."""
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock
 
 import click
 import pytest
+import qrcode
 from click.testing import CliRunner
 
 from aula import cli
@@ -19,8 +21,10 @@ from aula.cli import (
     _mu_task_rows,
     _password_provider,
     _print_otp_code,
+    _render_qr,
     _require_any_widget,
     _require_widget,
+    _terminal_draws_blocks,
     _token_digits_provider,
     _with_child,
     easyiq_homework,
@@ -360,6 +364,78 @@ class TestLogout:
         CliRunner().invoke(logout, [], obj={"OUTPUT_FORMAT": "text"})
 
         assert config_file.exists()
+
+
+def _qr(data: str) -> qrcode.QRCode:
+    qr = qrcode.QRCode(border=1)
+    qr.add_data(data)
+    qr.make()
+    return qr
+
+
+class TestQrDisplay:
+    """The two codes are halves of one value, so both have to reach the app."""
+
+    @pytest.fixture(autouse=True)
+    def _fast_frames(self, monkeypatch):
+        monkeypatch.setattr(cli, "_QR_FRAME_SECONDS", 0.01)
+        _terminal_draws_blocks.cache_clear()
+
+    @pytest.mark.asyncio
+    async def test_alternates_both_halves_until_the_codes_are_read(self, monkeypatch, capsys):
+        """MitID sends a pair once, but a half the app never sees blocks the login."""
+        monkeypatch.setattr(cli, "_stdout_is_tty", lambda: True)
+        display = cli._TerminalQRDisplay()
+
+        display.show(_qr("part-one"), _qr("part-two"))
+        await asyncio.sleep(0.05)
+        display.done()
+
+        out = capsys.readouterr().out
+        assert "QR code 1 of 2" in out
+        assert "QR code 2 of 2" in out
+        assert "Approve the login in your MitID app" in out
+
+    @pytest.mark.asyncio
+    async def test_redraws_over_itself_instead_of_scrolling(self, monkeypatch, capsys):
+        """Codes that scroll away leave the user scanning a stale one."""
+        monkeypatch.setattr(cli, "_stdout_is_tty", lambda: True)
+        display = cli._TerminalQRDisplay()
+
+        display.show(_qr("part-one"), _qr("part-two"))
+        await asyncio.sleep(0.03)
+        display.done()
+
+        assert "\x1b[" in capsys.readouterr().out
+
+    def test_prints_each_pair_once_without_a_terminal(self, monkeypatch, capsys):
+        """MitID repeats the codes every poll; a log file should not repeat them too."""
+        monkeypatch.setattr(cli, "_stdout_is_tty", lambda: False)
+        display = cli._TerminalQRDisplay()
+
+        display.show(_qr("part-one"), _qr("part-two"))
+        display.show(_qr("part-one"), _qr("part-two"))
+
+        assert capsys.readouterr().out.count("QR code 1 of 2") == 1
+
+    def test_prints_a_new_pair_when_the_codes_rotate(self, monkeypatch, capsys):
+        """MitID rotates the value, and only the current pair can be scanned."""
+        monkeypatch.setattr(cli, "_stdout_is_tty", lambda: False)
+        display = cli._TerminalQRDisplay()
+
+        display.show(_qr("part-one"), _qr("part-two"))
+        display.show(_qr("part-one-v2"), _qr("part-two-v2"))
+
+        assert capsys.readouterr().out.count("QR code 1 of 2") == 2
+
+    def test_falls_back_to_ascii_when_blocks_cannot_be_encoded(self, monkeypatch):
+        """A console that cannot print blocks would otherwise show a broken code."""
+        monkeypatch.setattr(cli, "_terminal_draws_blocks", lambda: False)
+
+        rendered = _render_qr(_qr("part-one"))
+
+        assert rendered.isascii()
+        assert "#" in rendered
 
 
 class TestOtpDisplay:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -417,6 +417,20 @@ class TestQrDisplay:
 
         assert "\x1b[" in capsys.readouterr().out
 
+    @pytest.mark.asyncio
+    async def test_keeps_every_frame_the_same_height(self, monkeypatch, capsys):
+        """A block that changes height as the halves swap leaves art behind on screen."""
+        monkeypatch.setattr(cli, "_stdout_is_tty", lambda: True)
+        display = cli._TerminalQRDisplay()
+
+        display.show(_qr("part-one"), _qr("part-two"))
+        await asyncio.sleep(0.05)
+        display.done()
+
+        blocks = capsys.readouterr().out.split("QR code 1 of 2:")
+        assert len(blocks) > 2
+        assert len({block.count("\n") for block in blocks[1:-1]}) == 1
+
     def test_prints_each_pair_once_without_a_terminal(self, monkeypatch, capsys):
         """MitID repeats the codes every poll; a log file should not repeat them too."""
         monkeypatch.setattr(cli, "_stdout_is_tty", lambda: False)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -373,12 +373,21 @@ def _qr(data: str) -> qrcode.QRCode:
     return qr
 
 
+class TestQrFrameSchedule:
+    def test_lingers_on_the_first_half_before_the_swapping_starts(self):
+        """The first code needs time to be scanned before it starts moving."""
+        assert cli._frame_seconds(0) == 2.0
+        assert cli._frame_seconds(1) == 1.0
+        assert cli._frame_seconds(2) == 1.0
+
+
 class TestQrDisplay:
     """The two codes are halves of one value, so both have to reach the app."""
 
     @pytest.fixture(autouse=True)
     def _fast_frames(self, monkeypatch):
         monkeypatch.setattr(cli, "_QR_FRAME_SECONDS", 0.01)
+        monkeypatch.setattr(cli, "_QR_FIRST_FRAME_SECONDS", 0.02)
         _terminal_draws_blocks.cache_clear()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
The two QR codes printed during `aula login` are halves of one channel binding, not alternatives. They were printed stacked, labelled "scan this first", and reprinted on every poll. Reported in #83: the first half looked broken because the app stays quiet until it has read both, and older pairs scrolled up the terminal.

Now they are drawn the way mitid.dk does it: one half at a time in the same spot, erased once the app has read them. The first half holds for two seconds so it can be found, then they swap every second.

Knowing when to stop takes a signal from the client, not a guess: MitID's long poll answers `timeout` for seconds at a stretch while the codes are still live, so a gap in polling means nothing. `BrowserClient` now reports `on_qr_done` at `channel_verified`, where the codes stop scanning.

Without a terminal to redraw, each pair prints once instead of on every poll. Includes #86, merged in: the client no longer resends codes that have not changed.