### PR TITLE
fix: select a consistent EasyIQ widget token

### DIFF
--- a/src/aula/cli.py
+++ b/src/aula/cli.py
@@ -20,10 +20,10 @@ from .api_client import AulaApiClient
 from .auth_flow import authenticate_and_create_client
 from .config import CONFIG_FILE, DEFAULT_TOKEN_FILE, load_config, save_config
 from .const import (
+    EASYIQ_WEEKPLAN_WIDGETS,
     MIN_UDDANNELSE_TASK_WIDGETS,
     WIDGET_BIBLIOTEKET,
     WIDGET_EASYIQ_HOMEWORK,
-    WIDGET_EASYIQ_WEEKPLAN,
     WIDGET_HUSKELISTEN,
     WIDGET_MEEBOOK,
     WIDGET_MIN_UDDANNELSE_UGEPLAN,
@@ -2061,7 +2061,8 @@ async def easyiq_ugeplan(ctx, week):
     """Fetch EasyIQ weekly plan (ugeplan) for children."""
     week = _resolve_week(week)
     async with await _get_client(ctx) as client:
-        if not await _require_widget(client, WIDGET_EASYIQ_WEEKPLAN, "EasyIQ Ugeplan"):
+        widget_id = await _require_any_widget(client, EASYIQ_WEEKPLAN_WIDGETS, "EasyIQ Ugeplan")
+        if widget_id is None:
             return
 
         try:
@@ -2110,6 +2111,7 @@ async def easyiq_ugeplan(ctx, week):
                         child_profile_id=str(child.id),
                         all_child_user_ids=all_child_user_ids,
                         all_institution_filter=institution_filter,
+                        widget_id=widget_id,
                     )
                     all_appointments.extend(_with_child(dict(a), child) for a in appointments)
                 except EasyIQChildNotInPortal:
@@ -2142,6 +2144,7 @@ async def easyiq_ugeplan(ctx, week):
                     child_profile_id=str(child.id),
                     all_child_user_ids=all_child_user_ids,
                     all_institution_filter=institution_filter,
+                    widget_id=widget_id,
                 )
             except EasyIQChildNotInPortal:
                 _echo_no_easyiq_identity(child.name, "weekly plan")
@@ -3133,9 +3136,12 @@ async def weekly_summary(ctx, child, week, providers):
                     click.echo()
 
         # ── EasyIQ – Weekly Plan ─────────────────────────────────────────────
-        if WeeklySummaryProvider.EASYIQ in enabled and await _has_widget(
-            client, WIDGET_EASYIQ_WEEKPLAN
-        ):
+        easyiq_weekplan_widget = (
+            await _first_available_widget(client, EASYIQ_WEEKPLAN_WIDGETS)
+            if WeeklySummaryProvider.EASYIQ in enabled
+            else None
+        )
+        if easyiq_weekplan_widget is not None:
             easyiq_appointments: list[dict] = []
             easyiq_any = False
             for c in children:
@@ -3156,6 +3162,7 @@ async def weekly_summary(ctx, child, week, providers):
                         child_profile_id=str(c.id),
                         all_child_user_ids=all_child_user_ids,
                         all_institution_filter=institution_filter,
+                        widget_id=easyiq_weekplan_widget,
                     )
                 except EasyIQChildNotInPortal:
                     # Expected for children whose institution is not on EasyIQ.

--- a/src/aula/const.py
+++ b/src/aula/const.py
@@ -25,6 +25,7 @@ CICERO_API = "https://surf.cicero-suite.com/portal-api/rest/aula"
 
 # Widget IDs for third-party integrations
 WIDGET_EASYIQ_WEEKPLAN = "0128"
+WIDGET_EASYIQ_LEGACY = "0001"
 WIDGET_EASYIQ_HOMEWORK = "0142"
 WIDGET_BIBLIOTEKET = "0019"
 WIDGET_MIN_UDDANNELSE_UGEPLAN = "0029"
