### PR TITLE
fix: preserve EasyIQ calendar response semantics

### DIFF
--- a/src/aula/models/appointment.py
+++ b/src/aula/models/appointment.py
@@ -4,6 +4,15 @@ from typing import Any
 from .base import AulaDataClass
 
 
+def _strict_bool(value: Any) -> bool:
+    """Parse only the Boolean encodings emitted by Aula and EasyIQ."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value == 1
+    return isinstance(value, str) and value.strip().casefold() in {"true", "1", "yes"}
+
+
 @dataclass
 class Appointment(AulaDataClass):
     appointment_id: str
@@ -16,6 +25,9 @@ class Appointment(AulaDataClass):
     activities: str = ""
     item_type: int | None = None
     _raw: dict | None = field(default=None, repr=False)
+    owner_name: str = field(default="", kw_only=True)
+    is_all_day: bool = field(default=False, kw_only=True)
+    is_notice: bool = field(default=False, kw_only=True)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Appointment:
@@ -27,4 +39,7 @@ class Appointment(AulaDataClass):
             end=data.get("end", ""),
             description=data.get("description", ""),
             item_type=data.get("itemType"),
+            owner_name=data.get("ownerName", data.get("owner_name", "")),
+            is_all_day=_strict_bool(data.get("isAllDay", data.get("is_all_day"))),
+            is_notice=_strict_bool(data.get("isNotice", data.get("is_notice"))),
         )

--- a/src/aula/models/easyiq_calendar_event.py
+++ b/src/aula/models/easyiq_calendar_event.py
@@ -3,6 +3,8 @@ import html
 from dataclasses import dataclass, field
 from typing import Any
 
+from bs4 import BeautifulSoup
+
 from .base import AulaDataClass
 
 #: EasyIQ tags every calendar row with an ``itemType``. Its own widget source
@@ -22,11 +24,13 @@ HOMEWORK_ITEM_TYPES = (1, 2, 3, 4, 8)
 #: (``ItemType``), so a case-sensitive lookup silently parses nothing. The
 #: ``*Display`` and ``*ISO`` variants come first because they are the ones the
 #: widget itself reads.
-_START_KEYS = ("starttimeiso", "start", "startdatetime", "starttime", "from")
-_END_KEYS = ("endtimeiso", "end", "enddatetime", "endtime", "to")
-_COURSE_KEYS = ("coursesdisplay", "courses", "course", "subject", "title", "name")
+_START_KEYS = ("starttimeiso", "startdate", "start", "startdatetime", "starttime", "from")
+_END_KEYS = ("endtimeiso", "enddate", "end", "enddatetime", "endtime", "to")
+_COURSE_KEYS = ("coursesdisplay", "courses", "course", "subject")
+_TITLE_KEYS = ("title", "name")
 _ACTIVITY_KEYS = ("activitiesdisplay", "activities", "activity", "lesson", "classname")
 _DESCRIPTION_KEYS = ("description", "details", "note", "content")
+_OWNER_KEYS = ("ownername", "teacher")
 _ITEM_TYPE_KEYS = ("itemtype", "itemtypeid", "type")
 _ID_KEYS = ("id", "workid")
 
@@ -100,6 +104,33 @@ def _item_type(folded: dict[str, Any]) -> int | None:
     return None
 
 
+def _strict_bool(value: Any) -> bool:
+    """Parse only EasyIQ's observed true encodings."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value == 1
+    return isinstance(value, str) and value.strip().casefold() in {"true", "1", "yes"}
+
+
+def _description_title(description: str) -> str:
+    """Return the first heading or visible line from an EasyIQ notice."""
+    if not description:
+        return ""
+
+    soup = BeautifulSoup(description, "html.parser")
+    for heading in soup.find_all(("h1", "h2", "h3")):
+        text = html.unescape(heading.get_text(" ", strip=True)).strip()
+        if text:
+            return text
+
+    for line in soup.get_text("\n").splitlines():
+        text = html.unescape(line).strip()
+        if text:
+            return text
+    return ""
+
+
 @dataclass
 class EasyIQCalendarEvent(AulaDataClass):
     """One row from EasyIQ's ``CalendarGetWeekplanEvents`` endpoint.
@@ -116,26 +147,41 @@ class EasyIQCalendarEvent(AulaDataClass):
     activities: str = ""
     description: str = ""
     _raw: dict | None = field(default=None, repr=False)
+    owner_name: str = field(default="", kw_only=True)
+    is_all_day: bool = field(default=False, kw_only=True)
+    is_notice: bool = field(default=False, kw_only=True)
+    event_title: str = field(default="", kw_only=True)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> EasyIQCalendarEvent:
         folded = _fold_keys(data)
+        course = _first_text(folded, _COURSE_KEYS)
+        is_notice = not course
         return cls(
             _raw=data,
             item_type=_item_type(folded),
             event_id=_first_text(folded, _ID_KEYS),
             start=_first_timestamp(folded, _START_KEYS),
             end=_first_timestamp(folded, _END_KEYS),
-            courses=_first_text(folded, _COURSE_KEYS),
+            courses=course,
             activities=_first_text(folded, _ACTIVITY_KEYS),
             description=_first_text(folded, _DESCRIPTION_KEYS),
+            owner_name=_first_text(folded, _OWNER_KEYS),
+            is_all_day=_strict_bool(folded.get("isallday")) or is_notice,
+            is_notice=is_notice,
+            event_title=_first_text(folded, _TITLE_KEYS),
         )
 
     @property
     def title(self) -> str:
-        """Best available label for the row, preferring the subject.
+        """Best available label from the explicit title, subject, or content.
 
-        Empty when the row carries neither, so callers render their own
-        placeholder rather than receiving one as data.
+        Empty when the row carries no useful label or content, so callers
+        render their own placeholder rather than receiving one as data.
         """
