### PR TITLE
docs: describe the QR login in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,26 @@ MitID chip and audio code readers (kodeoplæser) are not supported. If your acco
 
 ### First Login
 
-On first run you'll be prompted to approve the login. Tokens are saved to the storage file and reused on subsequent runs — no authenticator interaction needed until they expire.
+On first run you have to approve the login in your MitID app. With the default `app` method the terminal shows the QR code to scan:
+
+```
+Scan with your MitID app: open it, start the QR scanner, and hold the
+camera steady on the code below. The code comes in two halves that take
+turns in the same spot, so keep the phone still until the app has read
+both. It stays quiet until then, and asks you to approve the login once
+it has them.
+
+QR code 1 of 2:
+█▀▀▀▀▀▀▀███▀▀▀▀███▀▀▀█▀█▀▀▀▀█▀█▀▀▀▀▀▀▀█
+█ █▀▀▀█ █ ██ ▀▄ ███▄ ▀▀▀█▀▄█▀▀█ █▀▀▀█ █
+...
+```
+
+The two codes are halves of one value, not two things to choose between. The first half holds for two seconds, then the halves swap every second in the same spot. Nothing happens in the app until it has read both, so keep the phone still rather than moving it away after the first one. Once the app has them, the codes disappear and the app asks you to approve the login.
+
+If your app asks for a code to type instead of a scan, that code is printed instead of the QR code.
+
+Tokens are saved to the storage file and reused on subsequent runs — no authenticator interaction needed until they expire. `aula logout` removes them and forces a fresh MitID login; the saved MitID username is kept.
 
 For the kodeviser method you can skip the prompts:
 

--- a/src/aula/agent_skill.py
+++ b/src/aula/agent_skill.py
@@ -175,6 +175,14 @@ aula --output json login
 ```
 Returns: `{status: "ok", api_url: "..."}`
 
+#### `logout` — Forget the cached session
+```bash
+aula --output json logout
+```
+Returns: `{status: "ok", removed: true, path: "..."}`
+The next command then needs an interactive MitID login, so leave this to
+the user unless they ask for it.
+
 ## Tips
 
 - `--week` accepts a bare number (e.g. `10`) or full ISO format (`2026-W10`).

--- a/src/aula/agent_skill.py
+++ b/src/aula/agent_skill.py
@@ -40,6 +40,7 @@ aula --username "<username>" <command>
 | `--username TEXT` | MitID username (or `AULA_MITID_USERNAME` env var). |
 | `--auth-method [app\\|token]` | MitID method: `app` (QR/push) or `token`. |
 | `-v` / `-vv` / `-vvv` | Increase log verbosity. |
+| `--version` | Print the installed version and the Python it runs on. |
 
 ## Commands
 


### PR DESCRIPTION
The README said only that you would be prompted to approve the login. It now shows what the terminal actually prints and what to do with it: the two codes are halves of one value, the first holds for two seconds and then they swap every second, and the app stays quiet until it has read both.

Also mentions the typed-code fallback, and `aula logout` as the way back to a fresh login.

The agent reference in `agent_skill.py` gains `logout` (it listed `login` but not the command that undoes it) and the `--version` flag from #85, which merged without reaching that file.

Follows #83, where the first half was reported as not scannable.