### PR TITLE
fix: make token refresh durable and concurrency-safe

### DIFF
--- a/src/aula/api_client.py
+++ b/src/aula/api_client.py
@@ -1,9 +1,11 @@
+import asyncio
 import inspect
 import json
 import logging
 import time
 import warnings
 from collections.abc import Awaitable, Callable
+from contextvars import ContextVar
 from datetime import date, datetime
 from types import TracebackType
 from typing import Any, Self
@@ -123,7 +125,11 @@ class AulaApiClient:
         self._access_token = access_token
         self._csrf_token = csrf_token
         self._on_token_refresh = on_token_refresh
-        self._auth_retry_in_progress = False
+        self._auth_refresh_lock = asyncio.Lock()
+        self._auth_generation = 0
+        self._auth_refresh_context: ContextVar[bool] = ContextVar(
+            "aula_auth_refresh_context", default=False
+        )
         self.api_url = f"{API_URL}{API_VERSION}"
         self.widgets: AulaWidgetsClient = AulaWidgetsClient(self)
 
@@ -215,11 +221,12 @@ class AulaApiClient:
         refresh via the ``on_token_refresh`` callback (if provided), re-inits
         the session, and retries the request.
         """
+        observed_generation = self._auth_generation
         response = await self._do_request(method, url, headers=headers, params=params, json=json)
 
         # Check for auth failures that can be recovered via token refresh.
         # Only attempt once to avoid infinite loops.
-        if not self._auth_retry_in_progress and self._on_token_refresh:
+        if not self._auth_refresh_context.get() and self._on_token_refresh:
             needs_retry = response.status_code == 401
             if not needs_retry:
                 sub_code = self._extract_sub_code(response)
@@ -233,19 +240,10 @@ class AulaApiClient:
                     "Auth failure (HTTP %d), attempting token refresh and retry",
                     response.status_code,
                 )
-                self._auth_retry_in_progress = True
-                try:
-                    new_token = await self._on_token_refresh()
-                    if new_token:
-                        self._access_token = new_token
-                        await self.init()
-                        response = await self._do_request(
-                            method, url, headers=headers, params=params, json=json
-                        )
-                except Exception as e:
-                    _LOGGER.warning("Token refresh failed: %s", e)
-                finally:
-                    self._auth_retry_in_progress = False
+                if await self._refresh_authentication(observed_generation):
+                    response = await self._do_request(
+                        method, url, headers=headers, params=params, json=json
+                    )
 
         # After retry (or no retry), check for sub-code errors on the final response.
         sub_code = self._extract_sub_code(response)
@@ -254,6 +252,47 @@ class AulaApiClient:
             self._raise_for_sub_code(sub_code, api_method)
 
         return response
+
+    async def _refresh_authentication(
+        self,
+        observed_generation: int | None = None,
+        *,
+        force: bool = False,
+    ) -> bool:
+        """Refresh and reinitialize authentication once for concurrent callers.
+
+        A caller that waited for another request's successful refresh can
+        replay immediately when its observed generation is stale. ``force``
+        is reserved for providers that report token expiry in a successful
+        HTTP response rather than through Aula's authentication status.
+        """
+        if self._on_token_refresh is None:
+            return False
+
+        async with self._auth_refresh_lock:
+            if (
+                not force
+                and observed_generation is not None
+                and observed_generation != self._auth_generation
+            ):
+                return True
+
+            previous_access_token = self._access_token
+            refresh_context_token = self._auth_refresh_context.set(True)
+            try:
+                new_token = await self._on_token_refresh()
+                if not new_token:
+                    return False
+                self._access_token = new_token
+                await self.init()
+                self._auth_generation += 1
+                return True
+            except Exception as e:
+                self._access_token = previous_access_token
+                _LOGGER.warning("Token refresh failed: %s", e)
+                return False
+            finally:
+                self._auth_refresh_context.reset(refresh_context_token)
 
     async def _do_request(
         self,

--- a/src/aula/auth_flow.py
+++ b/src/aula/auth_flow.py
@@ -70,6 +70,8 @@ async def _refresh_token_via_oidc(refresh_token: str) -> dict[str, Any] | None:
 async def create_client(
     token_data: dict[str, Any],
     http_client: HttpClient | None = None,
+    *,
+    token_storage: TokenStorage | None = None,
 ) -> AulaApiClient:
     """Create an AulaApiClient from stored credentials.
 