-        return self.courses or self.activities
+        return (
+            self.event_title
+            or self.courses
+            or self.activities
+            or _description_title(self.description)
+        )

--- a/src/aula/widgets/client.py
+++ b/src/aula/widgets/client.py
@@ -93,6 +93,14 @@ def _as_list(data: Any, provider: str) -> list[Any]:
     return items
 
 
+def _is_meebook_jwt_expired(payload: Any) -> bool:
+    """Return whether Meebook reported its known JWT-expiry body."""
+    if not isinstance(payload, dict):
+        return False
+    message = payload.get("message")
+    return isinstance(message, str) and "jwt-token expired" in message.casefold()
+
+
 def _ordered_unique(pairs: list[tuple[str, str]]) -> list[tuple[str, str]]:
     """Drop repeats while keeping first-seen order."""
     seen: set[tuple[str, str]] = set()
@@ -150,6 +158,13 @@ def _log_unreadable_body(source: str, payload: Any, **context: str) -> None:
 
 class _WidgetRequestClient(Protocol):
     api_url: str
+
+    async def _refresh_authentication(
+        self,
+        observed_generation: int | None = None,
+        *,
+        force: bool = False,
+    ) -> bool: ...
 
     async def _request_with_version_retry(
         self,
@@ -918,8 +933,6 @@ class AulaWidgetsClient:
         week: str,
         session_uuid: str,
     ) -> list[MeebookStudentPlan]:
-        token = await self._get_bearer_token(WIDGET_MEEBOOK)
-
         parts = week.split("-W")
         if len(parts) == 2:
             week = f"{parts[0]}-W{int(parts[1]):02d}"
@@ -931,21 +944,35 @@ class AulaWidgetsClient:
             "institutionFilter[]": institution_filter,
         }
 
-        headers = {
-            "Authorization": token,
-            "Accept": "application/json",
-            "sessionUUID": session_uuid,
-            "X-Version": "1.0",
-        }
+        async def request_weekplan() -> Any:
+            token = await self._get_bearer_token(WIDGET_MEEBOOK)
+            headers = {
+                "Authorization": token,
+                "Accept": "application/json",
+                "sessionUUID": session_uuid,
+                "X-Version": "1.0",
+            }
 