@@ -32,6 +33,15 @@ WIDGET_MIN_UDDANNELSE_TASKS = "0030"
 WIDGET_MIN_UDDANNELSE_SSO = "0023"
 WIDGET_MEEBOOK = "0004"
 WIDGET_HUSKELISTEN = "0062"
+
+# Verified EasyIQ weekplan-capable widgets, in preference order. The reference
+# integration also sees legacy 0001 and homework 0142 accepted for weekplans;
+# keep the current dedicated 0128 widget first when an account exposes it.
+EASYIQ_WEEKPLAN_WIDGETS = (
+    WIDGET_EASYIQ_WEEKPLAN,
+    WIDGET_EASYIQ_LEGACY,
+    WIDGET_EASYIQ_HOMEWORK,
+)
 
 # Widget IDs that can mint a token for MinUddannelse's opgaveliste endpoint, in
 # preference order. Not every school lists 0030, and a school that only has the

--- a/src/aula/widgets/client.py
+++ b/src/aula/widgets/client.py
@@ -311,6 +311,7 @@ class AulaWidgetsClient:
         institution_filter: list[str],
         guardian_login: str,
         child_user_ids: list[str],
+        widget_id: str,
     ) -> None:
         """Establish the EasyIQ portal session once, and learn its child IDs.
 
@@ -335,7 +336,9 @@ class AulaWidgetsClient:
             # waited for the lock. Re-check rather than repeat it.
             if self._easyiq_session_ready:
                 return
-            await self._bootstrap_easyiq_session(institution_filter, guardian_login, child_user_ids)
+            await self._bootstrap_easyiq_session(
+                institution_filter, guardian_login, child_user_ids, widget_id
+            )
 
     async def authenticate_easyiq_session(
         self,
@@ -344,6 +347,7 @@ class AulaWidgetsClient:
         child_user_ids: list[str],
         child_user_id: str = "",
         token: str | None = None,
+        widget_id: str = WIDGET_EASYIQ_HOMEWORK,
     ) -> dict[str, Any]:
         """``POST /Aula/AuthenticateAulaUser``, returning its body key-folded.
 
