### PR TITLE
feat: add a logout command

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ The username can also be set via the `AULA_MITID_USERNAME` environment variable 
 | Command | Description |
 |---|---|
 | `aula login` | Verify credentials |
+| `aula logout` | Forget the cached session and log in through MitID again |
 | `aula profile` | Show profile and children |
 | `aula profile-details` | Extended profile info (email, phone, address) |
 | `aula overview` | Daily overview for all children |

--- a/src/aula/cli.py
+++ b/src/aula/cli.py
@@ -539,6 +539,20 @@ def _easyiq_child_user_ids(profile_context: dict) -> list[str]:
 @cli.command()
 @click.pass_context
 @async_cmd
+async def logout(ctx):
+    """Forget the cached session, so the next command logs in through MitID again"""
+    removed = await FileTokenStorage(DEFAULT_TOKEN_FILE).clear()
+    if output_json(ctx, {"status": "ok", "removed": removed, "path": str(DEFAULT_TOKEN_FILE)}):
+        return
+    if removed:
+        click.echo(f"Logged out. Removed {DEFAULT_TOKEN_FILE}")
+    else:
+        click.echo(f"No stored session at {DEFAULT_TOKEN_FILE}")
+
+
+@cli.command()
+@click.pass_context
+@async_cmd
 async def login(ctx):
     """Authenticate and initialize session"""
     async with await _get_client(ctx) as client:

--- a/src/aula/token_storage.py
+++ b/src/aula/token_storage.py
@@ -74,3 +74,16 @@ class FileTokenStorage(TokenStorage):
             os.unlink(tmp_path)
             raise
         _LOGGER.debug("Tokens saved to %s", self._path)
+
+    async def clear(self) -> bool:
+        """Remove the stored tokens.
+
+        Returns:
+            True when a token file was removed, False when there was none.
+        """
+        try:
+            self._path.unlink()
+        except FileNotFoundError:
+            return False
+        _LOGGER.debug("Tokens removed from %s", self._path)
+        return True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ import click
 import pytest
 from click.testing import CliRunner
 
+from aula import cli
 from aula.cli import (
     _WIDGET_ID_CACHE,
     CONTACTS_PAGE_SIZE,
@@ -24,6 +25,7 @@ from aula.cli import (
     _with_child,
     easyiq_homework,
     easyiq_ugeplan,
+    logout,
     print_mu_task_tables,
     report_sick,
 )
@@ -323,6 +325,41 @@ class TestCredentialProviders:
 
         assert await provide() == "typed"
         assert prompt.call_args.kwargs["hide_input"] is True
+
+
+class TestLogout:
+    """Testing a login flow means being able to throw the cached session away."""
+
+    def test_removes_the_stored_session(self, tmp_path, monkeypatch):
+        """A cached session skips MitID entirely, so it has to go."""
+        token_file = tmp_path / "tokens.json"
+        token_file.write_text('{"tokens": {"access_token": "abc123"}}')
+        monkeypatch.setattr(cli, "DEFAULT_TOKEN_FILE", token_file)
+
+        result = CliRunner().invoke(logout, [], obj={"OUTPUT_FORMAT": "text"})
+
+        assert result.exit_code == 0
+        assert not token_file.exists()
+
+    def test_says_so_when_there_was_no_session(self, tmp_path, monkeypatch):
+        """Silence would read as a session removed, and send the user hunting."""
+        monkeypatch.setattr(cli, "DEFAULT_TOKEN_FILE", tmp_path / "tokens.json")
+
+        result = CliRunner().invoke(logout, [], obj={"OUTPUT_FORMAT": "text"})
+
+        assert result.exit_code == 0
+        assert "No stored session" in result.output
+
+    def test_leaves_the_saved_username_alone(self, tmp_path, monkeypatch):
+        """Retyping the MitID username on every test login is the thing being avoided."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text('{"mitid_username": "tester"}')
+        monkeypatch.setattr(cli, "DEFAULT_TOKEN_FILE", tmp_path / "tokens.json")
+        monkeypatch.setattr(cli, "CONFIG_FILE", config_file)
+
+        CliRunner().invoke(logout, [], obj={"OUTPUT_FORMAT": "text"})
+
+        assert config_file.exists()
 
 
 class TestOtpDisplay:

--- a/tests/test_token_storage.py
+++ b/tests/test_token_storage.py
@@ -60,3 +60,23 @@ async def test_save_atomic_write(token_file):
     # File should contain valid JSON after save
     data = json.loads(token_file.read_text())
     assert data["tokens"]["key"] == "val"
+
+
+@pytest.mark.asyncio
+async def test_clear_removes_stored_tokens(token_file):
+    """Logging out has to leave nothing behind for the next login to reuse."""
+    storage = FileTokenStorage(token_file)
+    await storage.save({"tokens": {"access_token": "abc123"}})
+
+    removed = await storage.clear()
+
+    assert removed is True
+    assert not token_file.exists()
+
+
+@pytest.mark.asyncio
+async def test_clear_reports_when_there_was_nothing_stored(token_file):
+    """Without this, logging out twice claims to have removed a session that was not there."""
+    removed = await FileTokenStorage(token_file).clear()
+
+    assert removed is False


### PR DESCRIPTION
`aula logout` removes the cached session, so the next command goes through MitID again:

```
$ aula logout
Logged out. Removed /home/you/.config/aula/tokens.json
$ aula logout
No stored session at /home/you/.config/aula/tokens.json
```

Testing a login flow meant deleting `~/.config/aula/tokens.json` by hand. The saved MitID username in `config.json` is left alone, so the next login does not ask for it again.

`FileTokenStorage.clear()` does the removal and reports whether anything was there. Built test-first.