-        resp = await self._api_client._request_with_version_retry(
-            "get",
-            f"{MEEBOOK_API}/relatedweekplan/all",
-            params=params,
-            headers=headers,
-        )
-        resp.raise_for_status()
-        plans = _as_list(resp.json(), "Meebook weekplan")
+            resp = await self._api_client._request_with_version_retry(
+                "get",
+                f"{MEEBOOK_API}/relatedweekplan/all",
+                params=params,
+                headers=headers,
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+        payload = await request_weekplan()
+        if _is_meebook_jwt_expired(payload):
+            refreshed = await self._api_client._refresh_authentication(force=True)
+            if refreshed:
+                payload = await request_weekplan()
+
+            if not refreshed or _is_meebook_jwt_expired(payload):
+                _LOGGER.warning("Meebook weekplan JWT expired and could not be renewed")
+                return []
+
+        plans = _as_list(payload, "Meebook weekplan")
         return [MeebookStudentPlan.from_dict(s) for s in plans]
 
     async def get_momo_courses(

--- a/src/aula/widgets/client.py
+++ b/src/aula/widgets/client.py
@@ -123,13 +123,14 @@ def _find_events(payload: Any) -> list[dict[str, Any]] | None:
     if isinstance(payload, list):
         return [event for event in payload if isinstance(event, dict)]
     if isinstance(payload, dict):
-        for key in ("events", "calendarEvents", "items", "data", "result"):
-            value = payload.get(key)
+        folded = {str(key).casefold(): value for key, value in payload.items()}
+        for key in ("events", "calendarevents", "weekplan", "items", "data", "result"):
+            value = folded.get(key)
             if isinstance(value, list):
                 return [event for event in value if isinstance(event, dict)]
             if isinstance(value, dict):
                 nested = _find_events(value)
-                if nested:
+                if nested is not None:
                     return nested
     return None
 
@@ -876,6 +877,9 @@ class AulaWidgetsClient:
                 description=event.description,
                 activities=event.activities,
                 item_type=event.item_type,
+                owner_name=event.owner_name,
+                is_all_day=event.is_all_day,
+                is_notice=event.is_notice,
             )
             for event in events
             if event.item_type in WEEKPLAN_ITEM_TYPES

--- a/tests/models/test_appointment.py
+++ b/tests/models/test_appointment.py
@@ -22,6 +22,38 @@ def test_appointment_from_dict():
     assert appt._raw is data
 
 
+def test_appointment_from_dict_preserves_easyiq_metadata():
+    appt = Appointment.from_dict(
+        {
+            "appointmentId": "apt-1",
+            "title": "Sports day",
+            "ownerName": "Ada Teacher",
+            "isAllDay": "yes",
+            "isNotice": 1,
+        }
+    )
+
+    assert appt.owner_name == "Ada Teacher"
+    assert appt.is_all_day is True
+    assert appt.is_notice is True
+
+
+def test_appointment_metadata_round_trips_in_snake_case():
+    original = Appointment(
+        appointment_id="apt-1",
+        title="Sports day",
+        owner_name="Ada Teacher",
+        is_all_day=True,
+        is_notice=True,
+    )
+
+    restored = Appointment.from_dict(dict(original))
+
+    assert restored.owner_name == "Ada Teacher"
+    assert restored.is_all_day is True
+    assert restored.is_notice is True
+
+
 def test_appointment_from_dict_defaults():
     data = {}
     appt = Appointment.from_dict(data)
@@ -31,6 +63,16 @@ def test_appointment_from_dict_defaults():
     assert appt.end == ""
     assert appt.description == ""
     assert appt.item_type is None
+    assert appt.owner_name == ""
+    assert appt.is_all_day is False
+    assert appt.is_notice is False
+
+
+def test_appointment_booleans_reject_unknown_encodings():
+    for value in (False, "false", "0", 0, "sometimes", None):
+        appt = Appointment.from_dict({"isAllDay": value, "isNotice": value})
+        assert appt.is_all_day is False
+        assert appt.is_notice is False
 
 
 def test_appointment_dict_conversion():
@@ -41,9 +83,15 @@ def test_appointment_dict_conversion():
         end="09:00",
         description="Algebra",
         item_type=9,
+        owner_name="Ada Teacher",
+        is_all_day=True,
+        is_notice=True,
     )
     result = dict(appt)
     assert result["title"] == "Math"
     assert result["start"] == "08:00"
     assert result["item_type"] == 9
+    assert result["owner_name"] == "Ada Teacher"
+    assert result["is_all_day"] is True
+    assert result["is_notice"] is True
     assert "_raw" not in result

--- a/tests/models/test_easyiq_calendar_event.py
+++ b/tests/models/test_easyiq_calendar_event.py
@@ -70,6 +70,64 @@ def test_alternate_keys_are_read():
     assert event.description == "Husk tøj"
 
 