@@ -85,6 +87,9 @@ async def create_client(
         http_client: Optional HTTP client implementing the ``HttpClient``
             protocol. When *None*, an ``HttpxHttpClient`` is created with the
             session cookies from ``token_data``.
+        token_storage: Optional storage backend. When supplied, automatic
+            refresh merges rotated credentials into ``token_data`` and saves
+            the complete credential blob before the request is retried.
 
     Returns:
         A ready-to-use ``AulaApiClient`` (``init()`` has been called).
@@ -108,16 +113,29 @@ async def create_client(
         http_client = HttpxHttpClient(cookies=cookies)
 
     # Build a token refresh callback if a refresh_token is available.
-    refresh_token = tokens.get("refresh_token")
+    current_tokens = dict(tokens)
+    refresh_token = current_tokens.get("refresh_token")
     on_token_refresh = None
     if refresh_token:
 
         async def _do_refresh() -> str | None:
-            result = await _refresh_token_via_oidc(refresh_token)
-            if result and result.get("access_token"):
-                _LOGGER.info("Automatic token refresh successful")
-                return result["access_token"]
-            return None
+            current_refresh_token = current_tokens.get("refresh_token")
+            if not current_refresh_token:
+                return None
+
+            result = await _refresh_token_via_oidc(current_refresh_token)
+            if not result or not result.get("access_token"):
+                return None
+
+            current_tokens.update(result)
+            token_data["tokens"] = current_tokens
+            token_data["timestamp"] = time.time()
+            token_data["created_at"] = time.strftime("%Y-%m-%d %H:%M:%S")
+            if token_storage:
+                await token_storage.save(token_data)
+
+            _LOGGER.info("Automatic token refresh successful")
+            return result["access_token"]
 
         on_token_refresh = _do_refresh
 
@@ -292,7 +310,7 @@ async def authenticate_and_create_client(
         on_qr_done=on_qr_done,
     )
     try:
-        return await create_client(token_data)
+        return await create_client(token_data, token_storage=token_storage)
     except AulaAuthenticationError as err:
         _LOGGER.warning(
             "Cached session cookies were rejected (%s); retrying with fresh MitID login",
@@ -312,7 +330,7 @@ async def authenticate_and_create_client(
             on_otp_code=on_otp_code,
             on_qr_done=on_qr_done,
         )
-        return await create_client(fresh_token_data)
+        return await create_client(fresh_token_data, token_storage=token_storage)
 
 
 def _build_token_data(

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,5 +1,6 @@
 """Tests for aula.api_client."""
 
+import asyncio
 import inspect
 from datetime import date, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -86,6 +87,102 @@ class TestRequestWithVersionRetry:
         )
         assert resp.status_code == 500
         assert client._client.request.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_concurrent_auth_failures_share_one_refresh_and_both_retry(self):
+        """Concurrent callers wait for one refresh and both replay successfully."""
+        both_initial_requests_started = asyncio.Event()
+        initial_request_count = 0
+        request_counts = {"concurrent-one": 0, "concurrent-two": 0}
+
+        async def request(method, url, **kwargs):
+            nonlocal initial_request_count
+            for request_name in request_counts:
+                if f"method={request_name}" not in url:
+                    continue
+                request_counts[request_name] += 1
+                if request_counts[request_name] == 1:
+                    initial_request_count += 1
+                    if initial_request_count == 2:
+                        both_initial_requests_started.set()
+                    return HttpResponse(status_code=401, data=None)
+                return HttpResponse(status_code=200, data={"request": request_name})
+            return HttpResponse(status_code=200, data={"data": {"profiles": []}})
+
+        async def refresh_token():
+            await both_initial_requests_started.wait()
+            return "refreshed-token"
+
+        http_client = AsyncMock()
+        http_client.request = AsyncMock(side_effect=request)
+        http_client.get_cookie = MagicMock(return_value="csrf-token")
+        on_token_refresh = AsyncMock(side_effect=refresh_token)
+        client = AulaApiClient(http_client=http_client, on_token_refresh=on_token_refresh)
+
+        responses = await asyncio.gather(
+            client._request_with_version_retry(
+                "get", f"{API_URL}{API_VERSION}?method=concurrent-one"
+            ),
+            client._request_with_version_retry(
+                "get", f"{API_URL}{API_VERSION}?method=concurrent-two"
+            ),
+        )
+
+        assert [response.status_code for response in responses] == [200, 200]
+        assert [response.json()["request"] for response in responses] == [
+            "concurrent-one",
+            "concurrent-two",
+        ]
+        on_token_refresh.assert_awaited_once_with()
+        assert request_counts == {"concurrent-one": 2, "concurrent-two": 2}
+
+    @pytest.mark.asyncio
+    async def test_session_expired_subcode_refreshes_and_retries(self):
+        """Aula's session-expired envelope follows the same refresh path as 401."""
+        http_client = AsyncMock()
+        http_client.request = AsyncMock(
+            side_effect=[
+                HttpResponse(status_code=200, data={"status": {"subCode": 13}}),
+                HttpResponse(status_code=200),
+                HttpResponse(status_code=200),
+                HttpResponse(status_code=200, data={"data": {"ok": True}}),
+            ]
+        )
+        http_client.get_cookie = MagicMock(return_value="csrf-token")
+        on_token_refresh = AsyncMock(return_value="refreshed-token")
+        client = AulaApiClient(http_client=http_client, on_token_refresh=on_token_refresh)
+
+        response = await client._request_with_version_retry(
+            "get", f"{API_URL}{API_VERSION}?method=subcode-test"
+        )
+
+        assert response.json() == {"data": {"ok": True}}
+        on_token_refresh.assert_awaited_once_with()
+        assert http_client.request.await_count == 4
+
+    @pytest.mark.asyncio
+    async def test_authentication_replay_is_limited_to_one_attempt(self):
+        """A second 401 is returned without another refresh or replay."""
+        http_client = AsyncMock()
+        http_client.request = AsyncMock(
+            side_effect=[
+                HttpResponse(status_code=401),
+                HttpResponse(status_code=200),
+                HttpResponse(status_code=200),
+                HttpResponse(status_code=401),
+            ]
+        )
+        http_client.get_cookie = MagicMock(return_value="csrf-token")
+        on_token_refresh = AsyncMock(return_value="refreshed-token")
+        client = AulaApiClient(http_client=http_client, on_token_refresh=on_token_refresh)
+
+        response = await client._request_with_version_retry(
+            "get", f"{API_URL}{API_VERSION}?method=bounded-retry"
+        )
+
+        assert response.status_code == 401
+        on_token_refresh.assert_awaited_once_with()
+        assert http_client.request.await_count == 4
 
     @pytest.mark.asyncio
     async def test_debug_logging_includes_method_and_response(self, client, caplog):

--- a/tests/test_auth_flow.py
+++ b/tests/test_auth_flow.py
@@ -105,6 +105,96 @@ class TestCreateClient:
             # access_token cleared after init
             assert client._access_token is None
 
+    @pytest.mark.asyncio
+    async def test_automatic_refresh_persists_and_reuses_rotated_credentials(self):
+        """Reactive refresh saves the full blob and reuses token rotation."""
+        http = _mock_http_client()
+        token_data = {
+            "timestamp": 1.0,
+            "created_at": "old-created-at",
+            "username": "user",
+            "tokens": {
+                "access_token": "access-1",
+                "refresh_token": "refresh-1",
+                "scope": "openid",
+            },
+            "cookies": {"PHPSESSID": "session-1"},
+        }
+        token_storage = AsyncMock()
+
+        client = await create_client(
+            token_data,
+            http_client=http,
+            token_storage=token_storage,
+        )
+        http.request = AsyncMock(
+            side_effect=[
+                HttpResponse(status_code=401),
+                _profile_response(),
+                _profile_response(),
+                _profile_response(),
+                HttpResponse(status_code=401),
+                _profile_response(),
+                _profile_response(),
+                _profile_response(),
+            ]
+        )
+
+        with (
+            patch(
+                "aula.auth_flow._refresh_token_via_oidc",
+                new_callable=AsyncMock,
+                side_effect=[
+                    {
+                        "access_token": "access-2",
+                        "refresh_token": "refresh-2",
+                        "expires_at": 2_000.0,
+                    },
+                    {"access_token": "access-3", "expires_at": 3_000.0},
+                ],
+            ) as refresh_via_oidc,
+            patch("aula.auth_flow.time.time", side_effect=[100.0, 200.0]),
+            patch(
+                "aula.auth_flow.time.strftime",
+                side_effect=["created-after-first", "created-after-second"],
+            ),
+        ):
+            first_profile = await client.get_profile()
+
+            assert first_profile.display_name == "Test"
+            refresh_via_oidc.assert_awaited_once_with("refresh-1")
+            assert token_data == {
+                "timestamp": 100.0,
+                "created_at": "created-after-first",
+                "username": "user",
+                "tokens": {
+                    "access_token": "access-2",
+                    "refresh_token": "refresh-2",
+                    "scope": "openid",
+                    "expires_at": 2_000.0,
+                },
+                "cookies": {"PHPSESSID": "session-1"},
+            }
+            token_storage.save.assert_awaited_once_with(token_data)
+
+            second_profile = await client.get_profile()
+
+        assert second_profile.display_name == "Test"
+        assert [awaited.args for awaited in refresh_via_oidc.await_args_list] == [
+            ("refresh-1",),
+            ("refresh-2",),
+        ]
+        assert token_data["tokens"] == {
+            "access_token": "access-3",
+            "refresh_token": "refresh-2",
+            "scope": "openid",
+            "expires_at": 3_000.0,
+        }
+        assert token_data["timestamp"] == 200.0
+        assert token_data["created_at"] == "created-after-second"
+        assert token_storage.save.await_count == 2
+        assert token_storage.save.await_args.args[0] is token_data
+
 
 # ---------------------------------------------------------------------------
 # authenticate (returns token_data dict)
@@ -420,6 +510,7 @@ class TestAuthenticateAndCreateClient:
         # Verify create_client received the token_data from authenticate
         call_args = mock_create.call_args[0][0]
         assert call_args["tokens"]["access_token"] == "fresh-tok"
+        assert mock_create.call_args.kwargs == {"token_storage": token_storage}
         assert result is mock_create.return_value
 
     @pytest.mark.asyncio
@@ -466,6 +557,8 @@ class TestAuthenticateAndCreateClient:
         assert mock_create.await_count == 2
         assert mock_create.await_args_list[0].args[0] == cached_token_data
         assert mock_create.await_args_list[1].args[0] == fresh_token_data
+        assert mock_create.await_args_list[0].kwargs == {"token_storage": token_storage}
+        assert mock_create.await_args_list[1].kwargs == {"token_storage": token_storage}
         assert result is recovered_client
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- serialize automatic authentication refreshes so concurrent 401 responses share one refresh and all callers retry
- prevent refresh-triggered session initialization from recursively entering the refresh lock
- persist complete rotated OIDC credentials and reuse rotated refresh tokens
- pass TokenStorage through both authenticate-and-create-client paths

## Compatibility

- keeps the existing token-refresh callback contract
- adds token_storage as an optional keyword-only create_client argument
- preserves create_client callers that manage credentials themselves

## Test plan

- uv run pytest tests/test_api_client.py tests/test_auth_flow.py -q (205 passed)
- uv run ruff format --check .
- uv run ruff check .
- uv run pytest (775 passed, 4 skipped)