@@ -357,7 +361,7 @@ class AulaWidgetsClient:
         raising, since every caller can carry on without it. Transport
         failures do raise.
         """
-        token = token or await self._get_bearer_token(WIDGET_EASYIQ_HOMEWORK)
+        token = token or await self._get_bearer_token(widget_id)
         headers = self.easyiq_headers(
             token, institution_filter, guardian_login, child_user_ids, child_user_id
         )
@@ -379,9 +383,10 @@ class AulaWidgetsClient:
         institution_filter: list[str],
         guardian_login: str,
         child_user_ids: list[str],
+        widget_id: str,
     ) -> None:
         """Make the portal session and read its child IDs. Holds the lock."""
-        token = await self._get_bearer_token(WIDGET_EASYIQ_HOMEWORK)
+        token = await self._get_bearer_token(widget_id)
         headers = self.easyiq_headers(token, institution_filter, guardian_login, child_user_ids)
         try:
             body = await self.authenticate_easyiq_session(
@@ -597,7 +602,10 @@ class AulaWidgetsClient:
         # resolvable, and children at the guardian's other institutions could
         # then be mistaken for children EasyIQ does not know.
         await self.ensure_easyiq_session(
-            all_institution_filter or institution_filter, guardian_login, all_child_user_ids
+            all_institution_filter or institution_filter,
+            guardian_login,
+            all_child_user_ids,
+            widget_id,
         )
 
         easyiq_child_id = self.resolve_easyiq_child_id(child_user_id)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,10 +33,13 @@ from aula.cli import (
     logout,
     print_mu_task_tables,
     report_sick,
+    weekly_summary,
 )
 from aula.const import (
+    EASYIQ_WEEKPLAN_WIDGETS,
     MIN_UDDANNELSE_TASK_WIDGETS,
     WIDGET_EASYIQ_HOMEWORK,
+    WIDGET_EASYIQ_LEGACY,
     WIDGET_EASYIQ_WEEKPLAN,
 )
 from aula.models import (
@@ -130,7 +133,7 @@ class TestWidgetAvailability:
 
 
 class TestWidgetPreference:
-    """MinUddannelse opgaver are reachable through more than one widget."""
+    """Some providers are reachable through more than one widget."""
 
     @pytest.fixture(autouse=True)
     def _clear_cache(self):
@@ -196,6 +199,50 @@ class TestWidgetPreference:
         assert "0030" in out
         assert "0023" in out
         assert "aula widgets" in out
+
+    @pytest.mark.asyncio
+    async def test_easyiq_prefers_the_dedicated_weekplan_widget(self):
+        client = self._client(
+            [WIDGET_EASYIQ_HOMEWORK, WIDGET_EASYIQ_LEGACY, WIDGET_EASYIQ_WEEKPLAN]
+        )
+
+        assert (
+            await _first_available_widget(client, EASYIQ_WEEKPLAN_WIDGETS) == WIDGET_EASYIQ_WEEKPLAN
+        )
+
+    @pytest.mark.asyncio
+    async def test_easyiq_falls_back_to_the_legacy_widget(self):
+        client = self._client([WIDGET_EASYIQ_HOMEWORK, WIDGET_EASYIQ_LEGACY])
+
+        assert (
+            await _first_available_widget(client, EASYIQ_WEEKPLAN_WIDGETS) == WIDGET_EASYIQ_LEGACY
+        )
+
+    @pytest.mark.asyncio
+    async def test_easyiq_uses_the_homework_widget_as_the_last_verified_candidate(self):
+        client = self._client([WIDGET_EASYIQ_HOMEWORK])
+
+        assert (
+            await _first_available_widget(client, EASYIQ_WEEKPLAN_WIDGETS) == WIDGET_EASYIQ_HOMEWORK
+        )
+
+    @pytest.mark.asyncio
+    async def test_easyiq_reports_when_no_verified_candidate_is_available(self, capsys):
+        client = self._client(["0019"])
+
+        assert await _require_any_widget(client, EASYIQ_WEEKPLAN_WIDGETS, "EasyIQ Ugeplan") is None
+        out = capsys.readouterr().out
+        assert WIDGET_EASYIQ_WEEKPLAN in out
+        assert WIDGET_EASYIQ_LEGACY in out
+        assert WIDGET_EASYIQ_HOMEWORK in out
+
+    @pytest.mark.asyncio
+    async def test_easyiq_unreadable_widget_list_optimistically_uses_the_preferred_id(self):
+        client = self._client([], side_effect=RuntimeError("boom"))
+
+        assert (
+            await _first_available_widget(client, EASYIQ_WEEKPLAN_WIDGETS) == WIDGET_EASYIQ_WEEKPLAN
+        )
 
 
 class TestWithChild:
@@ -713,9 +760,9 @@ class TestEasyiqPerChildInstitutionScoping:
         client.__aexit__ = AsyncMock(return_value=False)
         return client
 
-    def _run(self, command, client, monkeypatch, *args):
+    def _run(self, command, client, monkeypatch, *args, output_format="text"):
         monkeypatch.setattr("aula.cli._get_client", AsyncMock(return_value=client))
-        return CliRunner().invoke(command, list(args), obj={"OUTPUT_FORMAT": "text"})
+        return CliRunner().invoke(command, list(args), obj={"OUTPUT_FORMAT": output_format})
 
     def test_ugeplan_scopes_institution_filter_per_child(self, monkeypatch):
         school_child = self._child(1, "u-school", "SCH-1")
@@ -730,6 +777,46 @@ class TestEasyiqPerChildInstitutionScoping:
         assert calls[0].args[2] == ["SCH-1"]
         assert calls[1].args[2] == ["DAY-2"]
         assert calls[0].args[2] != calls[1].args[2]
+        assert all(call_.kwargs["widget_id"] == WIDGET_EASYIQ_WEEKPLAN for call_ in calls)
+
+    def test_ugeplan_json_uses_the_selected_legacy_widget(self, monkeypatch):
+        child = self._child(1, "u-school", "SCH-1")
+        client = self._client([child])
+        client.get_widgets = AsyncMock(return_value=[MagicMock(widget_id=WIDGET_EASYIQ_LEGACY)])
+
+        result = self._run(
+            easyiq_ugeplan,
+            client,
+            monkeypatch,
+            output_format="json",
+        )
+
+        assert result.exit_code == 0
+        calls = client.widgets.get_easyiq_weekplan.await_args_list
+        assert len(calls) == 1
+        assert calls[0].kwargs["widget_id"] == WIDGET_EASYIQ_LEGACY
+
+    def test_weekly_summary_uses_the_selected_legacy_widget(self, monkeypatch):
+        child = self._child(1, "u-school", "SCH-1")
+        client = self._client([child])
+        client.get_widgets = AsyncMock(return_value=[MagicMock(widget_id=WIDGET_EASYIQ_LEGACY)])
+        client.get_calendar_events = AsyncMock(return_value=[])
+        client.get_message_threads = AsyncMock(return_value=[])
+
+        result = self._run(
+            weekly_summary,
+            client,
+            monkeypatch,
+            "--provider",
+            "easyiq",
+        )
+
+        assert result.exit_code == 0
+        client.widgets.get_easyiq_weekplan.assert_awaited_once()
+        assert (
+            client.widgets.get_easyiq_weekplan.await_args.kwargs["widget_id"]
+            == WIDGET_EASYIQ_LEGACY
+        )
 
     def test_ugeplan_passes_every_institution_for_the_portal_session(self, monkeypatch):
         """The session is cached, so it must be made under all institutions.