+def test_start_date_and_end_date_are_normalized():
+    event = EasyIQCalendarEvent.from_dict(
+        {"StartDate": "2026/08/13 12:55", "EndDate": "2026/08/13 14:25"}
+    )
+    assert event.start == "2026-08-13T12:55:00"
+    assert event.end == "2026-08-13T14:25:00"
+
+
+def test_owner_name_aliases_are_read():
+    assert EasyIQCalendarEvent.from_dict({"OwnerName": "Ada Teacher"}).owner_name == "Ada Teacher"
+    assert EasyIQCalendarEvent.from_dict({"teacher": "Grace Teacher"}).owner_name == "Grace Teacher"
+
+
+def test_is_all_day_uses_only_known_true_encodings():
+    for value in (True, "true", "1", "yes", 1):
+        event = EasyIQCalendarEvent.from_dict({"CoursesDisplay": "Dansk", "IsAllDay": value})
+        assert event.is_all_day is True
+
+    for value in (False, "false", "0", 0, "sometimes", None):
+        event = EasyIQCalendarEvent.from_dict({"CoursesDisplay": "Dansk", "IsAllDay": value})
+        assert event.is_all_day is False
+
+    assert EasyIQCalendarEvent.from_dict({"CoursesDisplay": "Dansk"}).is_all_day is False
+
+
+def test_rows_without_a_course_are_all_day_notices():
+    notice = EasyIQCalendarEvent.from_dict({"Description": "School closed"})
+    lesson = EasyIQCalendarEvent.from_dict({"CoursesDisplay": "Matematik"})
+
+    assert notice.is_notice is True
+    assert notice.is_all_day is True
+    assert lesson.is_notice is False
+
+
+def test_explicit_title_does_not_pretend_to_be_a_course():
+    event = EasyIQCalendarEvent.from_dict({"Title": "Sports day"})
+
+    assert event.event_title == "Sports day"
+    assert event.title == "Sports day"
+    assert event.courses == ""
+    assert event.is_notice is True
+    assert EasyIQCalendarEvent.from_dict({"Name": "Parents evening"}).event_title == (
+        "Parents evening"
+    )
+
+
+def test_notice_title_comes_from_heading_then_visible_text():
+    with_heading = EasyIQCalendarEvent.from_dict(
+        {"Description": "<h1> </h1><p>Introduction</p><h2>School &amp; SFO closed</h2>"}
+    )
+    without_heading = EasyIQCalendarEvent.from_dict(
+        {"Description": "<p>Remember indoor shoes</p><p>Applies all week</p>"}
+    )
+
+    assert with_heading.title == "School & SFO closed"
+    assert without_heading.title == "Remember indoor shoes"
+
+
 def test_list_values_are_joined():
     event = EasyIQCalendarEvent.from_dict({"activities": ["Læsning", "Skrivning"]})
     assert event.activities == "Læsning, Skrivning"
@@ -139,6 +197,13 @@ def test_event_id_is_read():
 
 
 def test_dict_conversion_drops_raw():
-    result = dict(EasyIQCalendarEvent.from_dict({"itemType": 4, "courses": "Dansk"}))
+    result = dict(
+        EasyIQCalendarEvent.from_dict(
+            {"itemType": 4, "courses": "Dansk", "OwnerName": "Ada Teacher", "IsAllDay": True}
+        )
+    )
     assert result["courses"] == "Dansk"
+    assert result["owner_name"] == "Ada Teacher"
+    assert result["is_all_day"] is True
+    assert result["is_notice"] is False
     assert "_raw" not in result

--- a/tests/test_widgets_client.py
+++ b/tests/test_widgets_client.py
@@ -183,6 +183,9 @@ class TestWidgetsClient:
                             "end": "2026-02-24 09:00",
                             "description": "<p>Algebra</p>",
                             "itemType": 9,
+                            "ownerName": "Ada Teacher",
+                            "isAllDay": "true",
+                            "isNotice": False,
                         }
                     ]
                 }
@@ -205,6 +208,9 @@ class TestWidgetsClient:
         assert appointments[0].end == "2026-02-24 09:00"
         assert appointments[0].description == "<p>Algebra</p>"
         assert appointments[0].item_type == 9
