### PR TITLE
fix: read calendar locations from event resources

### DIFF
--- a/src/aula/api_client.py
+++ b/src/aula/api_client.py
@@ -969,7 +969,7 @@ class AulaApiClient:
                 substitute = self._find_participant_by_role(lesson, "substituteTeacher")
 
                 has_substitute = lesson.get("lessonStatus", "").lower() == "substitute"
-                location = get_in(lesson, "primaryResource.name")
+                location = get_in(event, "primaryResource.name")
 
                 events.append(
                     CalendarEvent(

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1172,13 +1172,13 @@ class TestGetCalendarEvents:
                 "startDateTime": "2026-03-01T08:00:00+01:00",
                 "endDateTime": "2026-03-01T09:00:00+01:00",
                 "belongsToProfiles": [100],
+                "primaryResource": {"name": "Room 101"},
                 "lesson": {
                     "participants": [
                         {"participantRole": "primaryTeacher", "teacherName": "Mrs. Jensen"},
                         {"participantRole": "substituteTeacher", "teacherName": "Mr. Hansen"},
                     ],
                     "lessonStatus": "substitute",
-                    "primaryResource": {"name": "Room 101"},
                 },
             }
         ]


### PR DESCRIPTION
## Summary

- read calendar locations from the root-level primaryResource returned by Aula
- align the calendar regression fixture with the observed API response shape
- preserve existing behavior for events without a resource

## Test plan

- uv run pytest tests/test_api_client.py -q
- uv run ruff format --check .
- uv run ruff check .
- uv run pytest (771 passed, 4 skipped)