--- a/tests/test_widgets_client.py
+++ b/tests/test_widgets_client.py
@@ -19,6 +19,8 @@ from aula.const import (
     MIN_UDDANNELSE_API,
     SYSTEMATIC_API,
     WIDGET_EASYIQ_HOMEWORK,
+    WIDGET_EASYIQ_LEGACY,
+    WIDGET_EASYIQ_WEEKPLAN,
     WIDGET_HUSKELISTEN,
     WIDGET_MIN_UDDANNELSE_TASKS,
     WIDGET_MIN_UDDANNELSE_UGEPLAN,
@@ -284,6 +286,49 @@ class TestWidgetsClient:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "widget_id",
+        [WIDGET_EASYIQ_WEEKPLAN, WIDGET_EASYIQ_LEGACY],
+        ids=["dedicated", "legacy"],
+    )
+    async def test_calendar_bootstrap_uses_the_selected_widget(
+        self, unbootstrapped_client, widget_id
+    ):
+        client = unbootstrapped_client
+        client._request_with_version_retry = AsyncMock(
+            side_effect=[
+                _token_response(f"{widget_id}-bootstrap"),
+                _calendar_response(None),
+                _calendar_response({"Children": [{"Id": "9001", "Login": "astr8360"}]}),
+                _token_response(f"{widget_id}-read"),
+                _calendar_response(None),
+                _calendar_response({"child": "astr8360"}),
+                _calendar_response([{"ItemType": 9, "Title": "Dansk"}]),
+            ]
+        )
+
+        events = await client.widgets.get_easyiq_calendar_events(
+            week="2026-W09",
+            institution_filter=["inst-1"],
+            child_profile_id="4242",
+            child_user_id="astr8360",
+            all_child_user_ids=["astr8360"],
+            guardian_login="guardian-1",
+            widget_id=widget_id,
+        )
+
+        assert len(events) == 1
+        token_urls = [
+            call_.args[1]
+            for call_ in client._request_with_version_retry.await_args_list
+            if "getAulaToken" in call_.args[1]
+        ]
+        assert token_urls == [
+            f"{client.api_url}?method=aulaToken.getAulaToken&widgetId={widget_id}",
+            f"{client.api_url}?method=aulaToken.getAulaToken&widgetId={widget_id}",
+        ]
+
+    @pytest.mark.asyncio
     async def test_portal_session_is_established_before_any_controller(self, unbootstrapped_client):
         """Without AuthenticateAulaUser the portal's controllers all 500."""
         client = unbootstrapped_client