+        assert appointments[0].owner_name == "Ada Teacher"
+        assert appointments[0].is_all_day is True
+        assert appointments[0].is_notice is False
         calls = client._request_with_version_retry.await_args_list
         assert calls[1].args == ("post", f"{EASYIQ_API}/weekplaninfo")
         assert calls[1].kwargs["headers"] == {
@@ -453,6 +459,32 @@ class TestWidgetsClient:
         assert calls[3].args == ("get", EASYIQ_CALENDAR_URL)
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "envelope",
+        [
+            {"Events": [{"Id": "event-1", "ItemType": 9}]},
+            {"WeekPlan": [{"Id": "event-1", "ItemType": 9}]},
+            {"Data": {"Events": [{"Id": "event-1", "ItemType": 9}]}},
+        ],
+        ids=["events", "week-plan", "nested-mixed-case"],
+    )
+    async def test_easyiq_calendar_reads_observed_envelope_variants(self, client, envelope):
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[_token_response("token-easy"), _calendar_response(envelope)]
+        )
+
+        events = await client.widgets.get_easyiq_calendar_events(
+            week="2026-W09",
+            institution_filter=["inst-1"],
+            child_profile_id="4242",
+            child_user_id="child-user-1",
+            all_child_user_ids=["child-user-1"],
+            guardian_login="guardian-1",
+        )
+
+        assert [event.event_id for event in events] == ["event-1"]
+
+    @pytest.mark.asyncio
     async def test_easyiq_calendar_falls_through_to_the_accepted_identifiers(self, client):
         """EasyIQ answers 200-with-nothing for identifiers it does not know."""
         client._request_with_version_retry = AsyncMock(
@@ -560,6 +592,43 @@ class TestWidgetsClient:
         assert calls[3].args == ("get", EASYIQ_CALENDAR_URL)
 
     @pytest.mark.asyncio
+    async def test_easyiq_weekplan_fallback_preserves_notice_metadata(self, client):
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[
+                _token_response("token-easy"),
+                _calendar_response({"data": {"appointments": []}}),
+                _token_response("token-easy"),
+                _calendar_response(
+                    {
+                        "Events": [
+                            {
+                                "Id": "notice-1",
+                                "ItemType": 8,
+                                "Title": "Sports day",
+                                "OwnerName": "Ada Teacher",
+                            }
+                        ]
+                    }
+                ),
+            ]
+        )
+
+        appointments = await client.widgets.get_easyiq_weekplan(
+            "2026-W09",
+            "guardian-1",
+            ["inst-1"],
+            "child-user-1",
+            child_profile_id="4242",
+        )
+
+        assert len(appointments) == 1
+        assert appointments[0].appointment_id == "notice-1"
+        assert appointments[0].title == "Sports day"
+        assert appointments[0].owner_name == "Ada Teacher"
+        assert appointments[0].is_all_day is True
+        assert appointments[0].is_notice is True
+
+    @pytest.mark.asyncio
     async def test_get_easyiq_weekplan_falls_back_when_the_api_returns_nothing(self, client):
         """A 200 with an empty appointment list is the shape issue #45 reported."""
         empty = Mock()
@@ -614,7 +683,10 @@ class TestWidgetsClient:
     @pytest.mark.asyncio
     async def test_easyiq_calendar_stays_quiet_on_a_genuinely_empty_week(self, client, caplog):
         client._request_with_version_retry = AsyncMock(
-            side_effect=[_token_response("token-easy"), *[_calendar_response([])] * 4]
+            side_effect=[
+                _token_response("token-easy"),
+                *[_calendar_response({"Data": {"Events": []}})] * 4,
+            ]
         )
 
         homework = await client.widgets.get_easyiq_homework(

--- a/tests/test_widgets_client.py
+++ b/tests/test_widgets_client.py
@@ -982,8 +982,59 @@ class TestWidgetsClientMalformedResponses:
         )
 
     @pytest.mark.asyncio
