### PR TITLE
fix: notify QR consumers only when the codes change

### DIFF
--- a/src/aula/auth/browser_client.py
+++ b/src/aula/auth/browser_client.py
@@ -338,6 +338,9 @@ class BrowserClient:
         """Generate and display QR codes from a TQR poll response."""
         channel_binding = data["channelBindingValue"]
         update_count = data["updateCount"]
+        # The poll repeats every second; MitID rotates the codes far less often.
+        if (channel_binding, update_count) == self._qr_state:
+            return
         self._qr_state = (channel_binding, update_count)
         half = len(channel_binding) // 2
 

--- a/tests/auth/test_browser_client.py
+++ b/tests/auth/test_browser_client.py
@@ -445,7 +445,33 @@ def _no_poll_waiting(monkeypatch):
 
 
 class TestAppQrCodes:
-    """The codes come down when the app has read them, not when polling goes quiet."""
+    """MitID repeats the codes on every poll, but they only change now and then."""
+
+    @pytest.mark.asyncio
+    async def test_notifies_once_while_the_codes_are_unchanged(self, _no_poll_waiting):
+        """Repeating the same codes makes consumers redraw art the user is already scanning."""
+        shown = []
+        client = _polling_client(
+            [_tqr(), _tqr(), _tqr(), _confirmed()],
+            on_qr_codes=lambda qr1, qr2: shown.append((qr1, qr2)),
+        )
+
+        await client._poll_for_app_confirmation(POLL_URL, "ticket")
+
+        assert len(shown) == 1
+
+    @pytest.mark.asyncio
+    async def test_notifies_again_when_the_codes_rotate(self, _no_poll_waiting):
+        """Only the current codes can be scanned, so a rotation has to reach the user."""
+        shown = []
+        client = _polling_client(
+            [_tqr(update_count=1), _tqr(update_count=1), _tqr(update_count=2), _confirmed()],
+            on_qr_codes=lambda qr1, qr2: shown.append((qr1, qr2)),
+        )
+
+        await client._poll_for_app_confirmation(POLL_URL, "ticket")
+
+        assert len(shown) == 2
 
     @pytest.mark.asyncio
     async def test_signals_the_codes_are_spent_once_the_app_has_read_them(self, _no_poll_waiting):


### PR DESCRIPTION
Stacked on #84, which it needs. Retarget to `main` once that merges.

`BrowserClient` notified on every poll. MitID resends the same codes once a second, so consumers were told to redraw art the user was already scanning. It now notifies on a new channel binding only, the way the OTP code already did.

Tests cover one notification while the codes are unchanged, and another when they rotate.