@@ -310,6 +355,11 @@ class TestWidgetsClient:
 
         assert [hw.subject for hw in homework] == ["Dansk"]
         calls = client._request_with_version_retry.await_args_list
+        token_urls = [call_.args[1] for call_ in calls if "getAulaToken" in call_.args[1]]
+        assert token_urls == [
+            f"{client.api_url}?method=aulaToken.getAulaToken&widgetId={WIDGET_EASYIQ_HOMEWORK}",
+            f"{client.api_url}?method=aulaToken.getAulaToken&widgetId={WIDGET_EASYIQ_HOMEWORK}",
+        ]
         assert calls[1].args == ("post", f"{EASYIQ_PORTAL}{EASYIQ_AUTHENTICATE_PATH}")
         assert calls[2].args == ("get", f"{EASYIQ_PORTAL}{EASYIQ_CHILDREN_PATH}")
         # EasyIQ's own ID is used as loginId, matched on Login not Name, and
@@ -383,7 +433,10 @@ class TestWidgetsClient:
         await asyncio.gather(
             *(
                 client.widgets.ensure_easyiq_session(
-                    ["inst-1"], "guardian-1", ["astr8360", "kris37r9"]
+                    ["inst-1"],
+                    "guardian-1",
+                    ["astr8360", "kris37r9"],
+                    WIDGET_EASYIQ_HOMEWORK,
                 )
                 for _ in range(4)
             )
@@ -1260,7 +1313,9 @@ class TestEasyiqProtocolCorrectIdentifier:
             ]
         )
 
-        await client.widgets.ensure_easyiq_session(["inst-1"], "guardian-1", ["astr8360"])
+        await client.widgets.ensure_easyiq_session(
+            ["inst-1"], "guardian-1", ["astr8360"], WIDGET_EASYIQ_HOMEWORK
+        )
 
         assert client.widgets._easyiq_parent_login_id == "parent-42"
 
@@ -1274,7 +1329,9 @@ class TestEasyiqProtocolCorrectIdentifier:
             ]
         )
 
-        await client.widgets.ensure_easyiq_session(["inst-1"], "guardian-1", ["astr8360"])
+        await client.widgets.ensure_easyiq_session(
+            ["inst-1"], "guardian-1", ["astr8360"], WIDGET_EASYIQ_HOMEWORK
+        )
 
         assert client.widgets._easyiq_parent_login_id is None
 
@@ -1291,7 +1348,9 @@ class TestEasyiqProtocolCorrectIdentifier:
             ]
         )
 
-        await client.widgets.ensure_easyiq_session(["inst-1"], "guardian-1", ["astr8360"])
+        await client.widgets.ensure_easyiq_session(
+            ["inst-1"], "guardian-1", ["astr8360"], WIDGET_EASYIQ_HOMEWORK
+        )
 
         assert client.widgets._easyiq_parent_login_id is None
         # A bad AuthenticateAulaUser body is not fatal: GetChildren still runs.
@@ -1307,7 +1366,9 @@ class TestEasyiqProtocolCorrectIdentifier:
             ]
         )
 
-        await client.widgets.ensure_easyiq_session(["inst-1"], "guardian-1", ["astr8360"])
+        await client.widgets.ensure_easyiq_session(
+            ["inst-1"], "guardian-1", ["astr8360"], WIDGET_EASYIQ_HOMEWORK
+        )
 
         assert client.widgets.resolve_easyiq_child_id("astr8360") == "9001"
         # The real casing survives, even though the lookup key is casefolded.


### PR DESCRIPTION
## Summary

- define verified EasyIQ weekplan candidates in preference order: `0128`, `0001`, `0142`
- select the first candidate exposed by the account in the standalone command and weekly summary
- thread the selected ID through portal bootstrap, child switching, and weekplan reads
- preserve `0142` as the homework default and the existing one-bootstrap session guarantee

## Test plan

- `uv run pytest tests/test_widgets_client.py tests/test_cli.py -q` (136 passed)
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest` (800 passed, 4 skipped)