-    async def test_meebook_weekplan_returns_empty_on_jwt_expiry_message(self, client, caplog):
-        self._responses(client, self.JWT_EXPIRED)
+    async def test_meebook_weekplan_refreshes_and_retries_on_jwt_expiry(self, client):
+        old_token_response = Mock()
+        old_token_response.raise_for_status = Mock()
+        old_token_response.json = Mock(return_value={"data": "token-old"})
+
+        expired_response = Mock()
+        expired_response.raise_for_status = Mock()
+        expired_response.json = Mock(return_value=self.JWT_EXPIRED)
+
+        new_token_response = Mock()
+        new_token_response.raise_for_status = Mock()
+        new_token_response.json = Mock(return_value={"data": "token-new"})
+
+        successful_response = Mock()
+        successful_response.raise_for_status = Mock()
+        successful_response.json = Mock(
+            return_value=[{"name": "Child", "unilogin": "child-1", "weekPlan": []}]
+        )
+
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[
+                old_token_response,
+                expired_response,
+                new_token_response,
+                successful_response,
+            ]
+        )
+        client._refresh_authentication = AsyncMock(return_value=True)
+
+        plans = await client.widgets.get_meebook_weekplan(
+            child_filter=["child-1"],
+            institution_filter=["inst-1"],
+            week="2026-W09",
+            session_uuid="session-1",
+        )
+
+        assert [plan.name for plan in plans] == ["Child"]
+        client._refresh_authentication.assert_awaited_once_with(force=True)
+        calls = client._request_with_version_retry.await_args_list
+        assert calls[1].kwargs["headers"]["Authorization"] == "Bearer token-old"
+        assert calls[3].kwargs["headers"]["Authorization"] == "Bearer token-new"
+
+    @pytest.mark.asyncio
+    async def test_meebook_weekplan_returns_empty_when_jwt_refresh_is_unavailable(
+        self, client, caplog
+    ):
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[
+                _token_response("token-old"),
+                _calendar_response(self.JWT_EXPIRED),
+            ]
+        )
+        client._refresh_authentication = AsyncMock(return_value=False)
 
         plans = await client.widgets.get_meebook_weekplan(
             child_filter=["child-1"],
@@ -993,8 +1044,55 @@ class TestWidgetsClientMalformedResponses:
         )
 
         assert plans == []
+        client._refresh_authentication.assert_awaited_once_with(force=True)
+        calls = client._request_with_version_retry.await_args_list
+        assert sum("aulaToken.getAulaToken" in call_.args[1] for call_ in calls) == 1
+        assert sum(call_.args[1] == f"{MEEBOOK_API}/relatedweekplan/all" for call_ in calls) == 1
+        assert "Meebook weekplan JWT expired and could not be renewed" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_meebook_weekplan_retries_only_once_when_jwt_stays_expired(self, client, caplog):
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[
+                _token_response("token-old"),
+                _calendar_response(self.JWT_EXPIRED),
+                _token_response("token-new"),
+                _calendar_response(self.JWT_EXPIRED),
+            ]
+        )
+        client._refresh_authentication = AsyncMock(return_value=True)
+
+        plans = await client.widgets.get_meebook_weekplan(
+            child_filter=["child-1"],
+            institution_filter=["inst-1"],
+            week="2026-W09",
+            session_uuid="session-1",
+        )
+
+        assert plans == []
+        client._refresh_authentication.assert_awaited_once_with(force=True)
+        calls = client._request_with_version_retry.await_args_list
+        assert sum("aulaToken.getAulaToken" in call_.args[1] for call_ in calls) == 2
+        assert sum(call_.args[1] == f"{MEEBOOK_API}/relatedweekplan/all" for call_ in calls) == 2
+        assert "Meebook weekplan JWT expired and could not be renewed" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_meebook_weekplan_does_not_refresh_for_unrelated_error_object(
+        self, client, caplog
+    ):
+        self._responses(client, {"message": "Service temporarily unavailable"})
+        client._refresh_authentication = AsyncMock(return_value=True)
+
+        plans = await client.widgets.get_meebook_weekplan(
+            child_filter=["child-1"],
+            institution_filter=["inst-1"],
+            week="2026-W09",
+            session_uuid="session-1",
+        )
+
+        assert plans == []
+        client._refresh_authentication.assert_not_awaited()
         assert "Meebook weekplan returned dict instead of a list" in caplog.text
-        assert "JWT-Token expired" in caplog.text
 
     @pytest.mark.asyncio
     async def test_meebook_weekplan_skips_non_dict_items(self, client, caplog):


### PR DESCRIPTION
## Summary

- unwrap EasyIQ `Events`, `WeekPlan`, and nested response envelopes case-insensitively
- preserve the distinction between known empty envelopes and unreadable response bodies
- parse observed date, owner, all-day, notice, and explicit-title fields
- derive useful notice titles from headings or visible description text
- carry EasyIQ metadata through both direct and fallback `Appointment` results

## Compatibility

- new model fields are keyword-only, preserving existing positional constructor slots

## Dependency

- stacked on #96; base is `fix/meebook-expiry-retry`
- retarget to `main` after the preceding PRs merge

## Test plan

- `uv run pytest tests/models/test_easyiq_calendar_event.py tests/models/test_appointment.py tests/test_widgets_client.py -q` (86 passed)
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest` (791 passed, 4 skipped)