### PR TITLE
fix: recover Meebook weekplans after JWT expiry

### DIFF
--- a/src/aula/widgets/client.py
+++ b/src/aula/widgets/client.py
@@ -93,6 +93,14 @@ def _as_list(data: Any, provider: str) -> list[Any]:
     return items
 
 
+def _is_meebook_jwt_expired(payload: Any) -> bool:
+    """Return whether Meebook reported its known JWT-expiry body."""
+    if not isinstance(payload, dict):
+        return False
+    message = payload.get("message")
+    return isinstance(message, str) and "jwt-token expired" in message.casefold()
+
+
 def _ordered_unique(pairs: list[tuple[str, str]]) -> list[tuple[str, str]]:
     """Drop repeats while keeping first-seen order."""
     seen: set[tuple[str, str]] = set()
@@ -150,6 +158,13 @@ def _log_unreadable_body(source: str, payload: Any, **context: str) -> None:
 
 class _WidgetRequestClient(Protocol):
     api_url: str
+
+    async def _refresh_authentication(
+        self,
+        observed_generation: int | None = None,
+        *,
+        force: bool = False,
+    ) -> bool: ...
 
     async def _request_with_version_retry(
         self,
@@ -918,8 +933,6 @@ class AulaWidgetsClient:
         week: str,
         session_uuid: str,
     ) -> list[MeebookStudentPlan]:
-        token = await self._get_bearer_token(WIDGET_MEEBOOK)
-
         parts = week.split("-W")
         if len(parts) == 2:
             week = f"{parts[0]}-W{int(parts[1]):02d}"
@@ -931,21 +944,35 @@ class AulaWidgetsClient:
             "institutionFilter[]": institution_filter,
         }
 
-        headers = {
-            "Authorization": token,
-            "Accept": "application/json",
-            "sessionUUID": session_uuid,
-            "X-Version": "1.0",
-        }
+        async def request_weekplan() -> Any:
+            token = await self._get_bearer_token(WIDGET_MEEBOOK)
+            headers = {
+                "Authorization": token,
+                "Accept": "application/json",
+                "sessionUUID": session_uuid,
+                "X-Version": "1.0",
+            }
 
-        resp = await self._api_client._request_with_version_retry(
-            "get",
-            f"{MEEBOOK_API}/relatedweekplan/all",
-            params=params,
-            headers=headers,
-        )
-        resp.raise_for_status()
-        plans = _as_list(resp.json(), "Meebook weekplan")
+            resp = await self._api_client._request_with_version_retry(
+                "get",
+                f"{MEEBOOK_API}/relatedweekplan/all",
+                params=params,
+                headers=headers,
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+        payload = await request_weekplan()
+        if _is_meebook_jwt_expired(payload):
+            refreshed = await self._api_client._refresh_authentication(force=True)
+            if refreshed:
+                payload = await request_weekplan()
+
+            if not refreshed or _is_meebook_jwt_expired(payload):
+                _LOGGER.warning("Meebook weekplan JWT expired and could not be renewed")
+                return []
+
+        plans = _as_list(payload, "Meebook weekplan")
         return [MeebookStudentPlan.from_dict(s) for s in plans]
 
     async def get_momo_courses(

--- a/tests/test_widgets_client.py
+++ b/tests/test_widgets_client.py
@@ -982,8 +982,59 @@ class TestWidgetsClientMalformedResponses:
         )
 
     @pytest.mark.asyncio
-    async def test_meebook_weekplan_returns_empty_on_jwt_expiry_message(self, client, caplog):
-        self._responses(client, self.JWT_EXPIRED)
+    async def test_meebook_weekplan_refreshes_and_retries_on_jwt_expiry(self, client):
+        old_token_response = Mock()
+        old_token_response.raise_for_status = Mock()
+        old_token_response.json = Mock(return_value={"data": "token-old"})
+
+        expired_response = Mock()
+        expired_response.raise_for_status = Mock()
+        expired_response.json = Mock(return_value=self.JWT_EXPIRED)
+
+        new_token_response = Mock()
+        new_token_response.raise_for_status = Mock()
+        new_token_response.json = Mock(return_value={"data": "token-new"})
+
+        successful_response = Mock()
+        successful_response.raise_for_status = Mock()
+        successful_response.json = Mock(
+            return_value=[{"name": "Child", "unilogin": "child-1", "weekPlan": []}]
+        )
+
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[
+                old_token_response,
+                expired_response,
+                new_token_response,
+                successful_response,
+            ]
+        )
+        client._refresh_authentication = AsyncMock(return_value=True)
+
+        plans = await client.widgets.get_meebook_weekplan(
+            child_filter=["child-1"],
+            institution_filter=["inst-1"],
+            week="2026-W09",
+            session_uuid="session-1",
+        )
+
+        assert [plan.name for plan in plans] == ["Child"]
+        client._refresh_authentication.assert_awaited_once_with(force=True)
+        calls = client._request_with_version_retry.await_args_list
+        assert calls[1].kwargs["headers"]["Authorization"] == "Bearer token-old"
+        assert calls[3].kwargs["headers"]["Authorization"] == "Bearer token-new"
+
+    @pytest.mark.asyncio
+    async def test_meebook_weekplan_returns_empty_when_jwt_refresh_is_unavailable(
+        self, client, caplog
+    ):
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[
+                _token_response("token-old"),
+                _calendar_response(self.JWT_EXPIRED),
+            ]
+        )
+        client._refresh_authentication = AsyncMock(return_value=False)
 
         plans = await client.widgets.get_meebook_weekplan(
             child_filter=["child-1"],
@@ -993,8 +1044,55 @@ class TestWidgetsClientMalformedResponses:
         )
 
         assert plans == []
