### PR TITLE
feat: add a --version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ The username can also be set via the `AULA_MITID_USERNAME` environment variable 
 | `--password` | MitID password for `--auth-method token` (or `AULA_MITID_PASSWORD` env var) |
 | `--token-code` | 6 digits from your MitID kodeviser (or `AULA_MITID_TOKEN_CODE` env var) |
 | `-v` / `-vv` / `-vvv` | Increase verbosity (warning / info / debug) |
+| `--version` | Print the installed version and the Python it runs on |
 
 ### JSON output
 

--- a/src/aula/cli.py
+++ b/src/aula/cli.py
@@ -6,6 +6,7 @@ import functools
 import io
 import logging
 import os
+import platform
 import sys
 from collections import defaultdict
 from collections.abc import Awaitable, Callable, Sequence
@@ -14,6 +15,7 @@ from zoneinfo import ZoneInfo
 import click
 import qrcode
 
+from . import __version__
 from .api_client import AulaApiClient
 from .auth_flow import authenticate_and_create_client
 from .config import CONFIG_FILE, DEFAULT_TOKEN_FILE, load_config, save_config
@@ -118,6 +120,13 @@ def get_mitid_username(ctx: click.Context) -> str:
 
 # Define the main group
 @click.group()
+@click.version_option(
+    __version__,
+    "--version",
+    prog_name="aula",
+    # Bug reports arrive as tracebacks, and both numbers are needed to read one.
+    message=f"%(prog)s %(version)s (Python {platform.python_version()})",
+)
 @click.option(
     "--username",
     help="MitID username (can also be set via AULA_MITID_USERNAME env var or config file)",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import platform
 from unittest.mock import AsyncMock, MagicMock
 
 import click
@@ -9,7 +10,7 @@ import pytest
 import qrcode
 from click.testing import CliRunner
 
-from aula import cli
+from aula import __version__, cli
 from aula.cli import (
     _WIDGET_ID_CACHE,
     CONTACTS_PAGE_SIZE,
@@ -459,6 +460,16 @@ class TestQrDisplay:
 
         assert rendered.isascii()
         assert "#" in rendered
+
+
+class TestVersionFlag:
+    def test_reports_the_version_and_the_python_it_runs_on(self):
+        """Bug reports are read from a traceback, and both numbers are needed."""
+        result = CliRunner().invoke(cli.cli, ["--version"])
+
+        assert result.exit_code == 0
+        assert __version__ in result.output
+        assert platform.python_version() in result.output
 
 
 class TestOtpDisplay:


### PR DESCRIPTION
`aula --version` prints the installed version and the Python it runs on:

```
aula 1.9.1 (Python 3.14.2)
```

Bug reports arrive as tracebacks with no version in them. Pinning the version in #83 meant comparing line numbers against every tag.

`-v` is taken by `--verbose`, so there is no short flag.