+        client._refresh_authentication.assert_awaited_once_with(force=True)
+        calls = client._request_with_version_retry.await_args_list
+        assert sum("aulaToken.getAulaToken" in call_.args[1] for call_ in calls) == 1
+        assert sum(call_.args[1] == f"{MEEBOOK_API}/relatedweekplan/all" for call_ in calls) == 1
+        assert "Meebook weekplan JWT expired and could not be renewed" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_meebook_weekplan_retries_only_once_when_jwt_stays_expired(self, client, caplog):
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[
+                _token_response("token-old"),
+                _calendar_response(self.JWT_EXPIRED),
+                _token_response("token-new"),
+                _calendar_response(self.JWT_EXPIRED),
+            ]
+        )
+        client._refresh_authentication = AsyncMock(return_value=True)
+
+        plans = await client.widgets.get_meebook_weekplan(
+            child_filter=["child-1"],
+            institution_filter=["inst-1"],
+            week="2026-W09",
+            session_uuid="session-1",
+        )
+
+        assert plans == []
+        client._refresh_authentication.assert_awaited_once_with(force=True)
+        calls = client._request_with_version_retry.await_args_list
+        assert sum("aulaToken.getAulaToken" in call_.args[1] for call_ in calls) == 2
+        assert sum(call_.args[1] == f"{MEEBOOK_API}/relatedweekplan/all" for call_ in calls) == 2
+        assert "Meebook weekplan JWT expired and could not be renewed" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_meebook_weekplan_does_not_refresh_for_unrelated_error_object(
+        self, client, caplog
+    ):
+        self._responses(client, {"message": "Service temporarily unavailable"})
+        client._refresh_authentication = AsyncMock(return_value=True)
+
+        plans = await client.widgets.get_meebook_weekplan(
+            child_filter=["child-1"],
+            institution_filter=["inst-1"],
+            week="2026-W09",
+            session_uuid="session-1",
+        )
+
+        assert plans == []
+        client._refresh_authentication.assert_not_awaited()
         assert "Meebook weekplan returned dict instead of a list" in caplog.text
-        assert "JWT-Token expired" in caplog.text
 
     @pytest.mark.asyncio
     async def test_meebook_weekplan_skips_non_dict_items(self, client, caplog):


### PR DESCRIPTION
## Summary

- detect the known Meebook JWT-expiry response returned with HTTP 200
- refresh Aula authentication through the serialized lifecycle from PR #95
- mint a fresh Meebook widget token and retry the provider once
- keep failed or repeated expiry bounded and avoid refresh for unrelated objects

## Dependency

- stacked on #95; base is `fix/token-refresh-lifecycle`
- retarget to `main` after #95 merges

## Test plan

- `uv run pytest tests/test_widgets_client.py -q` (54 passed)
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest` (778 passed, 4 skipped)